### PR TITLE
Catch exception caused by invalid timezone such as "Eastern Standard Tim...

### DIFF
--- a/docs/ChangeLog
+++ b/docs/ChangeLog
@@ -3,6 +3,7 @@ Eventum Issue Tracking System
 
 2014-??-??, Version ???
 - Make Custom Fields Weekly Report honor Project ID (Raul Raat, GH#6)
+- Catch exception from invalid timezones and default to UTC (Bryan Alsdorf)
 
 2014-10-04, Version 2.4.0 pre1
 - Fixed bug with having multiple dynamic custom fields on a page (Bryan Alsdorf)

--- a/lib/eventum/class.date_helper.php
+++ b/lib/eventum/class.date_helper.php
@@ -71,7 +71,11 @@ class Date_Helper
         if (!$timezone) {
             $timezone = self::getPreferredTimezone();
         }
-        $dateTime->setTimeZone(new DateTimeZone($timezone));
+        try {
+            $dateTime->setTimeZone(new DateTimeZone($timezone));
+        } catch (Exception $e) {
+            # invalid timezone, ignore and use utc
+        }
 
         return $dateTime;
     }


### PR DESCRIPTION
...e" and fall back to UTC.

This fixes the exception some of my users were getting when they had old timezones.
