### PR TITLE
Fix error closing issue with no email accounts.

### DIFF
--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -170,11 +170,11 @@ class Email_Account
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($ema_id));
         } catch (DbException $e) {
-            throw new RuntimeException("email with id $ema_id not found");
+            throw new RuntimeException("email account with id $ema_id not found");
         }
 
         if (!$res) {
-            throw new RuntimeException("email with id $ema_id not found");
+            throw new RuntimeException("email account with id $ema_id not found");
         }
 
         $res['ema_issue_auto_creation_options'] = @unserialize($res['ema_issue_auto_creation_options']);

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1420,6 +1420,7 @@ class Issue
                 'full_email'    =>  $full_email,
                 'headers'       =>  $structure->headers
             );
+            $sup_id = null;
             Support::insertEmail($email, $structure, $sup_id, true);
             $ids = $sup_id;
         } else {

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1128,8 +1128,18 @@ class Support
             return -1;
         }
 
+        if (!empty($row['issue_id'])) {
+            $prj_id = Issue::getProjectID($row['issue_id']);
+        } elseif (!empty($row['ema_id'])) {
+            $prj_id = Email_Account::getProjectID($row["ema_id"]);
+        } else {
+            $prj_id = false;
+        }
+
         // FIXME: $row['ema_id'] is empty when mail is sent via convert note!
-        Workflow::handleNewEmail(Email_Account::getProjectID($row["ema_id"]), @$row["issue_id"], $structure, $row, $closing);
+        if ($prj_id !== false) {
+            Workflow::handleNewEmail($prj_id, @$row["issue_id"], $structure, $row, $closing);
+        }
         return 1;
     }
 


### PR DESCRIPTION
Project ID will be taken from issue ID instead. Closing comments are not displayed since emails are hidden if there is no email account.

This behavior is better then previous runtime error but still not perfect. We could either:
a) always add a dummy email account when creating a project.
b) always display the email section, just hide the "send email" button if there is no account setup.