### PR TITLE
Change sort links to use Filter::buildURL instead of relying on options ...

### DIFF
--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -518,7 +518,10 @@ class Filter
             if (is_array($options['custom_field'])) {
                 $options['custom_field'] = serialize($options['custom_field']);
             }
-            $url .= 'custom_field=' . urlencode($options['custom_field']);
+            $url .= 'custom_field=' . urlencode($options['custom_field']) . "&";
+        }
+        if (isset($options['nosave'])) {
+            $url .= 'nosave=' . $options['nosave'] . "&";
         }
 
         return $url;

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -91,6 +91,7 @@ class Search
             "sort_by"        => Misc::stripHTML($sort_by ? $sort_by : "pri_rank"),
             "sort_order"     => Misc::stripHTML($sort_order ? $sort_order : "ASC"),
             "customer_id"    => Misc::escapeString(self::getParam('customer_id')),
+            "nosave"         => self::getParam('nosave', $request_only),
             // quick filter form
             'keywords'       => self::getParam('keywords', $request_only),
             'match_mode'     => self::getParam('match_mode', $request_only),
@@ -110,7 +111,7 @@ class Search
             // other fields
             'release'        => Misc::escapeInteger(self::getParam('release', $request_only)),
             // custom fields
-            'custom_field'   => Misc::stripHTML($custom_field)
+            'custom_field'   => Misc::stripHTML($custom_field),
         );
         // now do some magic to properly format the date fields
         $date_fields = array(
@@ -209,7 +210,9 @@ class Search
                     $sort_order = "asc";
                 }
             }
-            $items["links"][$field] = $_SERVER["PHP_SELF"] . "?sort_by=" . $sortfield . "&sort_order=" . $sort_order;
+            $options['sort_by'] = $sortfield;
+            $options['sort_order'] = $sort_order;
+            $items["links"][$field] = $_SERVER["PHP_SELF"] . "?" . Filter::buildUrl(Filter::getFiltersInfo(), $options, false, true);
         }
 
         return $items;


### PR DESCRIPTION
...saved in the database or cookie.

This fixes problems with losing filters when using "nosave=1" links

Our filters and sorting are still ugly, but I don't have time to overhaul them at the moment.
