### PR TITLE
deprecate escapeInteger and escapeString in favor of using placeholders

### DIFF
--- a/lib/eventum/class.attachment.php
+++ b/lib/eventum/class.attachment.php
@@ -493,44 +493,32 @@ class Attachment
      */
     public static function add($issue_id, $usr_id, $description, $internal_only = false, $unknown_user = false, $associated_note_id = false)
     {
-        $issue_id = Misc::escapeInteger($issue_id);
-        $usr_id = Misc::escapeInteger($usr_id);
         if ($internal_only) {
             $attachment_status = 'internal';
         } else {
             $attachment_status = 'public';
         }
 
-        $stmt = "INSERT INTO
-                    {{%issue_attachment}}
-                 (
-                    iat_iss_id,
-                    iat_usr_id,
-                    iat_created_date,
-                    iat_description,
-                    iat_status";
+        $params = array(
+            'iat_iss_id' => $issue_id,
+            'iat_usr_id' => $usr_id,
+            'iat_created_date'=> Date_Helper::getCurrentDateGMT(),
+            'iat_description'=> $description,
+            'iat_status' => $attachment_status,
+        );
+
         if ($unknown_user != false) {
-            $stmt .= ", iat_unknown_user ";
+            $params['iat_unknown_user'] = $unknown_user;
         }
+
         if ($associated_note_id != false) {
-            $stmt .= ", iat_not_id ";
+            $params['iat_not_id'] = $associated_note_id;
         }
-        $stmt .=") VALUES (
-                    $issue_id,
-                    $usr_id,
-                    '" . Date_Helper::getCurrentDateGMT() . "',
-                    '" . Misc::escapeString($description) . "',
-                    '" . Misc::escapeString($attachment_status) . "'";
-        if ($unknown_user != false) {
-            $stmt .= ", '" . Misc::escapeString($unknown_user) . "'";
-        }
-        if ($associated_note_id != false) {
-            $stmt .= ", " . Misc::escapeInteger($associated_note_id);
-        }
-        $stmt .= " )";
+
+        $stmt = "INSERT INTO {{%issue_attachment}} SET ". DB_Helper::buildSet($params);
 
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.attachment.php
+++ b/lib/eventum/class.attachment.php
@@ -98,23 +98,25 @@ class Attachment
      * Method used to remove a specific file out of an existing attachment.
      *
      * @param   integer $iaf_id The attachment file ID
-     * @return  -1 or -2 if the removal was not successful, 1 otherwise
+     * @return int -1 or -2 if the removal was not successful, 1 otherwise
      */
     public static function removeIndividualFile($iaf_id)
     {
         $usr_id = Auth::getUserID();
-        $iaf_id = Misc::escapeInteger($iaf_id);
         $stmt = "SELECT
                     iat_iss_id
                  FROM
                     {{%issue_attachment}},
                     {{%issue_attachment_file}}
                  WHERE
-                    iaf_id=$iaf_id AND
+                    iaf_id=? AND
                     iat_id=iaf_iat_id";
+
+        $params = array($iaf_id);
         if (Auth::getCurrentRole() < User::getRoleID("Manager")) {
             $stmt .= " AND
-                    iat_usr_id=$usr_id";
+                    iat_usr_id=?";
+            $params[] = $usr_id;
         }
         try {
             $res = DB_Helper::getInstance()->getOne($stmt);
@@ -122,11 +124,9 @@ class Attachment
             return -1;
         }
 
-
         if (empty($res)) {
             return -2;
         }
-
 
         // check if the file is the only one in the attachment
         $stmt = "SELECT
@@ -135,9 +135,9 @@ class Attachment
                     {{%issue_attachment}},
                     {{%issue_attachment_file}}
                  WHERE
-                    iaf_id=$iaf_id AND
+                    iaf_id=? AND
                     iaf_iat_id=iat_id";
-        $attachment_id = DB_Helper::getInstance()->getOne($stmt);
+        $attachment_id = DB_Helper::getInstance()->getOne($stmt, array($iaf_id));
 
         $res = self::getFileList($attachment_id);
         if (count($res) > 1) {
@@ -157,7 +157,6 @@ class Attachment
      */
     public static function getDetails($file_id)
     {
-        $file_id = Misc::escapeInteger($file_id);
         $stmt = "SELECT
                     *
                  FROM
@@ -173,8 +172,8 @@ class Attachment
         }
 
         // don't allow customers to reach internal only files
-        if (($res['iat_status'] == 'internal')
-                && (User::getRoleByUser(Auth::getUserID(), Issue::getProjectID($res['iat_iss_id'])) <= User::getRoleID('Customer'))) {
+        $user_role_id = User::getRoleByUser(Auth::getUserID(), Issue::getProjectID($res['iat_iss_id']));
+        if (($res['iat_status'] == 'internal') && $user_role_id <= User::getRoleID('Customer')) {
             return '';
         } else {
             return $res;
@@ -220,20 +219,22 @@ class Attachment
      */
     public static function remove($iat_id, $add_history = true)
     {
-        $iat_id = Misc::escapeInteger($iat_id);
         $usr_id = Auth::getUserID();
         $stmt = "SELECT
                     iat_iss_id
                  FROM
                     {{%issue_attachment}}
                  WHERE
-                    iat_id=$iat_id";
+                    iat_id=?";
+        $params = array($iat_id);
         if (Auth::getCurrentRole() < User::getRoleID("Manager")) {
             $stmt .= " AND
-                    iat_usr_id=$usr_id";
+                    iat_usr_id=?";
+            $params[] = $usr_id;
         }
+
         try {
-            $res = DB_Helper::getInstance()->getOne($stmt);
+            $res = DB_Helper::getInstance()->getOne($stmt, $params);
         } catch (DbException $e) {
             return -1;
         }
@@ -277,7 +278,6 @@ class Attachment
      */
     public function removeFile($iaf_id)
     {
-        $iaf_id = Misc::escapeInteger($iaf_id);
         $stmt = "DELETE FROM
                     {{%issue_attachment_file}}
                  WHERE
@@ -299,7 +299,6 @@ class Attachment
      */
     public static function getFileList($attachment_id)
     {
-        $attachment_id = Misc::escapeInteger($attachment_id);
         $stmt = "SELECT
                     iaf_id,
                     iaf_filename,
@@ -330,7 +329,6 @@ class Attachment
      */
     public static function getList($issue_id)
     {
-        $issue_id = Misc::escapeInteger($issue_id);
         $usr_id = Auth::getUserID();
         $prj_id = Issue::getProjectID($issue_id);
 
@@ -346,7 +344,7 @@ class Attachment
                     {{%issue_attachment}},
                     {{%user}}
                  WHERE
-                    iat_iss_id=$issue_id AND
+                    iat_iss_id=? AND
                     iat_usr_id=usr_id";
         if (User::getRoleByUser($usr_id, $prj_id) <= User::getRoleID('Customer')) {
             $stmt .= " AND iat_status='public' ";
@@ -354,14 +352,15 @@ class Attachment
         $stmt .= "
                  ORDER BY
                     iat_created_date ASC";
+        $params = array($issue_id);
         try {
-            $res = DB_Helper::getInstance()->getAll($stmt);
+            $res = DB_Helper::getInstance()->getAll($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
 
         foreach ($res as &$row) {
-            $row["iat_description"] = Link_Filter::processText(Issue::getProjectID($issue_id), nl2br(htmlspecialchars($row["iat_description"])));
+            $row["iat_description"] = Link_Filter::processText($prj_id, nl2br(htmlspecialchars($row["iat_description"])));
             $row["files"] = self::getFileList($row["iat_id"]);
             $row["iat_created_date"] = Date_Helper::getFormattedDate($row["iat_created_date"]);
 
@@ -389,7 +388,6 @@ class Attachment
      */
     public static function attach($usr_id, $status = 'public')
     {
-        $usr_id = Misc::escapeInteger($usr_id);
         $files = array();
         $nfiles = count($_FILES["attachment"]["name"]);
         for ($i = 0; $i < $nfiles; $i++) {
@@ -452,7 +450,6 @@ class Attachment
      */
     public static function addFile($attachment_id, $filename, $filetype, &$blob)
     {
-        $attachment_id = Misc::escapeInteger($attachment_id);
         $filesize = strlen($blob);
         $stmt = "INSERT INTO
                     {{%issue_attachment_file}}
@@ -491,7 +488,7 @@ class Attachment
      * @param   integer $associated_note_id The note ID that these attachments should be associated with
      * @return  integer The new attachment ID
      */
-    public static function add($issue_id, $usr_id, $description, $internal_only = false, $unknown_user = false, $associated_note_id = false)
+    public static function add($issue_id, $usr_id, $description, $internal_only = false, $unknown_user = null, $associated_note_id = null)
     {
         if ($internal_only) {
             $attachment_status = 'internal';
@@ -507,11 +504,11 @@ class Attachment
             'iat_status' => $attachment_status,
         );
 
-        if ($unknown_user != false) {
+        if ($unknown_user) {
             $params['iat_unknown_user'] = $unknown_user;
         }
 
-        if ($associated_note_id != false) {
+        if ($associated_note_id) {
             $params['iat_not_id'] = $associated_note_id;
         }
 

--- a/lib/eventum/class.attachment.php
+++ b/lib/eventum/class.attachment.php
@@ -189,16 +189,15 @@ class Attachment
      */
     public static function removeByIssues($ids)
     {
-        $ids = Misc::escapeInteger($ids);
-        $items = @implode(", ", $ids);
         $stmt = "SELECT
                     iat_id
                  FROM
                     {{%issue_attachment}}
                  WHERE
-                    iat_iss_id IN ($items)";
+                    iat_iss_id IN (" . DB_Helper::buildList($ids) . ")";
+
         try {
-            $res = DB_Helper::getInstance()->getColumn($stmt);
+            $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.category.php
+++ b/lib/eventum/class.category.php
@@ -67,13 +67,12 @@ class Category
      */
     public static function removeByProjects($ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%project_category}}
                  WHERE
-                    prc_prj_id IN ($items)";
+                    prc_prj_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }
@@ -89,13 +88,13 @@ class Category
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%project_category}}
                  WHERE
-                    prc_id IN ($items)";
+                    prc_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -498,13 +498,13 @@ abstract class CRM
      */
     public static function removeAccountManager()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%customer_account_manager}}
                  WHERE
-                    cam_id IN ($items)";
+                    cam_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
@@ -704,9 +704,9 @@ abstract class CRM
         $stmt = "DELETE FROM
                     {{%customer_note}}
                  WHERE
-                    cno_id IN (" . join(", ", Misc::escapeInteger($ids)) . ")";
+                    cno_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return -1;
         }

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -534,7 +534,7 @@ abstract class CRM
                     cam_prj_id=? AND
                     cam_customer_id=?";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, array($prj_id, $customer_id), DB_FETCHMODE_ASSOC);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $customer_id), DB_FETCHMODE_ASSOC);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1363,13 +1363,12 @@ class Custom_Field
      */
     public static function removeByProjects($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%project_custom_field}}
                  WHERE
-                    pcf_prj_id IN ($items)";
+                    pcf_prj_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -83,7 +83,6 @@ class Custom_Field
      */
     public function addOptions($fld_id, $options)
     {
-        $fld_id = Misc::escapeInteger($fld_id);
         if (!is_array($options)) {
             $options = array($options);
         }
@@ -95,11 +94,12 @@ class Custom_Field
                         cfo_fld_id,
                         cfo_value
                      ) VALUES (
-                        $fld_id,
-                        '" . Misc::escapeString($option) . "'
+                        ?,
+                        " . DB_Helper::buildList($option) . "
                      )";
+            $params = array_merge(array($fld_id, $option));
             try {
-                DB_Helper::getInstance()->query($stmt);
+                DB_Helper::getInstance()->query($stmt, $params);
             } catch (DbException $e) {
                 return -1;
             }
@@ -141,11 +141,13 @@ class Custom_Field
     public static function updateValues()
     {
         $prj_id = Auth::getCurrentProject();
-        $issue_id = Misc::escapeInteger($_POST["issue_id"]);
+        $issue_id = $_POST["issue_id"];
 
         $old_values = self::getValuesByIssue($prj_id, $issue_id);
 
         if ((isset($_POST['custom_fields'])) && (count($_POST['custom_fields']) > 0)) {
+            $custom_fields = $_POST["custom_fields"];
+
             // get the types for all of the custom fields being submitted
             $stmt = "SELECT
                         fld_id,
@@ -153,7 +155,7 @@ class Custom_Field
                      FROM
                         {{%custom_field}}
                      WHERE
-                        fld_id IN (" . implode(", ", Misc::escapeInteger(@array_keys($_POST['custom_fields']))) . ")";
+                        fld_id IN (" . implode(", ", Misc::escapeInteger(@array_keys($custom_fields))) . ")";
 
             $field_types = DB_Helper::getInstance()->getPair($stmt);
 
@@ -164,11 +166,11 @@ class Custom_Field
                      FROM
                         {{%custom_field}}
                      WHERE
-                        fld_id IN (" . implode(", ", Misc::escapeInteger(@array_keys($_POST['custom_fields']))) . ")";
+                        fld_id IN (" . implode(", ", Misc::escapeInteger(@array_keys($custom_fields))) . ")";
             $field_titles = DB_Helper::getInstance()->getPair($stmt);
 
             $updated_fields = array();
-            foreach ($_POST["custom_fields"] as $fld_id => $value) {
+            foreach ($custom_fields as $fld_id => $value) {
 
                 $fld_id = Misc::escapeInteger($fld_id);
 
@@ -234,12 +236,12 @@ class Custom_Field
                                     icf_fld_id,
                                     $fld_db_name
                                  ) VALUES (
-                                    " . $issue_id . ",
+                                    " . Misc::escapeInteger($issue_id). ",
                                     $fld_id,
                                     $value
                                  )";
                         try {
-                            $res = DB_Helper::getInstance()->query($stmt);
+                            DB_Helper::getInstance()->query($stmt);
                         } catch (DbException $e) {
                             return -1;
                         }
@@ -252,7 +254,7 @@ class Custom_Field
                                  WHERE
                                     icf_id=$icf_id";
                         try {
-                            $res = DB_Helper::getInstance()->query($stmt);
+                            DB_Helper::getInstance()->query($stmt);
                         } catch (DbException $e) {
                             return -1;
                         }
@@ -263,7 +265,7 @@ class Custom_Field
                         $updated_fields[$field_titles[$fld_id]] = History::formatChanges($old_value, $value);
                     }
                 } else {
-                    $old_value = self::getDisplayValue($_POST['issue_id'], $fld_id, true);
+                    $old_value = self::getDisplayValue($issue_id, $fld_id, true);
 
                     if (!is_array($old_value)) {
                         $old_value = array($old_value);
@@ -273,21 +275,21 @@ class Custom_Field
                     }
                     if ((count(array_diff($old_value, $value)) > 0) || (count(array_diff($value, $old_value)) > 0)) {
 
-                        $old_display_value = self::getDisplayValue($_POST['issue_id'], $fld_id);
+                        $old_display_value = self::getDisplayValue($issue_id, $fld_id);
                         // need to remove all associated options from issue_custom_field and then
                         // add the selected options coming from the form
-                        self::removeIssueAssociation($fld_id, $_POST["issue_id"]);
+                        self::removeIssueAssociation($fld_id, $issue_id);
                         if (@count($value) > 0) {
-                            self::associateIssue($_POST["issue_id"], $fld_id, $value);
+                            self::associateIssue($issue_id, $fld_id, $value);
                         }
-                        $new_display_value = self::getDisplayValue($_POST['issue_id'], $fld_id);
+                        $new_display_value = self::getDisplayValue($issue_id, $fld_id);
                         $updated_fields[$field_titles[$fld_id]] = History::formatChanges($old_display_value, $new_display_value);
                     }
                 }
             }
 
             Workflow::handleCustomFieldsUpdated($prj_id, $issue_id, $old_values, self::getValuesByIssue($prj_id, $issue_id));
-            Issue::markAsUpdated($_POST["issue_id"]);
+            Issue::markAsUpdated($issue_id);
             // need to save a history entry for this
 
             if (count($updated_fields) > 0) {
@@ -307,7 +309,7 @@ class Custom_Field
                 }
 
                 $summary = ev_gettext('Custom field updated (%1$s) by %2$s', $changes, User::getFullName(Auth::getUserID()));
-                History::add($_POST["issue_id"], Auth::getUserID(), History::getTypeID('custom_field_updated'), $summary);
+                History::add($issue_id, Auth::getUserID(), History::getTypeID('custom_field_updated'), $summary);
             }
         }
 
@@ -559,9 +561,9 @@ class Custom_Field
      * @param   mixed   $form_type The name of the form this is for or if this is an array the ids of the fields to return
      * @return  array The list of custom fields
      */
-    public static function getListByIssue($prj_id, $iss_id, $usr_id = false, $form_type = false)
+    public static function getListByIssue($prj_id, $iss_id, $usr_id = null, $form_type = false)
     {
-        if ($usr_id == false) {
+        if (!$usr_id) {
             $usr_id = Auth::getUserID();
         }
 

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -45,8 +45,6 @@ class Custom_Field
      */
     public function removeOptions($fld_id, $cfo_id)
     {
-        $fld_id = Misc::escapeInteger($fld_id);
-        $cfo_id = Misc::escapeInteger($cfo_id);
         if (!is_array($fld_id)) {
             $fld_id = array($fld_id);
         }
@@ -56,9 +54,9 @@ class Custom_Field
         $stmt = "DELETE FROM
                     {{%custom_field_option}}
                  WHERE
-                    cfo_id IN (" . implode(",", $cfo_id) . ")";
+                    cfo_id IN (" . DB_Helper::buildList($cfo_id) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $cfo_id);
         } catch (DbException $e) {
             return false;
         }
@@ -68,9 +66,10 @@ class Custom_Field
         $stmt = "DELETE FROM
                     {{%issue_custom_field}}
                  WHERE
-                    icf_fld_id IN (" . implode(", ", $fld_id) . ") AND
-                    icf_value IN (" . implode(", ", $cfo_id) . ")";
-        DB_Helper::getInstance()->query($stmt);
+                    icf_fld_id IN (" . DB_Helper::buildList($fld_id) . ") AND
+                    icf_value IN (" . DB_Helper::buildList($cfo_id) . ")";
+        $params = array_merge($fld_id, $cfo_id);
+        DB_Helper::getInstance()->query($stmt, $params);
 
         return true;
     }

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -200,6 +200,20 @@ class DB_Helper
     }
 
     /**
+     * Give valid ORDER BY parameter
+     *
+     * @param string $order
+     * @param string $default
+     * @return string
+     */
+    public static function orderBy($order, $default = "DESC") {
+        if (!in_array(strtoupper($order), array("ASC", "DESC"))) {
+            return $default;
+        }
+        return $order;
+    }
+
+    /**
      * Returns the SQL used to calculate the difference of 2 dates, not counting weekends.
      * This thing is truly a work of art, the type of art that throws lemon juice in your eye and then laughs.
      * If $end_date_field is null, the current date is used instead.

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -176,6 +176,20 @@ class DB_Helper
     }
 
     /**
+     * Helper to build SQL queries with variable length parameters
+     *
+     * @param array $params
+     * @return string A SQL statement partial with placeholders: field1=?, field2=?, field3=? ...
+     */
+    public static function buildSet($params) {
+        $partial = array();
+        foreach (array_keys($params) as $key) {
+            $partial[] = "$key=?";
+        }
+        return join(", ", $partial);
+    }
+
+    /**
      * Returns the SQL used to calculate the difference of 2 dates, not counting weekends.
      * This thing is truly a work of art, the type of art that throws lemon juice in your eye and then laughs.
      * If $end_date_field is null, the current date is used instead.

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -190,6 +190,16 @@ class DB_Helper
     }
 
     /**
+     * Helper to build SQL queries with SET of parameters
+     *
+     * @param array $params
+     * @return string A SQL statement partial with placeholders: ?, ?, ? ...
+     */
+    public static function buildList($params) {
+        return join(', ', array_fill(0, count($params), '?'));
+    }
+
+    /**
      * Returns the SQL used to calculate the difference of 2 dates, not counting weekends.
      * This thing is truly a work of art, the type of art that throws lemon juice in your eye and then laughs.
      * If $end_date_field is null, the current date is used instead.

--- a/lib/eventum/class.display_column.php
+++ b/lib/eventum/class.display_column.php
@@ -126,7 +126,7 @@ class Display_Column
                 ORDER BY
                     ctd_rank";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, array($prj_id, $page), DB_FETCHMODE_ASSOC);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $page), DB_FETCHMODE_ASSOC);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.display_column.php
+++ b/lib/eventum/class.display_column.php
@@ -242,10 +242,10 @@ class Display_Column
      */
     public static function save()
     {
-        $page = Misc::escapeString($_REQUEST['page']);
-        $prj_id = Misc::escapeInteger($_REQUEST['prj_id']);
-
+        $page = $_REQUEST['page'];
+        $prj_id = $_REQUEST['prj_id'];
         $ranks = $_REQUEST['rank'];
+
         asort($ranks);
 
         // delete current entries

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -412,7 +412,7 @@ class Email_Account
                  ORDER BY
                     ema_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $projects);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $projects);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -412,7 +412,7 @@ class Email_Account
                  ORDER BY
                     ema_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $projects);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $projects);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.email_response.php
+++ b/lib/eventum/class.email_response.php
@@ -96,18 +96,18 @@ class Email_Response
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%email_response}}
                  WHERE
-                    ere_id IN ($items)";
+                    ere_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeProjectAssociations($_POST['items']);
+        self::removeProjectAssociations($items);
 
         return true;
     }
@@ -120,18 +120,17 @@ class Email_Response
      * @param   integer $prj_id The project ID
      * @return  boolean
      */
-    public function removeProjectAssociations($ere_id, $prj_id=false)
+    public function removeProjectAssociations($ere_id, $prj_id = null)
     {
-        $ere_id = Misc::escapeInteger($ere_id);
         if (!is_array($ere_id)) {
             $ere_id = array($ere_id);
         }
-        $items = @implode(", ", $ere_id);
+
         $stmt = "DELETE FROM
                     {{%project_email_response}}
                  WHERE
-                    per_ere_id IN ($items)";
-        $params = array();
+                    per_ere_id IN (" . DB_Helper::buildList($ere_id) . ")";
+        $params = $ere_id;
         if ($prj_id) {
             $stmt .= " AND per_prj_id=?";
             $params[] = $prj_id;
@@ -152,8 +151,6 @@ class Email_Response
      */
     public static function update()
     {
-        $_POST['id'] = Misc::escapeInteger($_POST['id']);
-
         if (Validation::isWhitespace($_POST["title"])) {
             return -2;
         }

--- a/lib/eventum/class.faq.php
+++ b/lib/eventum/class.faq.php
@@ -405,7 +405,7 @@ class FAQ
                  ORDER BY
                     faq_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.faq.php
+++ b/lib/eventum/class.faq.php
@@ -41,7 +41,6 @@ class FAQ
         if (!is_array($support_level_ids)) {
             $support_level_ids = array($support_level_ids);
         }
-        $support_level_ids = Misc::escapeString($support_level_ids);
         $prj_id = Auth::getCurrentProject();
 
         if (count($support_level_ids) == 0) {
@@ -62,14 +61,16 @@ class FAQ
                         {{%faq_support_level}}
                      WHERE
                         faq_id=fsl_faq_id AND
-                        fsl_support_level_id IN('" . join("', '", $support_level_ids) . "') AND
-                        faq_prj_id =
+                        fsl_support_level_id IN (" . DB_Helper::buildList($support_level_ids) . ") AND
+                        faq_prj_id = ?
                      GROUP BY
                         faq_id
                      ORDER BY
                         faq_rank ASC";
-            $params = array($prj_id);
+            $params = $support_level_ids;
+            $params[] = $prj_id;
         }
+
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
         } catch (DbException $e) {
@@ -93,18 +94,18 @@ class FAQ
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%faq}}
                  WHERE
-                    faq_id IN ($items)";
+                    faq_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeSupportLevelAssociations($_POST['items']);
+        self::removeSupportLevelAssociations($items);
 
         return true;
     }
@@ -118,17 +119,16 @@ class FAQ
      */
     public function removeSupportLevelAssociations($faq_id)
     {
-        $faq_id = Misc::escapeInteger($faq_id);
         if (!is_array($faq_id)) {
             $faq_id = array($faq_id);
         }
-        $items = @implode(", ", $faq_id);
+
         $stmt = "DELETE FROM
                     {{%faq_support_level}}
                  WHERE
-                    fsl_faq_id IN ($items)";
+                    fsl_faq_id IN (" . DB_Helper::buildList($faq_id) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $faq_id);
         } catch (DbException $e) {
             return false;
         }
@@ -143,14 +143,14 @@ class FAQ
      */
     public static function update()
     {
-        $_POST['id'] = Misc::escapeInteger($_POST['id']);
-
         if (Validation::isWhitespace($_POST["title"])) {
             return -2;
         }
         if (Validation::isWhitespace($_POST["message"])) {
             return -3;
         }
+
+        $faq_id = $_POST['id'];
         $stmt = "UPDATE
                     {{%faq}}
                  SET
@@ -161,7 +161,7 @@ class FAQ
                     faq_rank=?
                  WHERE
                     faq_id=?";
-        $params = array($_POST['project'], Date_Helper::getCurrentDateGMT(), $_POST["title"], $_POST["message"], $_POST['rank'], $_POST["id"]);
+        $params = array($_POST['project'], Date_Helper::getCurrentDateGMT(), $_POST["title"], $_POST["message"], $_POST['rank'], $faq_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
@@ -169,10 +169,10 @@ class FAQ
         }
 
         // remove all of the associations with support levels, then add them all again
-        self::removeSupportLevelAssociations($_POST['id']);
+        self::removeSupportLevelAssociations($faq_id);
         if (isset($_POST['support_levels']) && count($_POST['support_levels']) > 0) {
             foreach ($_POST['support_levels'] as $support_level_id) {
-                self::addSupportLevelAssociation($_POST['id'], $support_level_id);
+                self::addSupportLevelAssociation($faq_id, $support_level_id);
             }
         }
 

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -663,13 +663,12 @@ class Filter
      */
     public static function removeByProjects($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%custom_filter}}
                  WHERE
-                    cst_prj_id IN ($items)";
+                    cst_prj_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.group.php
+++ b/lib/eventum/class.group.php
@@ -98,7 +98,7 @@ class Group
         self::setProjects($_POST["id"], $_POST["projects"]);
         // get old users so we can remove any ones that have been removed
         $existing_users = self::getUsers($_POST["id"]);
-        $diff = array_diff($existing_users, Misc::escapeInteger($_POST["users"]));
+        $diff = array_diff($existing_users, $_POST["users"]);
         if (count($diff) > 0) {
             foreach ($diff as $usr_id) {
                 User::setGroupID($usr_id, false);
@@ -118,7 +118,8 @@ class Group
      */
     public static function remove()
     {
-        foreach (Misc::escapeInteger(@$_POST["items"]) as $grp_id) {
+        $items = $_POST["items"];
+        foreach ($items as $grp_id) {
             $users = self::getUsers($grp_id);
 
             $stmt = "DELETE FROM
@@ -151,8 +152,6 @@ class Group
      */
     public function setProjects($grp_id, $projects)
     {
-        $grp_id = Misc::escapeInteger($grp_id);
-        $projects = Misc::escapeInteger($projects);
         self::removeProjectsByGroup($grp_id);
 
         // make new associations
@@ -209,9 +208,10 @@ class Group
         $stmt = "DELETE FROM
                     {{%project_group}}
                  WHERE
-                    pgr_prj_id IN(" . join(",", Misc::escapeInteger($projects)) . ")";
+
+                    pgr_prj_id IN (" . DB_Helper::buildList($projects) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $projects);
         } catch (DbException $e) {
             return -1;
         }
@@ -228,8 +228,6 @@ class Group
     public static function getDetails($grp_id)
     {
         static $returns;
-
-        $grp_id = Misc::escapeInteger($grp_id);
 
         if (!empty($returns[$grp_id])) {
             return $returns[$grp_id];
@@ -272,16 +270,14 @@ class Group
      */
     public static function getName($grp_id)
     {
-        $grp_id = Misc::escapeInteger($grp_id);
-        if (empty($grp_id)) {
+        if (!$grp_id) {
             return "";
         }
         $details = self::getDetails($grp_id);
         if (count($details) < 1) {
             return "";
-        } else {
-            return $details["grp_name"];
         }
+        return $details["grp_name"];
     }
 
     /**
@@ -324,8 +320,6 @@ class Group
     public static function getAssocList($prj_id)
     {
         static $list;
-
-        $prj_id = Misc::escapeInteger($prj_id);
 
         if (!empty($list[$prj_id])) {
             return $list[$prj_id];

--- a/lib/eventum/class.group.php
+++ b/lib/eventum/class.group.php
@@ -363,7 +363,7 @@ class Group
                  ORDER BY
                     grp_name";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -328,13 +328,15 @@ class History
     /**
      * Returns the history for a specified user in a specified time frame for an optional type
      *
+     * NOTE: not used by eventum core. drop?
+     *
      * @param   integer $usr_id The id of the user.
      * @param   date $start The start date
      * @param   date $end The end date
      * @param   array $htt_id The htt_id or id's to to return history for.
      * @return  array An array of history items
      */
-    public function getHistoryByUser($usr_id, $start, $end, $htt_id = false)
+    public function getHistoryByUser($usr_id, $start, $end, $htt_id = null)
     {
         $stmt = "SELECT
                     his_id,
@@ -347,11 +349,14 @@ class History
                  WHERE
                     his_usr_id = ? AND
                     his_created_date BETWEEN ? AND ?";
+
         $params = array($usr_id, date("Y/m/d", $start), date("Y/m/d", $end));
-        if ($htt_id != false) {
-            $stmt .= "
-                    AND his_htt_id IN(" . join(",", Misc::escapeInteger($htt_id)) . ")";
+
+        if ($htt_id) {
+            $stmt .= "AND his_htt_id IN (" . DB_Helper::buildList($htt_id) . ")";
+            $params = array_merge($params, $htt_id);
         }
+
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
         } catch (DbException $e) {

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -94,7 +94,7 @@ class History
      */
     public static function getListing($iss_id, $order_by = 'DESC')
     {
-        $order_by = Misc::escapeString($order_by);
+        $order_by = DB_Helper::orderBy($order_by);
         $stmt = "SELECT
                     *
                  FROM

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -62,33 +62,26 @@ class History
      * @param   integer $htt_id The type ID of this history event.
      * @param   string $summary The summary of the changes
      * @param   boolean $hide If this history item should be hidden.
-     * @return  void
      */
     public static function add($iss_id, $usr_id, $htt_id, $summary, $hide = false)
     {
-        $stmt = "INSERT INTO
-                    {{%issue_history}}
-                 (
-                    his_iss_id,
-                    his_usr_id,
-                    his_created_date,
-                    his_summary,
-                    his_htt_id";
+        $params = array(
+            'his_iss_id' => $iss_id,
+            'his_usr_id' => $usr_id,
+            'his_created_date' => Date_Helper::getCurrentDateGMT(),
+            'his_summary' => $summary,
+            'his_htt_id' => $htt_id,
+        );
+
         if ($hide == true) {
-            $stmt .= ", his_is_hidden";
+            $params['his_is_hidden'] = 1;
         }
-        $stmt .= ") VALUES (
-                    ?, ?, ?, ?, ?
-                    ";
-        if ($hide == true) {
-            $stmt .= ", 1";
-        }
-        $stmt .= ")";
-        $params = array($iss_id, $usr_id, Date_Helper::getCurrentDateGMT(), $summary, $htt_id);
+
+        $stmt = "INSERT INTO {{%issue_history}} SET ". DB_Helper::buildSet($params);
+
         try {
             DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
-            return -1;
         }
     }
 

--- a/lib/eventum/class.impact_analysis.php
+++ b/lib/eventum/class.impact_analysis.php
@@ -168,21 +168,23 @@ class Impact_Analysis
      */
     public static function remove()
     {
-        $items = implode(", ", Misc::escapeInteger($_POST["item"]));
+        $items = $_POST["item"];
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "SELECT
                     isr_iss_id
                  FROM
                     {{%issue_requirement}}
                  WHERE
-                    isr_id IN ($items)";
-        $issue_id = DB_Helper::getInstance()->getOne($stmt);
+                    isr_id IN ($itemlist)";
+        $issue_id = DB_Helper::getInstance()->getOne($stmt, $items);
 
         $stmt = "DELETE FROM
                     {{%issue_requirement}}
                  WHERE
-                    isr_id IN ($items)";
+                    isr_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return -1;
         }
@@ -203,13 +205,13 @@ class Impact_Analysis
      */
     public static function removeByIssues($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
+        $items = DB_Helper::buildList($ids);
         $stmt = "DELETE FROM
                     {{%issue_requirement}}
                  WHERE
                     isr_iss_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -357,8 +357,6 @@ class Issue
     {
         static $returns;
 
-        $issue_id = Misc::escapeInteger($issue_id);
-
         if ((!empty($returns[$issue_id])) && ($force_refresh != true)) {
             return $returns[$issue_id];
         }

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -870,21 +870,28 @@ class Issue
         $stmt = "UPDATE
                     {{%issue}}
                  SET
-                    iss_updated_date='" . Date_Helper::getCurrentDateGMT() . "'\n";
+                    iss_updated_date=?\n";
+        $params = array(
+            Date_Helper::getCurrentDateGMT(),
+        );
+
         if ($type) {
             if (in_array($type, $public)) {
                 $field = "iss_last_public_action_";
             } else {
                 $field = "iss_last_internal_action_";
             }
-            $stmt .= ",\n " . $field . "date = '" . Date_Helper::getCurrentDateGMT() . "',\n" .
-                $field . "type  ='" . Misc::escapeString($type) . "'\n";
+            $stmt .= ",\n " . $field . "date = ?,\n" .
+                $field . "type  = ?\n";
+            $params[] = Date_Helper::getCurrentDateGMT();
+            $params[] = $type;
         }
         $stmt .= "WHERE
-                    iss_id=" . Misc::escapeInteger($issue_id);
+                    iss_id=?";
+        $params[] = $issue_id;
 
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1316,15 +1316,14 @@ class Issue
      */
     public static function removeByProjects($ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
         $stmt = "SELECT
                     iss_id
                  FROM
                     {{%issue}}
                  WHERE
-                    iss_prj_id IN ($items)";
+                    iss_prj_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            $res = DB_Helper::getInstance()->getColumn($stmt);
+            $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -864,14 +864,14 @@ class Issue
      * @param   string $type The type of update that was made (optional)
      * @return  boolean
      */
-    public static function markAsUpdated($issue_id, $type = false)
+    public static function markAsUpdated($issue_id, $type = null)
     {
         $public = array("staff response", "customer action", "file uploaded", "user response");
         $stmt = "UPDATE
                     {{%issue}}
                  SET
                     iss_updated_date='" . Date_Helper::getCurrentDateGMT() . "'\n";
-        if ($type != false) {
+        if ($type) {
             if (in_array($type, $public)) {
                 $field = "iss_last_public_action_";
             } else {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -2748,7 +2748,7 @@ class Issue
                     iss_id IN ($ids)";
 
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return;
         }
@@ -2832,7 +2832,7 @@ class Issue
                  WHERE
                     iss_id in ($ids)";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return;
         }
@@ -3307,7 +3307,7 @@ class Issue
                  ORDER BY
                     iss_id ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -179,12 +179,15 @@ class Link_Filter
      */
     public static function remove()
     {
+        $items = $_REQUEST["items"];
+        $itemlist = DB_Helper::buildList($items);
+
         $sql = "DELETE FROM
                     {{%link_filter}}
                 WHERE
-                    lfi_id IN(" . join(',', Misc::escapeInteger($_REQUEST["items"])) . ")";
+                    lfi_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($sql);
+            DB_Helper::getInstance()->query($sql, $items);
         } catch (DbException $e) {
             return -1;
         }
@@ -192,9 +195,9 @@ class Link_Filter
         $sql = "DELETE FROM
                     {{%project_link_filter}}
                 WHERE
-                    plf_lfi_id IN(" . join(',', Misc::escapeInteger($_REQUEST["items"])) . ")";
+                    plf_lfi_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($sql);
+            DB_Helper::getInstance()->query($sql, $items);
         } catch (DbException $e) {
             return -1;
         }
@@ -240,7 +243,7 @@ class Link_Filter
             return -1;
         }
 
-        foreach (Misc::escapeInteger($_REQUEST["projects"]) as $prj_id) {
+        foreach ($_REQUEST["projects"] as $prj_id) {
             $sql = "INSERT INTO
                         {{%project_link_filter}}
                     (

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -412,6 +412,7 @@ class Misc
      *
      * @param   string|array $input The original string
      * @return  string The escaped (or not) string
+     * @deprecated Using this is bad design, must use placeholders in query
      */
     public static function escapeString($input, $add_quotes = false)
     {
@@ -431,6 +432,7 @@ class Misc
      *
      * @param   mixed $input The original input.
      * @return  mixed The input converted to an integer
+     * @deprecated Using this is bad design, must use placeholders in query
      */
     public static function escapeInteger($input)
     {

--- a/lib/eventum/class.news.php
+++ b/lib/eventum/class.news.php
@@ -151,18 +151,19 @@ class News
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
         $stmt = "DELETE FROM
                     {{%news}}
                  WHERE
-                    nws_id IN ($items)";
+                    nws_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeProjectAssociations($_POST['items']);
+        self::removeProjectAssociations($items);
 
         return true;
     }
@@ -180,12 +181,13 @@ class News
         if (!is_array($nws_id)) {
             $nws_id = array($nws_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($nws_id));
+
+        $items = DB_Helper::buildList($nws_id);
         $stmt = "DELETE FROM
                     {{%project_news}}
                  WHERE
                     prn_nws_id IN ($items)";
-        $params = array();
+        $params = $nws_id;
         if ($prj_id) {
             $stmt .= " AND prn_prj_id=?";
             $params[] = $prj_id;

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -83,7 +83,6 @@ class Note
      */
     public static function getDetails($note_id)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $stmt = "SELECT
                     {{%note}}.*,
                     not_full_message,
@@ -124,7 +123,7 @@ class Note
     }
 
     /**
-     * Returns the sequensial note identification number for the given issue.
+     * Returns the sequential note identification number for the given issue.
      * This is only for display purposes, but has become relied upon by users
      * as a valid reference number.  It is simply a sequence, starting with the
      * first note created as #1, and each increasing by 1 there after.
@@ -220,7 +219,7 @@ class Note
      */
     public static function getNoteBySequence($issue_id, $sequence)
     {
-        $sequence = Misc::escapeInteger($sequence);
+        $offset = (int)$sequence - 1;
         $stmt = "SELECT
                     not_id
                 FROM
@@ -230,7 +229,7 @@ class Note
                     not_removed = 0
                  ORDER BY
                     not_created_date ASC
-                LIMIT 1 OFFSET " . ($sequence - 1);
+                LIMIT 1 OFFSET $offset";
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
         } catch (DbException $e) {

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -294,7 +294,6 @@ class Note
      */
     public static function insert($usr_id, $issue_id, $unknown_user = false, $log = true, $closing = false, $send_notification = true, $is_blocked = false)
     {
-        $issue_id = Misc::escapeInteger($issue_id);
         $prj_id = Issue::getProjectID($issue_id);
 
         if (@$_POST['add_extra_recipients'] != 'yes') {

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -174,7 +174,6 @@ class Note
      */
     public static function getBlockedMessage($note_id)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $stmt = "SELECT
                     not_full_message
                  FROM
@@ -184,7 +183,7 @@ class Note
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($note_id));
         } catch (DbException $e) {
-            throw new RuntimeException("Can't find note $note_id");
+            throw new RuntimeException("Can't find note");
         }
 
         return $res;
@@ -198,7 +197,6 @@ class Note
      */
     public static function getIssueID($note_id)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $stmt = "SELECT
                     not_iss_id
                  FROM
@@ -250,7 +248,6 @@ class Note
      */
     public function getUnknownUser($note_id)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $sql = "SELECT
                     not_unknown_user
                 FROM
@@ -412,13 +409,13 @@ class Note
      */
     public static function removeByIssues($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
+        $items = DB_Helper::buildList($ids);
         $stmt = "DELETE FROM
                     {{%note}}
                  WHERE
                     not_iss_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }
@@ -435,7 +432,6 @@ class Note
      */
     public static function remove($note_id, $log = true)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $stmt = "SELECT
                     not_iss_id,
                     not_usr_id,
@@ -457,7 +453,7 @@ class Note
                  WHERE
                     not_id=?";
         try {
-            $res = DB_Helper::getInstance()->query($stmt, array($note_id));
+            DB_Helper::getInstance()->query($stmt, array($note_id));
         } catch (DbException $e) {
             return -1;
         }
@@ -544,7 +540,6 @@ class Note
      */
     public static function convertNote($note_id, $target, $authorize_sender = false)
     {
-        $note_id = Misc::escapeInteger($note_id);
         $issue_id = self::getIssueID($note_id);
         $email_account_id = Email_Account::getEmailAccount();
         $blocked_message = self::getBlockedMessage($note_id);

--- a/lib/eventum/class.phone_support.php
+++ b/lib/eventum/class.phone_support.php
@@ -98,13 +98,15 @@ class Phone_Support
      */
     public static function removeCategory()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "DELETE FROM
                     {{%project_phone_category}}
                  WHERE
-                    phc_id IN ($items)";
+                    phc_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
@@ -359,8 +361,6 @@ class Phone_Support
      */
     public static function remove($phone_id)
     {
-        $phone_id = Misc::escapeInteger($phone_id);
-
         $stmt = "SELECT
                     phs_iss_id,
                     phs_ttr_id,
@@ -409,13 +409,14 @@ class Phone_Support
      */
     public static function removeByIssues($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
+        $items = DB_Helper::buildList($ids);
+
         $stmt = "DELETE FROM
                     {{%phone_support}}
                  WHERE
                     phs_iss_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.prefs.php
+++ b/lib/eventum/class.prefs.php
@@ -129,7 +129,7 @@ class Prefs
                 WHERE
                     upp_usr_id = $usr_id";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($sql, false, array(), DB_FETCHMODE_ASSOC);
+            $res = DB_Helper::getInstance()->fetchAssoc($sql, array(), DB_FETCHMODE_ASSOC);
         } catch (DbException $e) {
             return $returns[$usr_id];
         }

--- a/lib/eventum/class.priority.php
+++ b/lib/eventum/class.priority.php
@@ -145,13 +145,13 @@ class Priority
      */
     public function removeByProjects($ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
+        $items = DB_Helper::buildList($ids);
         $stmt = "DELETE FROM
                     {{%project_priority}}
                  WHERE
                     pri_prj_id IN ($items)";
         try {
-            $res = DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }
@@ -167,13 +167,14 @@ class Priority
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
         $stmt = "DELETE FROM
                     {{%project_priority}}
                  WHERE
-                    pri_id IN ($items)";
+                    pri_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.product.php
+++ b/lib/eventum/class.product.php
@@ -120,10 +120,10 @@ class Product
         $sql = "DELETE FROM
                     {{%product}}
                 WHERE
-                    pro_id IN(" . join(', ', Misc::escapeInteger($ids)) . ")";
+                    pro_id IN (" . DB_Helper::buildList($ids) . ")";
 
         try {
-            DB_Helper::getInstance()->query($sql);
+            DB_Helper::getInstance()->query($sql, $ids);
         } catch (DbException $e) {
             return -1;
         }

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -168,7 +168,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -640,7 +640,7 @@ class Project
                 User::getRoleID('Manager'),
             );
             if ($include_extra) {
-                $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params, DB_FETCHMODE_ASSOC);
+                $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, DB_FETCHMODE_ASSOC);
             } else {
                 $res = DB_Helper::getInstance()->getPair($stmt, $params);
             }
@@ -690,7 +690,7 @@ class Project
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -747,7 +747,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -842,7 +842,7 @@ class Project
                     usr_customer_id DESC,
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -868,7 +868,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -909,7 +909,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, array($usr_id));
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($usr_id));
         } catch (DbException $e) {
             return "";
         }
@@ -958,7 +958,7 @@ class Project
                  ORDER BY
                     usr_email ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -690,7 +690,7 @@ class Project
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -842,7 +842,7 @@ class Project
                     usr_customer_id DESC,
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -909,7 +909,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, array($usr_id));
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, array($usr_id));
         } catch (DbException $e) {
             return "";
         }
@@ -958,7 +958,7 @@ class Project
                  ORDER BY
                     usr_email ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -330,30 +330,30 @@ class Project
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%project}}
                  WHERE
-                    prj_id IN ($items)";
+                    prj_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return -1;
         }
 
-        self::removeUserByProjects($_POST["items"]);
-        Category::removeByProjects($_POST["items"]);
-        Release::removeByProjects($_POST["items"]);
-        Filter::removeByProjects($_POST["items"]);
-        Email_Account::removeAccountByProjects($_POST["items"]);
-        Issue::removeByProjects($_POST["items"]);
-        Custom_Field::removeByProjects($_POST["items"]);
+        self::removeUserByProjects($items);
+        Category::removeByProjects($items);
+        Release::removeByProjects($items);
+        Filter::removeByProjects($items);
+        Email_Account::removeAccountByProjects($items);
+        Issue::removeByProjects($items);
+        Custom_Field::removeByProjects($items);
 
-        $statuses = array_keys(Status::getAssocStatusList($_POST["items"]));
-        foreach ($_POST["items"] as $prj_id) {
+        $statuses = array_keys(Status::getAssocStatusList($items));
+        foreach ($items as $prj_id) {
             Status::removeProjectAssociations($statuses, $prj_id);
         }
-        Group::disassociateProjects($_POST["items"]);
+        Group::disassociateProjects($items);
 
         return 1;
     }
@@ -366,18 +366,20 @@ class Project
      * @param   array $users_to_not_remove Users that should not be removed
      * @return  boolean
      */
-    public static function removeUserByProjects($ids, $users_to_not_remove = false)
+    public static function removeUserByProjects($ids, $users_to_not_remove = null)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%project_user}}
                  WHERE
-                    pru_prj_id IN ($items)";
-        if ($users_to_not_remove != false) {
-            $stmt .= " AND\n pru_usr_id NOT IN(" . join(', ', Misc::escapeInteger($users_to_not_remove)) . ")";
+                    pru_prj_id IN (" . DB_Helper::buildList($ids) . ")";
+        $params = $ids;
+        if ($users_to_not_remove) {
+            $stmt .= " AND\n pru_usr_id NOT IN (" . DB_Helper::buildList($users_to_not_remove) . ")";
+            $params = array_merge($params, $users_to_not_remove);
         }
+
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }
@@ -462,8 +464,6 @@ class Project
      */
     public static function associateUser($prj_id, $usr_id, $role)
     {
-        $prj_id = Misc::escapeInteger($prj_id);
-        $usr_id = Misc::escapeInteger($usr_id);
         // see if association already exists
         $sql = "SELECT
                     pru_id
@@ -675,20 +675,22 @@ class Project
                     {{%user}},
                     {{%project_user}}
                  WHERE
-                    pru_prj_id=" . Misc::escapeInteger($prj_id) . " AND
+                    pru_prj_id=? AND
                     pru_usr_id=usr_id AND
-                    usr_id != " . APP_SYSTEM_USER_ID;
+                    usr_id != ?";
+        $params = array($prj_id, APP_SYSTEM_USER_ID);
         if ($status != NULL) {
             $stmt .= " AND usr_status='active' ";
         }
         if ($role != NULL) {
-            $stmt .= " AND pru_role > " . Misc::escapeInteger($role);
+            $stmt .= " AND pru_role > ?";
+            $params[] = $role;
         }
         $stmt .= "
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -824,12 +826,14 @@ class Project
                     {{%user}},
                     {{%project_user}}
                  WHERE
-                    pru_prj_id=" . Misc::escapeInteger($prj_id) . " AND
+                    pru_prj_id=? AND
                     pru_usr_id=usr_id AND
                     usr_status='active' AND
-                    usr_id <> " . APP_SYSTEM_USER_ID;
+                    usr_id <> ?";
+        $params = array($prj_id, APP_SYSTEM_USER_ID);
         if (!empty($customer_id)) {
-            $stmt .= " AND (usr_customer_id IS NULL OR usr_customer_id IN (0, " . Misc::escapeInteger($customer_id) . ")) ";
+            $stmt .= " AND (usr_customer_id IS NULL OR usr_customer_id IN (0, ?)) ";
+            $params[] = $customer_id;
         } else {
             $stmt .= " AND (usr_customer_id IS NULL OR usr_customer_id=0) ";
         }
@@ -838,7 +842,7 @@ class Project
                     usr_customer_id DESC,
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -896,7 +900,7 @@ class Project
                     {{%project_user}}
                  WHERE
                     prj_id=pru_prj_id AND
-                    pru_usr_id=" . Misc::escapeInteger($usr_id) . " AND
+                    pru_usr_id=? AND
                     prj_remote_invocation='enabled'";
         if ($only_customer_projects) {
             $stmt .= " AND prj_customer_backend <> '' AND prj_customer_backend IS NOT NULL ";
@@ -905,7 +909,7 @@ class Project
                  ORDER BY
                     prj_title";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, array($usr_id));
         } catch (DbException $e) {
             return "";
         }
@@ -940,19 +944,21 @@ class Project
                     {{%user}},
                     {{%project_user}}
                  WHERE
-                    pru_prj_id=" . Misc::escapeInteger($prj_id) . " AND
+                    pru_prj_id=? AND
                     pru_usr_id=usr_id";
-        if ($status != NULL) {
+        $params = array($prj_id);
+        if ($status) {
             $stmt .= " AND usr_status='active' ";
         }
-        if ($role != NULL) {
-            $stmt .= " AND pru_role > $role ";
+        if ($role) {
+            $stmt .= " AND pru_role > ?";
+            $params[] = $role;
         }
         $stmt .= "
                  ORDER BY
                     usr_email ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.release.php
+++ b/lib/eventum/class.release.php
@@ -142,16 +142,18 @@ class Release
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
+
         // gotta fix the issues that are using this release
         $stmt = "UPDATE
                     {{%issue}}
                  SET
                     iss_pre_id=0
                  WHERE
-                    iss_pre_id IN ($items)";
+                    iss_pre_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
@@ -159,9 +161,9 @@ class Release
         $stmt = "DELETE FROM
                     {{%project_release}}
                  WHERE
-                    pre_id IN ($items)";
+                    pre_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.release.php
+++ b/lib/eventum/class.release.php
@@ -121,13 +121,12 @@ class Release
      */
     public static function removeByProjects($ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%project_release}}
                  WHERE
-                    pre_prj_id IN ($items)";
+                    pre_prj_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.reminder.php
+++ b/lib/eventum/class.reminder.php
@@ -116,7 +116,7 @@ class Reminder
                  ORDER BY
                     rem_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -839,7 +839,7 @@ class Reminder
         // can't rely on the mysql server's timezone setting, so let's use gmt dates throughout
         $stmt = str_replace('UNIX_TIMESTAMP()', "UNIX_TIMESTAMP('" . Date_Helper::getCurrentDateGMT() . "')", $stmt);
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.reminder.php
+++ b/lib/eventum/class.reminder.php
@@ -486,33 +486,34 @@ class Reminder
      */
     public function removeAllAssociations($rem_id)
     {
-        $rem_id = Misc::escapeInteger($rem_id);
         if (!is_array($rem_id)) {
             $rem_id = array($rem_id);
         }
+        $itemlist = DB_Helper::buildList($rem_id);
+
         $stmt = "DELETE FROM
                     {{%reminder_requirement}}
                  WHERE
-                    rer_rem_id IN (" . implode(',', $rem_id) . ")";
-        DB_Helper::getInstance()->query($stmt);
+                    rer_rem_id IN ($itemlist)";
+        DB_Helper::getInstance()->query($stmt, $rem_id);
 
         $stmt = "DELETE FROM
                     {{%reminder_priority}}
                  WHERE
-                    rep_rem_id IN (" . implode(',', $rem_id) . ")";
-        DB_Helper::getInstance()->query($stmt);
+                    rep_rem_id IN ($itemlist)";
+        DB_Helper::getInstance()->query($stmt, $rem_id);
 
         $stmt = "DELETE FROM
                     {{%reminder_product}}
                  WHERE
-                    rpr_rem_id IN (" . implode(',', $rem_id) . ")";
-        DB_Helper::getInstance()->query($stmt);
+                    rpr_rem_id IN ($itemlist)";
+        DB_Helper::getInstance()->query($stmt, $rem_id);
 
         $stmt = "DELETE FROM
                     {{%reminder_severity}}
                  WHERE
-                    rms_rem_id IN (" . implode(',', $rem_id) . ")";
-        DB_Helper::getInstance()->query($stmt);
+                    rms_rem_id IN ($itemlist)";
+        DB_Helper::getInstance()->query($stmt, $rem_id);
     }
 
     /**
@@ -657,25 +658,27 @@ class Reminder
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "DELETE FROM
                     {{%reminder_level}}
                  WHERE
-                    rem_id IN ($items)";
+                    rem_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeAllAssociations($_POST["items"]);
+        self::removeAllAssociations($items);
         $stmt = "SELECT
                     rma_id
                  FROM
                     {{%reminder_action}}
                  WHERE
-                    rma_rem_id IN ($items)";
-        $actions = DB_Helper::getInstance()->getColumn($stmt);
+                    rma_rem_id IN ($itemlist)";
+        $actions = DB_Helper::getInstance()->getColumn($stmt, $items);
         if (count($actions) > 0) {
             Reminder_Action::remove($actions);
         }

--- a/lib/eventum/class.reminder_action.php
+++ b/lib/eventum/class.reminder_action.php
@@ -366,12 +366,13 @@ class Reminder_Action
         if (!is_array($rma_id)) {
             $rma_id = array($rma_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($rma_id));
+
+        $items = DB_Helper::buildList($rma_id);
         $stmt = "DELETE FROM
                     {{%reminder_action_list}}
                  WHERE
                     ral_rma_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+        DB_Helper::getInstance()->query($stmt, $rma_id);
     }
 
     /**
@@ -382,24 +383,25 @@ class Reminder_Action
      */
     public static function remove($action_ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($action_ids));
+        $items = DB_Helper::buildList($action_ids);
+
         $stmt = "DELETE FROM
                     {{%reminder_action}}
                  WHERE
                     rma_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+        DB_Helper::getInstance()->query($stmt, $action_ids);
 
         $stmt = "DELETE FROM
                     {{%reminder_history}}
                  WHERE
                     rmh_rma_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+        DB_Helper::getInstance()->query($stmt, $action_ids);
 
         $stmt = "DELETE FROM
                     {{%reminder_level_condition}}
                  WHERE
                     rlc_rma_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+        DB_Helper::getInstance()->query($stmt, $action_ids);
 
         self::clearActionUserList($action_ids);
     }
@@ -798,15 +800,17 @@ class Reminder_Action
             return $issues;
         }
 
+        $idlist = DB_Helper::buildList($issues);
+
         $stmt = "SELECT
                     rta_iss_id,
                     rta_rma_id
                  FROM
                     {{%reminder_triggered_action}}
                  WHERE
-                    rta_iss_id IN (" . implode(', ', Misc::escapeInteger($issues)) . ")";
+                    rta_iss_id IN ($idlist)";
         try {
-            $triggered_actions = DB_Helper::getInstance()->fetchAssoc($stmt);
+            $triggered_actions = DB_Helper::getInstance()->fetchAssoc($stmt, $issues);
         } catch (DbException $e) {
             return $issues;
         }
@@ -815,7 +819,7 @@ class Reminder_Action
         foreach ($issues as $issue_id) {
             // if the issue was already triggered and the last triggered
             // action was the given one, then add it to the list of repeat issues
-            if ((in_array($issue_id, array_keys($triggered_actions))) && ($triggered_actions[$issue_id] == $rma_id)) {
+            if (in_array($issue_id, array_keys($triggered_actions)) && $triggered_actions[$issue_id] == $rma_id) {
                 $repeat_issues[] = $issue_id;
             }
         }
@@ -833,8 +837,6 @@ class Reminder_Action
      */
     public function recordLastTriggered($issue_id, $rma_id)
     {
-        $issue_id = Misc::escapeInteger($issue_id);
-        $rma_id = Misc::escapeInteger($rma_id);
         $stmt = "SELECT
                     COUNT(*)
                  FROM
@@ -847,9 +849,10 @@ class Reminder_Action
             $stmt = "UPDATE
                         {{%reminder_triggered_action}}
                      SET
-                        rta_rma_id=$rma_id
+                        rta_rma_id=?
                      WHERE
-                        rta_iss_id=$issue_id";
+                        rta_iss_id=?";
+            $params = array($rma_id, $issue_id);
         } else {
             $stmt = "INSERT INTO
                         {{%reminder_triggered_action}}
@@ -857,12 +860,13 @@ class Reminder_Action
                         rta_iss_id,
                         rta_rma_id
                      ) VALUES (
-                        $issue_id,
-                        $rma_id
+                        ?,
+                        ?
                      )";
+            $params = array($issue_id, $rma_id);
         }
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }
@@ -883,7 +887,7 @@ class Reminder_Action
                  WHERE
                     rta_iss_id=?";
         try {
-            $res = DB_Helper::getInstance()->query($stmt, array($issue_id));
+            DB_Helper::getInstance()->query($stmt, array($issue_id));
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.reminder_action.php
+++ b/lib/eventum/class.reminder_action.php
@@ -419,7 +419,7 @@ class Reminder_Action
                  ORDER BY
                     rmt_title ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -806,7 +806,7 @@ class Reminder_Action
                  WHERE
                     rta_iss_id IN (" . implode(', ', Misc::escapeInteger($issues)) . ")";
         try {
-            $triggered_actions = DB_Helper::getInstance()->getAssoc($stmt);
+            $triggered_actions = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return $issues;
         }

--- a/lib/eventum/class.reminder_condition.php
+++ b/lib/eventum/class.reminder_condition.php
@@ -291,7 +291,7 @@ class Reminder_Condition
         $stmt .= "ORDER BY
                     rmf_title ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -315,7 +315,7 @@ class Reminder_Condition
                  ORDER BY
                     rmo_title ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.reminder_condition.php
+++ b/lib/eventum/class.reminder_condition.php
@@ -137,12 +137,12 @@ class Reminder_Condition
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
         $stmt = "DELETE FROM
                     {{%reminder_level_condition}}
                  WHERE
-                    rlc_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+                    rlc_id IN (" . DB_Helper::buildList($items) . ")";
+        DB_Helper::getInstance()->query($stmt, $items);
     }
 
     /**

--- a/lib/eventum/class.report.php
+++ b/lib/eventum/class.report.php
@@ -480,7 +480,7 @@ class Report
                  GROUP BY
                     time_period";
         try {
-            $total = DB_Helper::getInstance()->getAssoc($stmt);
+            $total = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -503,7 +503,7 @@ class Report
                  GROUP BY
                     time_period";
         try {
-            $dev_stats = DB_Helper::getInstance()->getAssoc($stmt);
+            $dev_stats = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -746,7 +746,7 @@ class Report
                     ORDER BY
                         $label_field ASC";
                 try {
-                    $res = DB_Helper::getInstance()->getAssoc($stmt);
+                    $res = DB_Helper::getInstance()->fetchAssoc($stmt);
                 } catch (DbException $e) {
                     return array();
                 }
@@ -934,7 +934,7 @@ class Report
             $stmt .= "\nORDER BY " . sprintf($order_by, 'iss_created_date');
         }
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }
@@ -988,7 +988,7 @@ class Report
         }
 
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.resolution.php
+++ b/lib/eventum/class.resolution.php
@@ -89,16 +89,17 @@ class Resolution
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
         // gotta fix the issues before removing the resolution
         $stmt = "UPDATE
                     {{%issue}}
                  SET
                     iss_res_id=0
                  WHERE
-                    iss_res_id IN ($items)";
+                    iss_res_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
@@ -106,9 +107,9 @@ class Resolution
         $stmt = "DELETE FROM
                     {{%resolution}}
                  WHERE
-                    res_id IN ($items)";
+                    res_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.resolution.php
+++ b/lib/eventum/class.resolution.php
@@ -209,7 +209,7 @@ class Resolution
                     res_rank ASC,
                     res_title ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.round_robin.php
+++ b/lib/eventum/class.round_robin.php
@@ -478,13 +478,13 @@ class Round_Robin
         if (!is_array($prr_id)) {
             $prr_id = array($prr_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($prr_id));
+        $items = DB_Helper::buildList($prr_id);
         $stmt = "DELETE FROM
                     {{%round_robin_user}}
                  WHERE
                     rru_prr_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $prr_id);
         } catch (DbException $e) {
             return false;
         }
@@ -499,18 +499,20 @@ class Round_Robin
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "DELETE FROM
                     {{%project_round_robin}}
                  WHERE
-                    prr_id IN ($items)";
+                    prr_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeUserAssociations($_POST['items']);
+        self::removeUserAssociations($items);
 
         return true;
     }

--- a/lib/eventum/class.scm.php
+++ b/lib/eventum/class.scm.php
@@ -42,13 +42,13 @@ class SCM
      */
     public static function removeByIssues($ids)
     {
-        $items = implode(", ", Misc::escapeInteger($ids));
+        $items = DB_Helper::buildList($ids);
         $stmt = "DELETE FROM
                     {{%issue_checkin}}
                  WHERE
                     isc_iss_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }
@@ -64,21 +64,22 @@ class SCM
      */
     public static function remove($items)
     {
-        $items = implode(", ", Misc::escapeInteger($items));
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "SELECT
                     isc_iss_id
                  FROM
                     {{%issue_checkin}}
                  WHERE
-                    isc_id IN ($items)";
-        $issue_id = DB_Helper::getInstance()->getOne($stmt);
+                    isc_id IN ($itemlist)";
+        $issue_id = DB_Helper::getInstance()->getOne($stmt, $items);
 
         $stmt = "DELETE FROM
                     {{%issue_checkin}}
                  WHERE
-                    isc_id IN ($items)";
+                    isc_id IN ($itemlist)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return -1;
         }

--- a/lib/eventum/class.severity.php
+++ b/lib/eventum/class.severity.php
@@ -154,13 +154,13 @@ class Severity
      */
     public static function removeByProjects($prj_ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($prj_ids));
+        $items = DB_Helper::buildList($prj_ids);
         $sql = "DELETE FROM
                     {{%project_severity}}
                  WHERE
                     sev_prj_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($sql);
+            DB_Helper::getInstance()->query($sql, $prj_ids);
         } catch (DbException $e) {
             return false;
         }
@@ -179,13 +179,14 @@ class Severity
         if (count($sev_ids) < 1) {
             return true;
         }
-        $items = @implode(", ", Misc::escapeInteger($sev_ids));
+
+        $items = DB_Helper::buildList($sev_ids);
         $sql = "DELETE FROM
                     {{%project_severity}}
                  WHERE
                     sev_id IN ($items)";
         try {
-            DB_Helper::getInstance()->query($sql);
+            DB_Helper::getInstance()->query($sql, $sev_ids);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -46,6 +46,7 @@ class Status
     public static function getProjectStatusCustomization($prj_id, $sta_ids)
     {
         $sta_ids = array_unique($sta_ids);
+
         $stmt = "SELECT
                     psd_sta_id,
                     psd_label,
@@ -54,9 +55,11 @@ class Status
                     {{%project_status_date}}
                  WHERE
                     psd_prj_id=? AND
-                    psd_sta_id IN (" . implode(', ', Misc::escapeInteger($sta_ids)) . ")";
+                    psd_sta_id IN (" . DB_Helper::buildList($sta_ids). ")";
+        $params = array_merge(array($prj_id), $sta_ids);
+
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, array($prj_id));
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
         } catch (DbException $e) {
             return array();
         }
@@ -95,11 +98,10 @@ class Status
      */
     public static function removeCustomization($items)
     {
-        $items = @implode(", ", Misc::escapeInteger($items));
         $stmt = "DELETE FROM
                     {{%project_status_date}}
                  WHERE
-                    psd_id IN ($items)";
+                    psd_id IN (" . DB_Helper::buildList($items) . ")";
         try {
             DB_Helper::getInstance()->query($stmt);
         } catch (DbException $e) {
@@ -337,26 +339,28 @@ class Status
      */
     public static function remove()
     {
-        $items = @implode(", ", Misc::escapeInteger($_POST["items"]));
+        $items = $_POST["items"];
+        $item_list = DB_Helper::buildList($items);
+
         $stmt = "DELETE FROM
                     {{%status}}
                  WHERE
-                    sta_id IN ($items)";
+                    sta_id IN ($item_list)";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }
 
-        self::removeProjectAssociations($_POST['items']);
+        self::removeProjectAssociations($items);
         // also set all issues currently set to these statuses to status '0'
         $stmt = "UPDATE
                     {{%issue}}
                  SET
                     iss_sta_id=0
                  WHERE
-                    iss_sta_id IN ($items)";
-        DB_Helper::getInstance()->query($stmt);
+                    iss_sta_id IN ($item_list)";
+        DB_Helper::getInstance()->query($stmt, $items);
 
         return true;
     }
@@ -389,21 +393,24 @@ class Status
      * @param   integer $prj_id The project ID
      * @return  boolean
      */
-    public static function removeProjectAssociations($sta_id, $prj_id=false)
+    public static function removeProjectAssociations($sta_id, $prj_id = null)
     {
         if (!is_array($sta_id)) {
             $sta_id = array($sta_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($sta_id));
+
         $stmt = "DELETE FROM
                     {{%project_status}}
                  WHERE
-                    prs_sta_id IN ($items)";
+                    prs_sta_id IN (" . DB_Helper::buildList($sta_id) . ")";
+
+        $params = $sta_id;
         if ($prj_id) {
-            $stmt .= " AND prs_prj_id=" . Misc::escapeInteger($prj_id);
+            $stmt .= " AND prs_prj_id=?";
+            $params[] = $prj_id;
         }
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }
@@ -558,7 +565,7 @@ class Status
         if (!is_array($prj_id)) {
             $prj_id = array($prj_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($prj_id));
+
         $stmt = "SELECT
                     UPPER(sta_abbreviation),
                     sta_title
@@ -566,13 +573,13 @@ class Status
                     {{%status}},
                     {{%project_status}}
                  WHERE
-                    prs_prj_id IN ($items) AND
+                    prs_prj_id IN (" . DB_Helper::buildList($prj_id) . ") AND
                     prs_sta_id=sta_id AND
                     sta_is_closed=1
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -593,7 +600,7 @@ class Status
         if (!is_array($prj_id)) {
             $prj_id = array($prj_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($prj_id));
+
         $stmt = "SELECT
                     UPPER(sta_abbreviation),
                     sta_title
@@ -601,7 +608,7 @@ class Status
                     {{%status}},
                     {{%project_status}}
                  WHERE
-                    prs_prj_id IN ($items) AND
+                    prs_prj_id IN (" . DB_Helper::buildList($prj_id) . ") AND
                     prs_sta_id=sta_id";
         if (!$show_closed) {
             $stmt .= " AND sta_is_closed=0 ";
@@ -610,7 +617,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -631,7 +638,7 @@ class Status
         if (!is_array($prj_id)) {
             $prj_id = array($prj_id);
         }
-        $items = @implode(", ", Misc::escapeInteger($prj_id));
+
         $stmt = "SELECT
                     sta_id,
                     sta_title
@@ -639,7 +646,7 @@ class Status
                     {{%status}},
                     {{%project_status}}
                  WHERE
-                    prs_prj_id IN ($items) AND
+                    prs_prj_id IN (" . DB_Helper::buildList($prj_id) . ") AND
                     prs_sta_id=sta_id";
         if (!$show_closed) {
             $stmt .= " AND sta_is_closed=0 ";
@@ -648,7 +655,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -59,7 +59,7 @@ class Status
         $params = array_merge(array($prj_id), $sta_ids);
 
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
         } catch (DbException $e) {
             return array();
         }
@@ -579,7 +579,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -617,7 +617,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -655,7 +655,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -679,7 +679,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -103,7 +103,7 @@ class Status
                  WHERE
                     psd_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -579,7 +579,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -617,7 +617,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
         } catch (DbException $e) {
             return "";
         }
@@ -655,7 +655,7 @@ class Status
                  ORDER BY
                     sta_rank ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $prj_id);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $prj_id);
         } catch (DbException $e) {
             return "";
         }

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -159,7 +159,7 @@ class Support
                  ORDER BY
                     " . $options["sort_by"] . " " . $options["sort_order"];
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -1849,7 +1849,7 @@ class Support
                     {{%support_email}}
                  WHERE
                     sup_id IN ($items)";
-        $subjects = DB_Helper::getInstance()->getAssoc($stmt);
+        $subjects = DB_Helper::getInstance()->fetchAssoc($stmt);
         for ($i = 0; $i < count($_POST["item"]); $i++) {
             History::add($issue_id, Auth::getUserID(), History::getTypeID('email_disassociated'),
                             ev_gettext('Email (subject: \'%1$s\') disassociated by %2$s', $subjects[$_POST["item"][$i]], User::getFullName(Auth::getUserID())));

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -357,11 +357,11 @@ class Support
         if (count($ids) < 1) {
             return true;
         }
-        $items = @implode(", ", Misc::escapeInteger($ids));
+
         $stmt = "DELETE FROM
                     {{%support_email}}
                  WHERE
-                    sup_ema_id IN ($items)";
+                    sup_ema_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
             DB_Helper::getInstance()->query($stmt);
         } catch (DbException $e) {

--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -114,7 +114,7 @@ class Time_Tracking
                     ttr_ttc_id IN (" . DB_Helper::buildList($ttc_ids) . ")
                  GROUP BY 1";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $ttc_ids);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $ttc_ids);
         } catch (DbException $e) {
             return null;
         }
@@ -316,7 +316,7 @@ class Time_Tracking
                  GROUP BY
                     ttr_iss_id";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $ids);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, false, $ids);
         } catch (DbException $e) {
             return;
         }
@@ -599,7 +599,7 @@ class Time_Tracking
                     ttc_title";
         $params = array(Auth::getCurrentProject(), $usr_id, $start, $end);
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $params, DB_FETCHMODE_ASSOC);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, DB_FETCHMODE_ASSOC);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -105,17 +105,16 @@ class Time_Tracking
      */
     private static function getCategoryStats($ttc_ids)
     {
-        $list = implode(", ", Misc::escapeInteger($ttc_ids));
         $stmt = "SELECT
                     ttr_ttc_id,
                     COUNT(*)
                  FROM
                     {{%time_tracking}}
                  WHERE
-                    ttr_ttc_id IN ($list)
+                    ttr_ttc_id IN (" . DB_Helper::buildList($ttc_ids) . ")
                  GROUP BY 1";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $ttc_ids);
         } catch (DbException $e) {
             return null;
         }
@@ -140,13 +139,12 @@ class Time_Tracking
             }
         }
 
-        $items = implode(", ", Misc::escapeInteger($items));
         $stmt = "DELETE FROM
                     {{%time_tracking_category}}
                  WHERE
-                    ttc_id IN ($items)";
+                    ttc_id IN (" . DB_Helper::buildList($items) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $items);
         } catch (DbException $e) {
             return -1;
         }
@@ -236,19 +234,20 @@ class Time_Tracking
      */
     public static function getList($prj_id)
     {
-        $ttc_list = join(', ', Misc::escapeString(self::$default_categories, true));
         $stmt = "SELECT
                     ttc_id,
                     ttc_title
                  FROM
                     {{%time_tracking_category}}
                  WHERE
-                    ttc_prj_id=? AND
-                    ttc_title NOT IN ($ttc_list)
+                    ttc_title NOT IN (" . DB_Helper::buildList(self::$default_categories) . ") AND
+                    ttc_prj_id=?
                  ORDER BY
                     ttc_title ASC";
+        $params = self::$default_categories;
+        $params[] = $prj_id;
         try {
-            $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
+            $res = DB_Helper::getInstance()->getAll($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -293,8 +292,9 @@ class Time_Tracking
     /**
      * Method used to get the time spent on a given list of issues.
      *
+     * FIXME: bad prefix: should not be called "getXXX" if it modifies $result, not returns it (updateXXX perhaps)
+     *
      * @param   array $result The result set
-     * @return  void
      */
     public static function getTimeSpentByIssues(&$result)
     {
@@ -303,20 +303,20 @@ class Time_Tracking
             $ids[] = $result[$i]["iss_id"];
         }
         if (count($ids) == 0) {
-            return false;
+            return;
         }
-        $ids = implode(", ", Misc::escapeInteger($ids));
+
         $stmt = "SELECT
                     ttr_iss_id,
                     SUM(ttr_time_spent)
                  FROM
                     {{%time_tracking}}
                  WHERE
-                    ttr_iss_id IN ($ids)
+                    ttr_iss_id IN (" . DB_Helper::buildList($ids) . ")
                  GROUP BY
                     ttr_iss_id";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, $ids);
         } catch (DbException $e) {
             return;
         }
@@ -421,13 +421,12 @@ class Time_Tracking
      */
     public static function removeByIssues($ids)
     {
-        $items = @implode(", ", Misc::escapeInteger($ids));
         $stmt = "DELETE FROM
                     {{%time_tracking}}
                  WHERE
-                    ttr_iss_id IN ($items)";
+                    ttr_iss_id IN (" . DB_Helper::buildList($ids) . ")";
         try {
-            DB_Helper::getInstance()->query($stmt);
+            DB_Helper::getInstance()->query($stmt, $ids);
         } catch (DbException $e) {
             return false;
         }
@@ -444,7 +443,6 @@ class Time_Tracking
      */
     public static function removeEntry($time_id, $usr_id)
     {
-        $time_id = Misc::escapeInteger($time_id);
         $stmt = "SELECT
                     ttr_iss_id issue_id,
                     ttr_usr_id owner_usr_id
@@ -643,6 +641,7 @@ class Time_Tracking
 
         return $res;
     }
+
     /**
      * Method used to add time spent on issue to a list of user issues.
      *
@@ -657,9 +656,8 @@ class Time_Tracking
 
         $issue_ids = array();
         for ($i = 0; $i < count($res); $i++) {
-            $issue_ids[] = Misc::escapeInteger($res[$i]["iss_id"]);
+            $issue_ids[] = $res[$i]["iss_id"];
         }
-        $ids = implode(", ", $issue_ids);
 
         $stmt = "SELECT
                     ttr_iss_id, sum(ttr_time_spent)
@@ -668,12 +666,14 @@ class Time_Tracking
                  WHERE
                     ttr_usr_id = ? AND
                     ttr_created_date BETWEEN ? AND ? AND
-                    ttr_iss_id in ($ids)
+                    ttr_iss_id in (" . DB_Helper::buildList($issue_ids) . ")
                  GROUP BY ttr_iss_id";
+        $params = array($usr_id, $start, $end);
+        $params = array_merge($params, $issue_ids);
         try {
-            $result = DB_Helper::getInstance()->getPair($stmt, array($usr_id, $start, $end));
+            $result = DB_Helper::getInstance()->getPair($stmt, $params);
         } catch (DbException $e) {
-            return 0;
+            return;
         }
 
         foreach ($res as $key => $item) {

--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -114,7 +114,7 @@ class Time_Tracking
                     ttr_ttc_id IN (" . DB_Helper::buildList($ttc_ids) . ")
                  GROUP BY 1";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $ttc_ids);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $ttc_ids);
         } catch (DbException $e) {
             return null;
         }
@@ -316,7 +316,7 @@ class Time_Tracking
                  GROUP BY
                     ttr_iss_id";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt, $ids);
+            $res = DB_Helper::getInstance()->getAssoc($stmt, false, $ids);
         } catch (DbException $e) {
             return;
         }

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -1487,10 +1487,8 @@ class User
      */
     public static function setGroupID($usr_id, $grp_id)
     {
-        if ($grp_id == false) {
-            $grp_id = 'null';
-        } else {
-            $grp_id = Misc::escapeInteger($grp_id);
+        if (!$grp_id) {
+            $grp_id = null;
         }
 
         $stmt = "UPDATE

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -532,7 +532,7 @@ class User
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -1296,7 +1296,7 @@ class User
                  FROM
                     {{%user}}";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -1322,7 +1322,7 @@ class User
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return "";
         }
@@ -1392,7 +1392,7 @@ class User
                  WHERE
                     usr_clocked_in=1";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return array();
         }

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -496,34 +496,41 @@ class User
      * @Param   integer $grp_id The ID of the group.
      * @return  array The associative array of users
      */
-    public static function getActiveAssocList($prj_id = false, $role = null, $exclude_grouped = false, $grp_id = false)
+    public static function getActiveAssocList($prj_id = null, $role = null, $exclude_grouped = false, $grp_id = null)
     {
-        $grp_id = Misc::escapeInteger($grp_id);
         $stmt = "SELECT
                     usr_id,
                     usr_full_name
                  FROM
                     {{%user}}";
-        if ($prj_id != false) {
+        $params = array();
+
+        if ($prj_id) {
             $stmt .= ",
                     {{%project_user}}";
         }
         $stmt .= "
                  WHERE
                     usr_status='active' AND
-                    usr_id != " . APP_SYSTEM_USER_ID;
-        if ($prj_id != false) {
-            $stmt .= " AND pru_prj_id = " . Misc::escapeInteger($prj_id) . " AND
+                    usr_id != ?";
+        $params[] = APP_SYSTEM_USER_ID;
+
+        if ($prj_id) {
+            $stmt .= " AND pru_prj_id = ? AND
                        usr_id = pru_usr_id";
-            if ($role != NULL) {
-                $stmt .= " AND pru_role > $role ";
+            $params[] = $prj_id;
+            if ($role) {
+                $stmt .= " AND pru_role > ?";
+                $params[] = $role;
             }
         }
-        if ($grp_id != false) {
+        if ($grp_id) {
             if ($exclude_grouped == false) {
-                $stmt .= " AND (usr_grp_id IS NULL OR usr_grp_id = $grp_id)";
+                $stmt .= " AND (usr_grp_id IS NULL OR usr_grp_id = ?)";
+                $params[] = $grp_id;
             } else {
-                $stmt .= " AND usr_grp_id = $grp_id";
+                $stmt .= " AND usr_grp_id = ?";
+                $params[] = $grp_id;
             }
         } elseif ($exclude_grouped == true) {
             $stmt .= " AND (usr_grp_id IS NULL or usr_grp_id = 0)";
@@ -532,7 +539,7 @@ class User
                  ORDER BY
                     usr_full_name ASC";
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
         } catch (DbException $e) {
             return "";
         }
@@ -671,14 +678,16 @@ class User
         $key = md5(serialize($usr_ids));
 
         if (empty($returns[$key])) {
+            $itemlist = DB_Helper::buildList($usr_ids);
+
             $stmt = "SELECT
                         *
                      FROM
                         {{%user}}
                      WHERE
-                        usr_id IN (" . implode(', ', Misc::escapeInteger($usr_ids)) . ")";
+                        usr_id IN ($itemlist)";
             try {
-                $res = DB_Helper::getInstance()->getAll($stmt);
+                $res = DB_Helper::getInstance()->getAll($stmt, $usr_ids);
             } catch (DbException $e) {
                 return null;
             }
@@ -729,17 +738,19 @@ class User
             }
         }
 
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "SELECT
                     usr_full_name
                  FROM
                     {{%user}}
                  WHERE
-                    usr_id IN (" . implode(', ', Misc::escapeInteger($items)) . ")";
+                    usr_id IN ($itemlist)";
         try {
             if (!is_array($usr_id)) {
-                $res = DB_Helper::getInstance()->getOne($stmt);
+                $res = DB_Helper::getInstance()->getOne($stmt, $items);
             } else {
-                $res = DB_Helper::getInstance()->getColumn($stmt);
+                $res = DB_Helper::getInstance()->getColumn($stmt, $items);
             }
         } catch (DbException $e) {
             return "";
@@ -779,17 +790,19 @@ class User
             }
         }
 
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "SELECT
                     usr_email
                  FROM
                     {{%user}}
                  WHERE
-                    usr_id IN (" . implode(', ', Misc::escapeInteger($items)) . ")";
+                    usr_id IN ($itemlist)";
         try {
             if (!is_array($usr_id)) {
-                $res = DB_Helper::getInstance()->getOne($stmt);
+                $res = DB_Helper::getInstance()->getOne($stmt, $items);
             } else {
-                $res = DB_Helper::getInstance()->getColumn($stmt);
+                $res = DB_Helper::getInstance()->getColumn($stmt, $items);
             }
         } catch (DbException $e) {
             if (!is_array($usr_id)) {
@@ -825,17 +838,19 @@ class User
             return $returns[$key];
         }
 
+        $itemlist = DB_Helper::buildList($items);
+
         $stmt = "SELECT
                     usr_grp_id
                  FROM
                     {{%user}}
                  WHERE
-                    usr_id IN (" . implode(', ', Misc::escapeInteger($items)) . ")";
+                    usr_id IN ($itemlist)";
         try {
             if (!is_array($usr_id)) {
-                $res = DB_Helper::getInstance()->getOne($stmt);
+                $res = DB_Helper::getInstance()->getOne($stmt, $items);
             } else {
-                $res = DB_Helper::getInstance()->getColumn($stmt);
+                $res = DB_Helper::getInstance()->getColumn($stmt, $items);
             }
         } catch (DbException $e) {
             return "";
@@ -907,15 +922,17 @@ class User
             }
         }
 
-        $items = implode(", ", Misc::escapeInteger((array)$usr_ids));
+        $usr_ids = (array)$usr_ids;
+        $items = DB_Helper::buildList($usr_ids);
         $stmt = "UPDATE
                     {{%user}}
                  SET
                     usr_status=?
                  WHERE
                     usr_id IN ($items)";
+        $params = array_merge(array($status), $usr_ids);
         try {
-            DB_Helper::getInstance()->query($stmt, array($status));
+            DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
             return false;
         }

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -77,7 +77,7 @@ class Workflow
                  ORDER BY
                     prj_id";
         try {
-            $res = DB_Helper::getInstance()->getAssoc($stmt);
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt);
         } catch (DbException $e) {
             return '';
         }

--- a/lib/eventum/db/DbInterface.php
+++ b/lib/eventum/db/DbInterface.php
@@ -120,8 +120,23 @@ interface DbInterface
      * @param bool $group
      * @return array  the associative array containing the query results.
      * @throws DbException on failure.
+     * @deprecated use fetchAssoc() instead for cleaner interface
      */
     public function getAssoc($query, $force_array = false, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT, $group = false);
+
+    /**
+     * Fetches an entire query result and returns it as an
+     * associative array using the first column as the key
+     *
+     * Keep in mind that database functions in PHP usually return string
+     * values for results regardless of the database's internal type.
+     *
+     * @param string $query
+     * @param mixed $params
+     * @param int $fetchmode
+     * @throws DbException on failure.
+     */
+    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT);
 
     /**
      * Fetches a single column from a query result and returns it as an

--- a/lib/eventum/db/DbPear.php
+++ b/lib/eventum/db/DbPear.php
@@ -108,6 +108,16 @@ class DbPear implements DbInterface
         return $res;
     }
 
+    /**
+     * @see DB_common::getAssoc
+     */
+    public function fetchAssoc($query, $params = array(), $fetchmode = DB_FETCHMODE_DEFAULT) {
+        $query = $this->quoteSql($query, $params);
+        $res = $this->db->getAssoc($query, false, $params, $fetchmode, false);
+        $this->assertError($res);
+        return $res;
+    }
+
     public function getPair($query, $params = array())
     {
         return $this->getAssoc($query, false, $params);

--- a/lib/eventum/db/DbYii.php
+++ b/lib/eventum/db/DbYii.php
@@ -129,6 +129,22 @@ class DbYii implements DbInterface
         return $command->queryAll(PDO::FETCH_GROUP | PDO::FETCH_UNIQUE | PDO::FETCH_ASSOC);
     }
 
+    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT) {
+        $this->convertParams($params);
+        $command = $this->connection->createCommand($query, $params);
+
+        $flags = PDO::FETCH_GROUP | PDO::FETCH_UNIQUE;
+        if ($fetchmode == DbInterface::DB_FETCHMODE_ASSOC) {
+            $flags |= PDO::FETCH_ASSOC;
+        } elseif ($fetchmode == DbInterface::DB_FETCHMODE_DEFAULT) {
+            $flags |= PDO::FETCH_NUM;
+        } else {
+            throw new UnexpectedValueException(__FUNCTION__ . " unsupported fetchmode: ". $fetchmode);
+        }
+
+        return $command->queryAll($flags);
+    }
+
     public function getPair($query, $params = array())
     {
         $this->convertParams($params);

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -38,5 +38,12 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $res = $stmt . '|' . join(',', $params);
         $exp = 'psd_prj_id=? AND psd_sta_id IN (?, ?, ?, ?)|110,1,2,a,f';
         $this->assertEquals($exp, $res);
+
+        // test merge two arrays
+        $stmt = "WHERE icf_fld_id IN (" . DB_Helper::buildList($ids) . ") AND icf_value IN (" . DB_Helper::buildList($ids) . ")";
+        $params = array_merge($ids, $ids);
+        $res = $stmt . '|' . join(',', $params);
+        $exp = 'WHERE icf_fld_id IN (?, ?, ?, ?) AND icf_value IN (?, ?, ?, ?)|1,2,a,f,1,2,a,f';
+        $this->assertEquals($exp, $res);
     }
 }

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -24,5 +24,9 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $res = DB_Helper::buildList($ids);
         $exp = "?, ?, ?, ?";
         $this->assertEquals($exp, $res);
+
+        $res = "DELETE FROM {{%product}} WHERE pro_id IN (" . DB_Helper::buildList($ids) . ")";
+        $exp = "DELETE FROM {{%product}} WHERE pro_id IN (?, ?, ?, ?)";
+        $this->assertEquals($exp, $res);
     }
 }

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -14,6 +14,13 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $res = DB_Helper::buildSet($params);
         $exp = "a=?, c=?, d=?";
         $this->assertEquals($exp, $res);
+
+        // test combining params with a list
+        $stmt = "SET " . DB_Helper::buildSet($params) . " WHERE ID=?";
+        $params[] = 11;
+        $res = $stmt . '|' . join(',', $params);
+        $exp = 'SET a=?, c=?, d=? WHERE ID=?|b,d,f,11';
+        $this->assertEquals($exp, $res);
     }
 
     public function testBuildList()

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -15,4 +15,14 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $exp = "a=?, c=?, d=?";
         $this->assertEquals($exp, $res);
     }
+
+    public function testBuildList()
+    {
+        $ids = array(
+            1, 2, 'a', 'f'
+        );
+        $res = DB_Helper::buildList($ids);
+        $exp = "?, ?, ?, ?";
+        $this->assertEquals($exp, $res);
+    }
 }

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -1,0 +1,18 @@
+<?php
+
+class DbHelperTest extends PHPUnit_Framework_TestCase
+{
+    public function testBuildSet()
+    {
+        $params = array(
+            'a' => 'b',
+            'c' => 'd',
+        );
+
+        $params['d'] = 'f';
+
+        $res = DB_Helper::buildSet($params);
+        $exp = "a=?, c=?, d=?";
+        $this->assertEquals($exp, $res);
+    }
+}

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -40,10 +40,28 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
 
         // test merge two arrays
-        $stmt = "WHERE icf_fld_id IN (" . DB_Helper::buildList($ids) . ") AND icf_value IN (" . DB_Helper::buildList($ids) . ")";
+        $stmt
+            = "WHERE icf_fld_id IN (" . DB_Helper::buildList($ids) . ") AND icf_value IN (" . DB_Helper::buildList($ids)
+            . ")";
         $params = array_merge($ids, $ids);
         $res = $stmt . '|' . join(',', $params);
         $exp = 'WHERE icf_fld_id IN (?, ?, ?, ?) AND icf_value IN (?, ?, ?, ?)|1,2,a,f,1,2,a,f';
         $this->assertEquals($exp, $res);
     }
+
+    public function testOrderBy()
+    {
+        $res = DB_Helper::orderBy("ASC");
+        $this->assertEquals("ASC", $res);
+
+        $res = DB_Helper::orderBy("desc");
+        $this->assertEquals("desc", $res);
+
+        $res = DB_Helper::orderBy("desc having 1=1");
+        $this->assertEquals("DESC", $res);
+
+        $res = DB_Helper::orderBy("desc having 1=1", "asc");
+        $this->assertEquals("asc", $res);
+    }
+
 }

--- a/tests/DbHelperTest.php
+++ b/tests/DbHelperTest.php
@@ -18,6 +18,7 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
 
     public function testBuildList()
     {
+        // simple test
         $ids = array(
             1, 2, 'a', 'f'
         );
@@ -25,8 +26,17 @@ class DbHelperTest extends PHPUnit_Framework_TestCase
         $exp = "?, ?, ?, ?";
         $this->assertEquals($exp, $res);
 
+        // test in a sql
         $res = "DELETE FROM {{%product}} WHERE pro_id IN (" . DB_Helper::buildList($ids) . ")";
         $exp = "DELETE FROM {{%product}} WHERE pro_id IN (?, ?, ?, ?)";
+        $this->assertEquals($exp, $res);
+
+        // test combining params with a list
+        $params = array(110);
+        $stmt = "psd_prj_id=? AND psd_sta_id IN (" . DB_Helper::buildList($ids) . ")";
+        $params = array_merge($params, $ids);
+        $res = $stmt . '|' . join(',', $params);
+        $exp = 'psd_prj_id=? AND psd_sta_id IN (?, ?, ?, ?)|110,1,2,a,f';
         $this->assertEquals($exp, $res);
     }
 }

--- a/tests/DbMaxAllowedPacketTest.php
+++ b/tests/DbMaxAllowedPacketTest.php
@@ -4,15 +4,17 @@
  * Separate test to use different getInstance call
  */
 class DbMaxAllowedPacketTest extends PHPUnit_Framework_TestCase {
-    public function testPhp56() {
+    public function setUp()
+    {
+        if (getenv('TRAVIS')) {
+            $this->markTestSkipped("No DB tests in Travis");
+        }
+
         if (PHP_VERSION_ID >= 50600) {
             $this->markTestSkipped("PEAR::DB not compatible with php 5.6");
         }
     }
 
-    /**
-     * @depends testPhp56
-     */
     public function testGetMaxAllowedPacket() {
         // this should not fail if db is not reachable
         $res = DB_Helper::getMaxAllowedPacket();

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -35,6 +35,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         );
     }
 
+    /** @group getAll */
     public function testGetAllDefault()
     {
         $res = $this->db->getAll(
@@ -59,6 +60,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getAll */
     public function testGetAllAssoc()
     {
         $res = $this->db->getAll(
@@ -83,6 +85,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getAssoc */
     public function testGetAssocTrueDefault()
     {
         $this->markTestSkipped("this combination is never used in eventum code");
@@ -108,6 +111,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getAssoc */
     public function testGetAssocFalseDefault()
     {
         $this->markTestSkipped("this fails under yii as it tries to switch to fetchPair");
@@ -134,6 +138,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getAssoc */
     public function testGetAssocFalseAssoc()
     {
         $res = $this->db->getAssoc(
@@ -158,6 +163,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getAssoc */
     public function testGetAssocTrueAssoc()
     {
         $res = $this->db->getAssoc(
@@ -182,6 +188,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getColumn */
     public function testGetColumn()
     {
         $res = $this->db->getColumn(
@@ -197,6 +204,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getOne */
     public function testGetOne()
     {
         $res = $this->db->getOne(
@@ -210,6 +218,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $res);
     }
 
+    /** @group getPair */
     public function testGetPair()
     {
         $res = $this->db->getPair(
@@ -226,6 +235,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getRow */
     public function testGetRowDefault()
     {
         $res = $this->db->getRow(
@@ -243,6 +253,7 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group getRow */
     public function testGetRowAssoc()
     {
         $res = $this->db->getRow(

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -188,6 +188,56 @@ class DbTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($exp, $res);
     }
 
+    /** @group fetchAssoc */
+    public function testFetchAssocDefault()
+    {
+        $res = $this->db->fetchAssoc(
+            'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
+            array(2),
+            DbInterface::DB_FETCHMODE_DEFAULT
+        );
+
+        $this->assertInternalType('array', $res);
+        $exp = array(
+            1 => array(
+                0 => 'system',
+                1 => 'system-account@example.com',
+                2 => null,
+            ),
+            2 => array(
+                0 => 'Admin User',
+                1 => 'admin@example.com',
+                2 => null,
+            ),
+        );
+        $this->assertEquals($exp, $res);
+    }
+
+    /** @group fetchAssoc */
+    public function testFetchAssoc()
+    {
+        $res = $this->db->fetchAssoc(
+            'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
+            array(2),
+            DbInterface::DB_FETCHMODE_ASSOC
+        );
+
+        $this->assertInternalType('array', $res);
+        $exp = array(
+            1 => array(
+                'usr_full_name' => 'system',
+                'usr_email'     => 'system-account@example.com',
+                'usr_lang'      => null,
+            ),
+            2 => array(
+                'usr_full_name' => 'Admin User',
+                'usr_email'     => 'admin@example.com',
+                'usr_lang'      => null,
+            ),
+        );
+        $this->assertEquals($exp, $res);
+    }
+
     /** @group getColumn */
     public function testGetColumn()
     {


### PR DESCRIPTION
deprecate escapeInteger and escapeString in favor of using placeholders

overview by classes:
- [x] product.php 1
- [x] reminder_condition.php 1
- [x] resolution.php 1
- [x] authorized_replier.php 2
- [x] category.php 2
- [x] crm.php 2
- [x] display_column.php 2
- [x] history.php 2
- [x] impact_analysis.php 2
- [x] news.php 2
- [x] priority.php 2
- [x] release.php 2
- [x] reminder.php 2
- [x] round_robin.php 2
- [x] scm.php 2
- [x] severity.php 2
- [x] email_response.php 3
- [ ] filter.php 3
- [x] link_filter.php 3
- [x] phone_support.php 3
- [x] email_account.php 4
- [x] faq.php 4
- [x] reminder_action.php 5
- [x] time_tracking.php 7
- [x] group.php 8
- [x] status.php 8
- [x] draft.php 10
- [ ] mail_queue.php 11
- [x] project.php 11
- [x] attachment.php 15
- [ ] note.php 15
- [x] user.php 15
- [ ] report.php 23
- [ ] support.php 23
- [ ] notification.php 26
- [ ] custom_field.php 30
- [ ] search.php 38
- [ ] issue.php 103

above list built with:
```
grep -rcE 'Misc::escape(Integer|String)' lib/eventum/class.*.php|grep -v :0|cut -d/ -f3|sed -e 's/class.//'| tr : ' '|sort +1 -n | sed -e 's/^/- [ ] /'
```