### PR TITLE
CLI fixes and performance improvements

### DIFF
--- a/cli/box.json.dist
+++ b/cli/box.json.dist
@@ -41,7 +41,6 @@
     "compactors": [
         "Herrera\\Box\\Compactor\\Php"
     ],
-    "compression": "GZ",
     "main": "cli/eventum.php",
     "output": "cli/eventum.phar",
     "stub": true

--- a/cli/eventum.php
+++ b/cli/eventum.php
@@ -53,214 +53,218 @@ $client = new Eventum_RPC("$scheme://$hostname$relative_url/rpc/xmlrpc.php");
 //$client->setCredentials($user_email, $user_password);
 if (in_array('--debug', $argv)) {
     $client->setDebug(true);
+    $debug = true;
     unset($argv[array_search('--debug', $argv)]);
-}
-
-try {
-    // need to process authentication first
-    Command_Line::checkAuthentication($client, $user_email, $user_password);
-} catch (Eventum_RPC_Exception $e) {
-    Command_Line::quit($e->getMessage());
+} else {
+    $debug = false;
 }
 
 $auth = array($user_email, $user_password);
 
-// log command
-Command_Line::log($client, $auth, join(' ', $argv));
-
 $issue_id = (integer) $argv[1];
-if ($issue_id > 0) {
-    if (count($argv) == 2) {
-        Command_Line::printIssueDetails($client, $auth, $issue_id);
+try {
+    if ($issue_id > 0) {
+        if (count($argv) == 2) {
+            Command_Line::printIssueDetails($client, $auth, $issue_id);
+        } else {
+            if ($should_confirm) {
+                Command_Line::promptConfirmation($client, $auth, $issue_id, @$argv);
+            }
+            switch ($argv[2]) {
+                case 'assign':
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the developer");
+                    }
+                    Command_Line::assignIssue($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'take':
+                    Command_Line::takeIssue($client, $auth, $issue_id);
+                    break;
+                case 'add-replier':
+                case 'ar':
+                    // adds a user to the list of authorized repliers
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the developer");
+                    }
+                    Command_Line::addAuthorizedReplier($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'set-status':
+                case 'ss':
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the status");
+                    }
+                    Command_Line::setIssueStatus($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'add-time':
+                case 'at':
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for time worked");
+                    }
+                    $check = (integer) $argv[3];
+                    if ($check == 0) {
+                        Command_Line::quit("Third argument to command 'add-time' should be a number");
+                    }
+                    Command_Line::addTimeEntry($client, $auth, $issue_id, $check);
+                    break;
+                case 'list-files':
+                case 'lf':
+                    Command_Line::printFileList($client, $auth, $issue_id);
+                    break;
+                case 'get-file':
+                case 'gf':
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the file number");
+                    }
+                    Command_Line::getFile($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'close':
+                    Command_Line::closeIssue($client, $auth, $issue_id);
+                    break;
+
+                // email related commands
+                case 'list-emails':
+                case 'le':
+                    // lists all emails for the given issue
+                    Command_Line::listEmails($client, $auth, $issue_id);
+                    break;
+                case 'get-email':
+                case 'ge':
+                    // views an email
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the email number");
+                    }
+                    if (@$argv[4] == "--full") {
+                        $full = true;
+                    } else {
+                        $full = false;
+                    }
+                    Command_Line::printEmail($client, $auth, $issue_id, $argv[3], $full);
+                    break;
+
+                // note related commands
+                case 'list-notes':
+                case 'ln':
+                    // list notes for the given issues
+                    Command_Line::listNotes($client, $auth, $issue_id);
+                    break;
+                case 'get-note':
+                case 'gn':
+                    // view a note
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the note number");
+                    }
+                    Command_Line::printNote($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'convert-note':
+                case 'cn':
+                    // convert a note to an email
+                    if (empty($argv[3])) {
+                        Command_Line::quit("Missing parameter for the note number");
+                    }
+                    if (@$argv[4] != 'draft' && @$argv[4] != 'email') {
+                        Command_Line::quit("4th parameter must be 'draft' or 'email'");
+                    }
+                    if (@$argv[5] == 'authorize') {
+                        $authorize_sender = true;
+                    } else {
+                        $authorize_sender = false;
+                    }
+                    Command_Line::convertNote($client, $auth, $issue_id, $argv[3], $argv[4], $authorize_sender);
+                    break;
+
+                // draft related commands
+                case 'list-drafts':
+                case 'ld':
+                    // list drafts
+                    Command_Line::listDrafts($client, $auth, $issue_id);
+                    break;
+                case 'get-draft':
+                case 'gd':
+                    // viewing a draft
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the draft number");
+                    }
+                    Command_Line::printDraft($client, $auth, $issue_id, $argv[3]);
+                    break;
+                case 'send-draft':
+                case 'sd':
+                    // viewing a draft
+                    if (count($argv) == 3) {
+                        Command_Line::quit("Missing parameter for the draft number");
+                    }
+                    Command_Line::sendDraft($client, $auth, $issue_id, $argv[3]);
+                    break;
+
+                case 'redeem':
+                    // marking an issue as redeemed
+                    Command_Line::redeemIssue($client, $auth, $issue_id);
+                    break;
+
+                case 'unredeem':
+                    // unmarks issue as redeemed incident
+                    Command_Line::unredeemIssue($client, $auth, $issue_id);
+                    break;
+
+                default:
+                    Command_Line::quit("Unknown command '" . $argv[2] . "'");
+            }
+        }
     } else {
-        if ($should_confirm) {
-            Command_Line::promptConfirmation($client, $auth, $issue_id, @$argv);
-        }
-        switch ($argv[2]) {
-            case 'assign':
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the developer");
-                }
-                Command_Line::assignIssue($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'add-replier':
-            case 'ar':
-                // adds a user to the list of authorized repliers
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the developer");
-                }
-                Command_Line::addAuthorizedReplier($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'set-status':
-            case 'ss':
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the status");
-                }
-                Command_Line::setIssueStatus($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'add-time':
-            case 'at':
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for time worked");
-                }
-                $check = (integer) $argv[3];
-                if ($check == 0) {
-                    Command_Line::quit("Third argument to command 'add-time' should be a number");
-                }
-                Command_Line::addTimeEntry($client, $auth, $issue_id, $check);
-                break;
-            case 'list-files':
-            case 'lf':
-                Command_Line::printFileList($client, $auth, $issue_id);
-                break;
-            case 'get-file':
-            case 'gf':
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the file number");
-                }
-                Command_Line::getFile($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'close':
-                Command_Line::closeIssue($client, $auth, $issue_id);
-                break;
-
-            // email related commands
-            case 'list-emails':
-            case 'le':
-                // lists all emails for the given issue
-                Command_Line::listEmails($client, $auth, $issue_id);
-                break;
-            case 'get-email':
-            case 'ge':
-                // views an email
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the email number");
-                }
-                if (@$argv[4] == "--full") {
-                    $full = true;
+        if ($argv[1] == 'developers') {
+            Command_Line::printDeveloperList($client, $auth);
+        } elseif ($argv[1] == 'open-issues') {
+            if (count($argv) == 3) {
+                if (@$argv[2] == 'my') {
+                    $show_all_issues = false;
+                    $status = '';
                 } else {
-                    $full = false;
+                    $show_all_issues = true;
+                    $status = $argv[2];
                 }
-                Command_Line::printEmail($client, $auth, $issue_id, $argv[3], $full);
-                break;
-
-            // note related commands
-            case 'list-notes':
-            case 'ln':
-                // list notes for the given issues
-                Command_Line::listNotes($client, $auth, $issue_id);
-                break;
-            case 'get-note':
-            case 'gn':
-                // view a note
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the note number");
-                }
-                Command_Line::printNote($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'convert-note':
-            case 'cn':
-                // convert a note to an email
-                if (empty($argv[3])) {
-                    Command_Line::quit("Missing parameter for the note number");
-                }
-                if (@$argv[4] != 'draft' && @$argv[4] != 'email') {
-                    Command_Line::quit("4th parameter must be 'draft' or 'email'");
-                }
-                if (@$argv[5] == 'authorize') {
-                    $authorize_sender = true;
+            } elseif (count($argv) == 4) {
+                if (@$argv[3] == 'my') {
+                    $show_all_issues = false;
                 } else {
-                    $authorize_sender = false;
+                    $show_all_issues = true;
                 }
-                Command_Line::convertNote($client, $auth, $issue_id, $argv[3], $argv[4], $authorize_sender);
-                break;
-
-            // draft related commands
-            case 'list-drafts':
-            case 'ld':
-                // list drafts
-                Command_Line::listDrafts($client, $auth, $issue_id);
-                break;
-            case 'get-draft':
-            case 'gd':
-                // viewing a draft
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the draft number");
-                }
-                Command_Line::printDraft($client, $auth, $issue_id, $argv[3]);
-                break;
-            case 'send-draft':
-            case 'sd':
-                // viewing a draft
-                if (count($argv) == 3) {
-                    Command_Line::quit("Missing parameter for the draft number");
-                }
-                Command_Line::sendDraft($client, $auth, $issue_id, $argv[3]);
-                break;
-
-            case 'redeem':
-                // marking an issue as redeemed
-                Command_Line::redeemIssue($client, $auth, $issue_id);
-                break;
-
-            case 'unredeem':
-                // unmarks issue as redeemed incident
-                Command_Line::unredeemIssue($client, $auth, $issue_id);
-                break;
-
-            default:
-                Command_Line::quit("Unknown command '" . $argv[2] . "'");
-        }
-    }
-} else {
-    if ($argv[1] == 'developers') {
-        Command_Line::printDeveloperList($client, $auth);
-    } elseif ($argv[1] == 'open-issues') {
-        if (count($argv) == 3) {
-            if (@$argv[2] == 'my') {
-                $show_all_issues = false;
-                $status = '';
-            } else {
-                $show_all_issues = true;
                 $status = $argv[2];
-            }
-        } elseif (count($argv) == 4) {
-            if (@$argv[3] == 'my') {
-                $show_all_issues = false;
             } else {
                 $show_all_issues = true;
+                $status = '';
             }
-            $status = $argv[2];
-        } else {
-            $show_all_issues = true;
-            $status = '';
-        }
-        Command_Line::printOpenIssues($client, $auth, $show_all_issues, $status);
-    } elseif ($argv[1] == 'list-status') {
-        Command_Line::printStatusList($client, $auth);
-    } elseif ($argv[1] == 'customer') {
-        if (count($argv) != 4) {
-            Command_Line::quit("Wrong parameter count");
-        }
-        Command_Line::lookupCustomer($client, $auth, $argv[2], $argv[3]);
-    } elseif (($argv[1] == 'weekly-report') || ($argv[1] == 'wr')) {
-        if (count(@$argv) >= 4 and $argv[3] != '--separate-closed') {
-            $separate_closed = (@$argv[4] == '--separate-closed');
-            // date range
-            Command_Line::getWeeklyReport($client, $auth, 0, $argv[2], $argv[3], $separate_closed);
-        } else {
-            // weekly
-            if (@$argv[2] == '') {
-                $separate_closed = false;
-                @$argv[2] = 0;
+            Command_Line::printOpenIssues($client, $auth, $show_all_issues, $status);
+        } elseif ($argv[1] == 'list-status') {
+            Command_Line::printStatusList($client, $auth);
+        } elseif ($argv[1] == 'customer') {
+            if (count($argv) != 4) {
+                Command_Line::quit("Wrong parameter count");
+            }
+            Command_Line::lookupCustomer($client, $auth, $argv[2], $argv[3]);
+        } elseif (($argv[1] == 'weekly-report') || ($argv[1] == 'wr')) {
+            if (count(@$argv) >= 4 and $argv[3] != '--separate-closed') {
+                $separate_closed = (@$argv[4] == '--separate-closed');
+                // date range
+                Command_Line::getWeeklyReport($client, $auth, 0, $argv[2], $argv[3], $separate_closed);
             } else {
-                $separate_closed = (@$argv[3] == '--separate-closed' or @$argv[2] == '--separate-closed');
+                // weekly
+                if (@$argv[2] == '') {
+                    $separate_closed = false;
+                    @$argv[2] = 0;
+                } else {
+                    $separate_closed = (@$argv[3] == '--separate-closed' or @$argv[2] == '--separate-closed');
+                }
+                Command_Line::getWeeklyReport($client, $auth, $argv[2], '', '', $separate_closed);
             }
-            Command_Line::getWeeklyReport($client, $auth, $argv[2], '', '', $separate_closed);
+        } elseif ($argv[1] == 'clock') {
+            Command_Line::timeClock($client, $auth, @$argv[2]);
+        } else {
+            Command_Line::quit("Unknown parameter '" . $argv[1] . "'");
         }
-    } elseif ($argv[1] == 'clock') {
-        Command_Line::timeClock($client, $auth, @$argv[2]);
-    } else {
-        Command_Line::quit("Unknown parameter '" . $argv[1] . "'");
     }
+} catch (Eventum_RPC_Exception $e) {
+    print "ERROR: " . $e->getMessage() . "\n";
+    if ($debug) {
+        print $e->getTraceAsString();
+    }
+
 }

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -359,6 +359,7 @@ class Command_Line
     {
         $projects = self::getUserAssignedProjects($client, $auth);
         $details = $client->getIssueDetails($auth[0], $auth[1], $issue_id);
+        $details['iss_prj_id'] = (int) $details['iss_prj_id'];
 
         // check if the issue the user is trying to change is inside a project viewable to him
         $found = 0;
@@ -407,11 +408,11 @@ class Command_Line
      * @param   array $auth Array of authentication information (email, password)
      * @param   integer $issue_id The issue ID
      */
-    public function takeIssue($client, $auth, $issue_id)
+    public static function takeIssue($client, $auth, $issue_id)
     {
         $details = self::checkIssuePermissions($client, $auth, $issue_id);
 
-        $result = $client->takeIssue($auth[0], $auth[1], $issue_id, $details['iss_prj_id']);
+        $result = $client->takeIssue($auth[0], $auth[1], $issue_id, (int)$details['iss_prj_id']);
         if ($result == 'OK') {
             echo "OK - Issue #$issue_id successfully taken.\n";
         } else {


### PR DESCRIPTION
- Don't make separate authentication / log calls (removes two additional HTTP requests)
- Remove compression from phar format (file size increases from 21K to 80K but runs twice as fast)
- Added missing "take" command
- Simplify error messages by hiding stack trace unless --debug is passed.
