### PR TITLE
CAS Auth Backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .project
 .settings
 config/config.php
+config/cas.php
 config/ldap.php
 config/private_key.php
 config/setup.php

--- a/composer.json
+++ b/composer.json
@@ -82,6 +82,7 @@
 		"sphinx/php-sphinxapi": "2.0.*"
 	},
 	"suggest": {
-		"ext-ldap": "Adds support for LDAP auth backend"
+		"ext-ldap": "Adds support for LDAP auth backend",
+		"jasig/phpcas": "1.3.x-dev"
 	}
 }

--- a/docs/examples/config/cas.php
+++ b/docs/examples/config/cas.php
@@ -1,5 +1,5 @@
 <?php
-$cas_setup = array(
+return array(
     'host'  =>  'localhost',
     'port'  =>  443,
     'context' =>  '/cas',

--- a/docs/examples/config/cas.php
+++ b/docs/examples/config/cas.php
@@ -1,0 +1,12 @@
+<?php
+$cas_setup = array(
+    'host'  =>  'localhost',
+    'port'  =>  443,
+    'context' =>  '/cas',
+    'customer_id_attribute' => '',
+    'contact_id_attribute' => '',
+    'create_users' => true,
+    'default_role' => array(
+        1 =>    4,
+    ),
+);

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -49,8 +49,6 @@ if ($has_valid_cookie && $is_anon_user) {
 }
 
 if ($has_valid_cookie && !$is_anon_user) {
-    // FIXME: $cookie unused?
-    $cookie = Auth::getCookieInfo(APP_COOKIE);
     if (!empty($_REQUEST['url'])) {
         $extra = '?url=' . urlencode($_REQUEST['url']);
     } else {
@@ -65,4 +63,5 @@ if (empty($projects)) {
 } else {
     $tpl->assign('anonymous_post', 1);
 }
+$tpl->assign('login_url', Auth::getExternalLoginURL());
 $tpl->displayTemplate();

--- a/htdocs/login.php
+++ b/htdocs/login.php
@@ -59,26 +59,7 @@ if (!Auth::isCorrectPassword($login, $passwd)) {
     Auth::redirect('index.php?err=3&email=' . rawurlencode($login));
 }
 
-// handle aliases since the user is now authenticated
-$login = User::getEmail(Auth::getUserIDByLogin($login));
-
-// check if this user did already confirm his account
-if (Auth::isPendingUser($login)) {
-    Auth::saveLoginAttempt($login, 'failure', 'pending user');
-    Auth::redirect('index.php?err=9');
-}
-// check if this user is really an active one
-if (!Auth::isActiveUser($login)) {
-    Auth::saveLoginAttempt($login, 'failure', 'inactive user');
-    Auth::redirect('index.php?err=7');
-}
-
-Auth::saveLoginAttempt($login, 'success');
-
-$remember = !empty($_POST['remember']);
-Auth::createLoginCookie(APP_COOKIE, $login, $remember);
-
-Session::init(User::getUserIDByEmail($login));
+Auth::login($login);
 if (!empty($_POST['url'])) {
     $extra = '?url=' . urlencode($_POST['url']);
 } else {

--- a/lib/eventum/auth/class.auth_backend_interface.php
+++ b/lib/eventum/auth/class.auth_backend_interface.php
@@ -101,10 +101,32 @@ interface Auth_Backend_Interface
     public function resetFailedLogins($usr_id);
 
     /**
-     * Returns the true if the account is currently locked becouse of Back-Off locking
+     * Returns the true if the account is currently locked because of Back-Off locking
      *
      * @param   integer $usr_id The ID of the user
      * @return  boolean
      */
     public function isUserBackOffLocked($usr_id);
+
+    /**
+     * Returns a URL to redirect the user to when they attempt to login or null if the native login pages
+     * should be used.
+     *
+     * @return  string The login url or null
+     */
+    public function getExternalLoginURL();
+
+    /**
+     * Called on every page load and can be used to process external authentication checks before the rest of the
+     * authentication process happens.
+     *
+     * @return null
+     */
+    public function checkAuthentication();
+
+    /**
+     * Called when a user logs out.
+     * @return mixed
+     */
+    public function logout();
 }

--- a/lib/eventum/auth/class.cas_auth_backend.php
+++ b/lib/eventum/auth/class.cas_auth_backend.php
@@ -29,7 +29,7 @@
 /**
  * This auth backend integrates with a CAS server
  *
- * This backend will look for users in the default mysql backend if no LDAP
+ * This backend will look for users in the default mysql backend if no CAS
  * user is found. This behaviour may be configurable in the future.
  *
  * Set define('APP_AUTH_BACKEND', 'CAS_Auth_Backend') in the config file and
@@ -102,7 +102,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
             // do not reset user password, it maybe be set locally before this
             unset($data['password']);
 
-            // perspective what is main address and what is alias may be different in ldap and in eventum
+            // perspective what is main address and what is alias may be different in CAS and in eventum
             $emails = array($remote['mail']);
             $email = User::getEmail($usr_id);
 
@@ -288,11 +288,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
 
             if (file_exists($configfile)) {
                 /** @noinspection PhpIncludeInspection */
-                require $configfile;
-
-                if (isset($cas_setup)) {
-                    $setup = $cas_setup;
-                }
+                $setup = require $configfile;
             }
 
             // merge with defaults

--- a/lib/eventum/auth/class.cas_auth_backend.php
+++ b/lib/eventum/auth/class.cas_auth_backend.php
@@ -1,0 +1,356 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 encoding=utf-8: */
+// +----------------------------------------------------------------------+
+// | Eventum - Issue Tracking System                                      |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2012 - 2015 Eventum Team.                              |
+// |                                                                      |
+// | This program is free software; you can redistribute it and/or modify |
+// | it under the terms of the GNU General Public License as published by |
+// | the Free Software Foundation; either version 2 of the License, or    |
+// | (at your option) any later version.                                  |
+// |                                                                      |
+// | This program is distributed in the hope that it will be useful,      |
+// | but WITHOUT ANY WARRANTY; without even the implied warranty of       |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        |
+// | GNU General Public License for more details.                         |
+// |                                                                      |
+// | You should have received a copy of the GNU General Public License    |
+// | along with this program; if not, write to:                           |
+// |                                                                      |
+// | Free Software Foundation, Inc.                                       |
+// | 51 Franklin Street, Suite 330                                        |
+// | Boston, MA 02110-1301, USA.                                          |
+// +----------------------------------------------------------------------+
+// | Authors: Bryan Alsdorf <balsdorf@gmail.com>                          |
+// | Authors: Elan Ruusamäe <glen@delfi.ee>                               |
+// +----------------------------------------------------------------------+
+
+/**
+ * This auth backend integrates with a CAS server
+ *
+ * This backend will look for users in the default mysql backend if no LDAP
+ * user is found. This behaviour may be configurable in the future.
+ *
+ * Set define('APP_AUTH_BACKEND', 'CAS_Auth_Backend') in the config file and
+ * then fill in the CAS server details config/cas.php. An example config file is
+ * in docs/examples/config/cas.php
+ */
+class CAS_Auth_Backend implements Auth_Backend_Interface
+{
+    protected $client;
+
+    public function __construct()
+    {
+        $setup = self::loadSetup();
+        $this->client = phpCAS::client(CAS_VERSION_2_0, $setup['host'], $setup['port'], $setup['context']);
+
+        // For simplicities sake at the moment we are not validating the server auth.
+        phpCAS::setNoCasServerValidation();
+
+        phpCAS::setPostAuthenticateCallback(array($this, 'loginCallback'));
+    }
+
+    public function checkAuthentication()
+    {
+        if (phpCAS::isAuthenticated() && !Auth::isValidCookie(Auth::getCookieInfo(APP_COOKIE))) {
+            $this->loginCallback();
+        }
+
+        // force CAS authentication
+        $auth = phpCAS::forceAuthentication();
+    }
+
+    public function logout()
+    {
+        phpCAS::logoutWithRedirectService(APP_BASE_URL);
+    }
+
+    public function loginCallback()
+    {
+        $attributes = phpCAS::getAttributes();
+
+        $this->updateLocalUserFromBackend($attributes);
+
+        $usr_id = User::getUserIDByEmail($attributes['mail'], true);
+        $user = User::getDetails($usr_id);
+
+        Auth::createLoginCookie(APP_COOKIE, $user['usr_email'], true);
+    }
+
+    public function updateLocalUserFromBackend($remote)
+    {
+        $setup = self::loadSetup();
+
+        $usr_id = User::getUserIDByEmail($remote['mail'], true);
+
+        $data = array(
+            'password' => '',
+            'full_name' => $remote['firstname'] . " " . $remote['lastname'],
+            'external_id' => $remote['uid'],
+        );
+
+        if (!empty($setup['customer_id_attribute'])) {
+            $data['customer_id'] = $remote[$setup['customer_id_attribute']];
+        }
+        if (!empty($setup['contact_id_attribute'])) {
+            $data['contact_id'] = $remote[$setup['contact_id_attribute']];
+        }
+
+        // if local user found, update it and return usr id
+        if ($usr_id) {
+            // do not reset user password, it maybe be set locally before this
+            unset($data['password']);
+
+            // perspective what is main address and what is alias may be different in ldap and in eventum
+            $emails = array($remote['mail']);
+            $email = User::getEmail($usr_id);
+
+            if (($key = array_search($email, $emails)) !== false) {
+                unset($emails[$key]);
+                $data['email'] = $email;
+            } else {
+                if (count($emails) < 1) {
+                    throw new AuthException('E-mail is required');
+                }
+                // just use first email
+                $data['email'] = array_shift($emails);
+            }
+
+            // do not clear full name if for some reason it is empty
+            if (empty($data['full_name'])) {
+                unset($data['full_name']);
+            }
+
+            $update = User::update($usr_id, $data, false);
+            if ($update > 0) {
+                $this->updateAliases($usr_id, $emails);
+            }
+
+            return $usr_id;
+        } else {
+            // create new local user
+            $setup = self::loadSetup();
+            if ($setup['create_users'] == false) {
+                throw new AuthException('User does not exist and will not be created.');
+            }
+            $data['role'] = $setup['default_role'];
+
+            $emails = array($remote['mail']);
+            if (count($emails) < 1) {
+                throw new AuthException('E-mail is required');
+            }
+            $data['email'] = array_shift($emails);
+
+            if (!empty($data['customer_id']) && !empty($data['contact_id'])) {
+                foreach ($data['role'] as $prj_id => $role) {
+                    if ($role > 0) {
+                        $data['role'][$prj_id] = User::ROLE_CUSTOMER;
+                    }
+                }
+            }
+            $usr_id = User::insert($data);
+            if ($usr_id > 0 && $emails) {
+                $this->updateAliases($usr_id, $emails);
+            }
+        }
+
+        return $usr_id;
+    }
+
+    private function updateAliases($usr_id, $aliases)
+    {
+        foreach ($aliases as $alias) {
+            User::addAlias($usr_id, $alias);
+        }
+    }
+
+
+    /**
+     * With CAS we cannot do a simple password check like this. This will prevent the CLI from working
+     * so at some point in the future we need to find a solution.
+     *
+     * @param   string $login The login or email to check for
+     * @param   string $password The password of the user to check for
+     * @return  boolean
+     */
+    public function verifyPassword($login, $password)
+    {
+        return false;
+    }
+
+    /**
+     * Method used to update the account password for a specific user.
+     *
+     * @param   integer $usr_id The user ID
+     * @param   string $password The password.
+     * @return  boolean true if update worked, false otherwise
+     */
+    public function updatePassword($usr_id, $password)
+    {
+        return false;
+    }
+
+    /**
+     * Returns the user ID for the specified login. This can be the email address, an alias,
+     * the external login id or any other info the backend can handle.
+     *
+     * @param $login
+     * @return  int|null The user id or null
+     */
+    public function getUserIDByLogin($login)
+    {
+        return null;
+    }
+
+    /**
+     * If this backend allows the user to update their name.
+     *
+     * @param int $usr_id
+     * @return bool
+     */
+    public function canUserUpdateName($usr_id)
+    {
+        return false;
+    }
+
+    /**
+     * If this backend allows the user to update their email.
+     *
+     * @param int $usr_id
+     * @return bool
+     */
+    public function canUserUpdateEmail($usr_id)
+    {
+        return false;
+    }
+
+    /**
+     * If this backend allows the user to update their password.
+     *
+     * @param int $usr_id
+     * @return bool
+     */
+    public function canUserUpdatePassword($usr_id)
+    {
+        return false;
+    }
+
+    /**
+     * Increment the failed logins attempts for this user
+     *
+     * @param   integer $usr_id The ID of the user
+     * @return  boolean
+     */
+    public function incrementFailedLogins($usr_id)
+    {
+        return true;
+    }
+
+    /**
+     * Reset the failed logins attempts for this user
+     *
+     * @param   integer $usr_id The ID of the user
+     * @return  boolean
+     */
+    public function resetFailedLogins($usr_id)
+    {
+        return true;
+    }
+
+    /**
+     * Returns the true if the account is currently locked because of Back-Off locking
+     *
+     * @param   integer $usr_id The ID of the user
+     * @return  boolean
+     */
+    public function isUserBackOffLocked($usr_id)
+    {
+        return false;
+    }
+
+    /**
+     * Just return the main eventum page since that will prompt a CAS login.
+     *
+     * @return  string The login url or null
+     */
+    public function getExternalLoginURL()
+    {
+        return APP_RELATIVE_URL . "main.php";
+    }
+
+    public static function loadSetup($force = false)
+    {
+        static $setup;
+        if (empty($setup) || $force == true) {
+            $setup = array();
+            $configfile = APP_CONFIG_PATH . '/cas.php';
+
+            if (file_exists($configfile)) {
+                /** @noinspection PhpIncludeInspection */
+                require $configfile;
+
+                if (isset($cas_setup)) {
+                    $setup = $cas_setup;
+                }
+            }
+
+            // merge with defaults
+            $setup = Misc::array_extend(self::getDefaults(), $setup);
+        }
+
+        return $setup;
+    }
+
+    public static function saveSetup($options)
+    {
+        // this is needed to check if the file can be created or not
+        if (!file_exists(APP_CONFIG_PATH . '/cas.php')) {
+            if (!is_writable(APP_CONFIG_PATH)) {
+                clearstatcache();
+
+                return -1;
+            }
+        } else {
+            if (!is_writable(APP_CONFIG_PATH . '/cas.php')) {
+                clearstatcache();
+
+                return -2;
+            }
+        }
+        $contents = '<' . "?php\n\$cas_setup = " . var_export($options, 1) . ";\n";
+        $res = file_put_contents(APP_CONFIG_PATH . '/cas.php', $contents);
+        if ($res === false) {
+            return -2;
+        }
+
+        return 1;
+    }
+
+    /**
+     * Method used to get the system-wide defaults.
+     *
+     * @return  string array of the default parameters
+     */
+    public static function getDefaults()
+    {
+        $defaults = array(
+            'host' => 'localhost',
+            'port' => 443,
+            'context'   =>  '/cas',
+            'customer_id_attribute' => '',
+            'contact_id_attribute' => '',
+            'create_users' => null,
+            'default_role' => array(),
+        );
+
+        if (Auth::hasValidCookie(APP_COOKIE)) {
+            // ensure there is entry for current project
+            $prj_id = Auth::getCurrentProject();
+
+            $defaults['default_role'][$prj_id] = 0;
+        }
+
+        return $defaults;
+    }
+}

--- a/lib/eventum/auth/class.ldap_auth_backend.php
+++ b/lib/eventum/auth/class.ldap_auth_backend.php
@@ -280,7 +280,7 @@ class LDAP_Auth_Backend implements Auth_Backend_Interface
 
         $emails = $remote['emails'];
         if (!$emails) {
-            throw new AuthException('E-mail is requred');
+            throw new AuthException('E-mail is required');
         }
         $data['email'] = array_shift($emails);
 
@@ -502,5 +502,36 @@ class LDAP_Auth_Backend implements Auth_Backend_Interface
     public function isUserBackOffLocked($usr_id)
     {
         return false;
+    }
+
+    /**
+     * Returns a URL to redirect the user to when they attempt to login or null if the native login pages
+     * should be used.
+     *
+     * @return  string The login url or null
+     */
+    public function getExternalLoginURL()
+    {
+        return null;
+    }
+
+    /**
+     * Called on every page load and can be used to process external authentication checks before the rest of the
+     * authentication process happens.
+     *
+     * @return null
+     */
+    public function checkAuthentication()
+    {
+        return null;
+    }
+
+    /**
+     * Called when a user logs out.
+     * @return mixed
+     */
+    public function logout()
+    {
+        return null;
     }
 }

--- a/lib/eventum/auth/class.mysql_auth_backend.php
+++ b/lib/eventum/auth/class.mysql_auth_backend.php
@@ -178,4 +178,35 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
     {
         return true;
     }
+
+    /**
+     * Returns a URL to redirect the user to when they attempt to login or null if the native login pages
+     * should be used.
+     *
+     * @return  string The login url or null
+     */
+    public function getExternalLoginURL()
+    {
+        return null;
+    }
+
+    /**
+     * Called on every page load and can be used to process external authentication checks before the rest of the
+     * authentication process happens.
+     *
+     * @return null
+     */
+    public function checkAuthentication()
+    {
+        return null;
+    }
+
+    /**
+     * Called when a user logs out.
+     * @return mixed
+     */
+    public function logout()
+    {
+        return null;
+    }
 }

--- a/lib/eventum/autoload.php
+++ b/lib/eventum/autoload.php
@@ -76,6 +76,7 @@ class Eventum_Autoload
             'Auth_Backend_Interface' => $baseDir . '/auth/class.auth_backend_interface.php',
             'Mysql_Auth_Backend' => $baseDir . '/auth/class.mysql_auth_backend.php',
             'LDAP_Auth_Backend' => $baseDir . '/auth/class.ldap_auth_backend.php',
+            'CAS_Auth_Backend' => $baseDir . '/auth/class.cas_auth_backend.php',
 
             'Abstract_Fulltext_Search' => $baseDir . '/search/class.abstract_fulltext_search.php',
             'MySQL_Fulltext_Search' => $baseDir . '/search/class.mysql_fulltext_search.php',

--- a/lib/eventum/class.session.php
+++ b/lib/eventum/class.session.php
@@ -108,8 +108,6 @@ class Session
      */
     public static function verify($usr_id)
     {
-        session_start();
-
         // Don't check the IP of the session, since this caused problems for users that use a proxy farm that uses
         // a different IP address each page load.
         if (!self::is_set('usr_id')) {

--- a/lib/eventum/class.session.php
+++ b/lib/eventum/class.session.php
@@ -108,6 +108,10 @@ class Session
      */
     public static function verify($usr_id)
     {
+        if (session_id() == '') {
+            session_start();
+        }
+        
         // Don't check the IP of the session, since this caused problems for users that use a proxy farm that uses
         // a different IP address each page load.
         if (!self::is_set('usr_id')) {

--- a/templates/index.tpl.html
+++ b/templates/index.tpl.html
@@ -58,6 +58,13 @@ $().ready(function() {
       </td>
     </tr>
     {/if}
+    {if $login_url != ''}
+    <tr align="center">
+      <td colspan="2">
+        {t 1=$login_url escape=off}Click <a href="%1">here</a> to login.{/t}
+      </td>
+    </tr>
+    {else}
     <tr>
       <td class="label">{t}Login{/t}:</td>
       <td>
@@ -93,6 +100,7 @@ $().ready(function() {
         <strong>* {t}Requires support for cookies and javascript in your browser{/t}</strong>
       </td>
     </tr>
+    {/if}
 </table>
 </form>
 {if $anonymous_post}


### PR DESCRIPTION
This adds support for Central Authentication Service (CAS) in Eventum. The backend totally replaces the built in auth and does not allow fallback. If configured, Eventum will create new users.

Changes to auth interface are:
* Addition of getExternalLoginURL() method. If set no login form will be displayed. Instead the user
 will be redirect to an external URL to authenticate.
* Addition of checkAuthentication() method. This is called before the normal Eventum authentication
process.
* Addition of logout() method. This is called after the Eventum logout process is completed.

I'm not 100% sure that getExternalLoginURL() and checkAuthentication() is the cleanest way but I haven't thought of a better way.

Please let me know any feedback you have on this or if you have any better ideas on how to handle systems with external authentication like this.