### PR TITLE
replace "Only Status Changes" with "No time spent" in weekly report

### DIFF
--- a/templates/reports/weekly.tpl.html
+++ b/templates/reports/weekly.tpl.html
@@ -86,8 +86,8 @@ $().ready(function() {
             <label><input type="checkbox" name="separate_not_assigned_to_user" value="1" {if $smarty.request.separate_not_assigned_to_user == 1}checked{/if}>
             {t}Separate Not Assigned to User{/t}</label>&nbsp;
             <br />
-            <label><input type="checkbox" name="separate_status_changed" value="1" {if $smarty.request.separate_status_changed == 1}checked{/if}>
-            {t}Separate Only Status Changes{/t}</label>&nbsp;
+            <label><input type="checkbox" name="separate_no_time" value="1" {if $smarty.request.separate_no_time == 1}checked{/if}>
+            {t}Separate No time spent{/t}</label>&nbsp;
             <br />
             <label><input type="checkbox" name="ignore_statuses" value="1" {if $smarty.request.ignore_statuses == 1}checked{/if}>
             {t}Ignore Issue Status Changes{/t}</label>&nbsp;

--- a/templates/reports/weekly_data.tpl.html
+++ b/templates/reports/weekly_data.tpl.html
@@ -37,15 +37,15 @@ $smarty.request.show_status == 1} ({$data.issues.not_mine[issue].sta_title}){/if
 
 {/if}
 
-{if $smarty.request.separate_status_changed|default:'' == 1}
-{t}Issues with only status changed{/t}:
+{if $smarty.request.separate_no_time|default:'' == 1}
+{t}Issues with no time spent{/t}:
 
-{section name=issue loop=$data.issues.status_changed}
-<a href="{$core.rel_url}view.php?id={$data.issues.status_changed[issue].iss_id}" style="text-decoration: none" target="_blank">{$data.issues.status_changed[issue].iss_id|str_pad:5:" ":$smarty.const.STR_PAD_LEFT}</a> {$data.issues.status_changed[issue].iss_summary|htmlspecialchars} {if
-$smarty.request.show_status == 1} ({$data.issues.status_changed[issue].sta_title}){/if}{if $smarty.request.show_priority == 1} ({$data.issues.status_changed[issue].pri_title}){/if} {if $smarty.request.show_per_issue|default:'' == 1}({$data.issues.status_changed[issue].time_spent}){/if}
+{section name=issue loop=$data.issues.no_time}
+<a href="{$core.rel_url}view.php?id={$data.issues.no_time[issue].iss_id}" style="text-decoration: none" target="_blank">{$data.issues.no_time[issue].iss_id|str_pad:5:" ":$smarty.const.STR_PAD_LEFT}</a> {$data.issues.no_time[issue].iss_summary|htmlspecialchars} {if
+$smarty.request.show_status == 1} ({$data.issues.no_time[issue].sta_title}){/if}{if $smarty.request.show_priority == 1} ({$data.issues.no_time[issue].pri_title}){/if} {if $smarty.request.show_per_issue|default:'' == 1}({$data.issues.no_time[issue].time_spent}){/if}
 
 {sectionelse}
-{t}No issues with only status changed this time period{/t}
+{t}No issues where no time was spent on this time period{/t}
 {/section}
 {/if}
 


### PR DESCRIPTION
In Eventum weekly report the filter "only status changed" did not work as intended and did not help filter out issues that were only changed (updated) - not worked with.

In order to make it work as was originally intended it would have been necessary overview all of the history types and sort them into categories "I worked on this issue" and "I only changed the status of this issue"

However I presume that it would be quite difficult as initially categorize the history types, then manage the list and overall give users a clear indication of what is considered a "Status Change".

Therefore, I suggest we replace "Status changed" with "No time spent" - that will group up issues with no timetracking.
