### PR TITLE
Fix POP3 email download bug (Issue #66)

### DIFF
--- a/docs/UPGRADE.md
+++ b/docs/UPGRADE.md
@@ -22,6 +22,9 @@ Upgrading from version 2.2 and from versions upwards
     require_once(APP_INC_PATH."workflow/class.abstract_workflow_backend.php");
     require_once(APP_INC_PATH."customer/class.abstract_customer_backend.php");
 ```
+ 6. Update your cron jobs to point to the scripts in the new location (see INSTALL.md).
+ 	Previously the scripts were in 'crons', now in 'bin', eg:
+	0 * * * * <PATH-TO-EVENTUM>/bin/download_emails.php username_here mail.domain.com INBOX
 
 Upgrading from versions before 2.2
 ----------------------------------

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: João Prado Maia <jpm@mysql.com>                             |
@@ -123,9 +123,15 @@ class Email_Account
                     {{%email_account}}
                  WHERE
                     ema_username=? AND
-                    ema_hostname=? AND
-                    ema_folder=?';
+                    ema_hostname=?';
         try {
+            if (is_null($mailbox)) {
+                $res = DB_Helper::getInstance()->getOne($stmt, array($username, $hostname));
+            } else { 
+                $stmt .= ' AND ema_folder=?';
+                $res = DB_Helper::getInstance()->getOne($stmt, array($username, $hostname, $mailbox));
+            }
+
             $res = DB_Helper::getInstance()->getOne($stmt, array($username, $hostname, $mailbox));
         } catch (DbException $e) {
             return 0;


### PR DESCRIPTION
Fix POP3 email download bug (Issue #66) where $mailbox was null, but a null string in the pre 3.02 database caused the email account ID to be zero.

Also changed UPGRADE.md to reflect location change of cron jobs.