### PR TITLE
fix "Separate No time spent" filter in WeeklyReport

### DIFF
--- a/lib/eventum/class.report.php
+++ b/lib/eventum/class.report.php
@@ -382,7 +382,7 @@ class Report
 
         // organize issues into categories
         if ($issue_list) {
-            if (!empty($options['show_per_issue'])) {
+            if (!empty($options['show_per_issue']) || !empty($options['separate_no_time'])) {
                 Time_Tracking::fillTimeSpentByIssueAndTime($issue_list, $usr_id, $start_ts, $end_ts);
             }
 


### PR DESCRIPTION
make "Separate No time spent" filter work when "Show Times spent on issue" is not checked in Weekly Report