### PR TITLE
Chosen (Assignee selection dropdown) fixes

### DIFF
--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -360,7 +360,11 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
     height: 27px;
 }
 .chosen-container .chosen-drop {
+    top: 0;
+    box-shadow: 4px 4px 5px rgba(0, 0, 0, 0.3);
+}
+#bulk_update .chosen-container .chosen-drop {
     top: -270px;
-    box-shadow: 4px 0 5px rgba(0, 0, 0, 0.8);
+    box-shadow: 4px -4px 5px rgba(0, 0, 0, 0.3);
 	border-top: 1px solid #aaaaaa;
 }

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -361,6 +361,6 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
 }
 .chosen-container .chosen-drop {
     top: -270px;
-    box-shadow: 0 4px 5px rgba(0, 0, 0, 0.8);
+    box-shadow: 4px 0 5px rgba(0, 0, 0, 0.8);
 	border-top: 1px solid #aaaaaa;
 }

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -360,5 +360,7 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
     height: 27px;
 }
 .chosen-container .chosen-drop {
-    top: 0;
+    top: -270px;
+    box-shadow: 0 4px 5px rgba(0, 0, 0, 0.8);
+	border-top: 1px solid #aaaaaa;
 }

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -355,3 +355,10 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
     width: 97%;
     border: 2px dashed #027c99;
 }
+/* Chosen.js overrides */
+.chosen-container {
+    height: 27px;
+}
+.chosen-container .chosen-drop {
+    top: 0;
+}

--- a/templates/bulk_update.tpl.html
+++ b/templates/bulk_update.tpl.html
@@ -23,6 +23,7 @@
         <tr>
           <td>
               <select name="users[]" size="5" multiple data-placeholder="{t}Choose Assignees...{/t}" class="chosen-select">
+              <option></option>
               {html_options options=$users}
               </select>
               {include file="error_icon.tpl.html" field="users[]"}


### PR DESCRIPTION
Global:
* don't create bigger area, when clicking on Choose Assignees, make it 27px, let the dropdown act like dropdown not new 240px height div
* style changes: separate default chosen dropdowns and bulk update dropdown. nicer dropdown shadows 

Bulk update:
* when bulk update, add dummy/empty option, so first assignee will not be selected automatically when clicking on dropdown
* bulk update vs chosen conflict - dropdown makes page longer and chosen selects the item under mouse, lets open assignee list to the top, not below
* minor style changes: cast shadow to top, not to bottom, as dropdown opens to top