### PR TITLE
Static & Deprecated calls

### DIFF
--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1710,7 +1710,7 @@ class Custom_Field
      * @param   integer $issue_id The ID of the issue
      * @return  mixed   the formatted value.
      */
-    public function formatValue($value, $fld_id, $issue_id)
+    public static function formatValue($value, $fld_id, $issue_id)
     {
         $backend = self::getBackend($fld_id);
         if ((is_object($backend)) && (method_exists($backend, 'formatValue'))) {
@@ -1756,7 +1756,7 @@ class Custom_Field
         }
     }
 
-    public function getDBValueFieldSQL()
+    public static function getDBValueFieldSQL()
     {
         return "(CASE
         WHEN fld_type = 'date' THEN icf_value_date

--- a/lib/eventum/class.display_column.php
+++ b/lib/eventum/class.display_column.php
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: Bryan Alsdorf <bryan@mysql.com>                             |
@@ -149,7 +149,7 @@ class Display_Column
      * @param   string $column The name of the column
      * @return  string Info on the column
      */
-    public function getColumnInfo($page, $column)
+    public static function getColumnInfo($page, $column)
     {
         $columns = self::getAllColumns($page);
 

--- a/lib/eventum/class.group.php
+++ b/lib/eventum/class.group.php
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: Bryan Alsdorf <bryan@mysql.com>                             |
@@ -379,7 +379,7 @@ class Group
      * @param   integer $grp_id The ID of the group.
      * @return  array An array of usr ids
      */
-    public function getUsers($grp_id)
+    public static function getUsers($grp_id)
     {
         $stmt = 'SELECT
                     usr_id
@@ -402,7 +402,7 @@ class Group
      * @param   integer $grp_id The ID of the group.
      * @return  array An array of project ids
      */
-    public function getProjects($grp_id)
+    public static function getProjects($grp_id)
     {
         $stmt = 'SELECT
                     pgr_prj_id,

--- a/lib/eventum/class.pager.php
+++ b/lib/eventum/class.pager.php
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: João Prado Maia <jpm@mysql.com>                             |
@@ -53,13 +53,13 @@ class Pager
             // go the extra mile and try to use the grouped by column in the count() call
             preg_match("/.*\s+GROUP BY\s+(\w*)\s+.*/i", $stmt, $matches);
             if (!empty($matches[1])) {
-                $stmt = preg_replace('/SELECT (.*?) FROM /sei', "'SELECT COUNT(DISTINCT " . $matches[1] . ") AS total_rows FROM '", $stmt);
+                $stmt = preg_replace('/SELECT (.*?) FROM /si', "SELECT COUNT(DISTINCT " . $matches[1] . ") AS total_rows FROM ", $stmt);
             }
         } else {
-            $stmt = preg_replace('/SELECT (.*?) FROM /sei', "'SELECT COUNT(*) AS total_rows FROM '", $stmt);
+            $stmt = preg_replace('/SELECT (.*?) FROM /si', "SELECT COUNT(*) AS total_rows FROM ", $stmt);
         }
         // remove any order by clauses
-        $stmt = preg_replace("/(.*)(ORDER BY\s+\w+\s+\w+)(?:,\s+\w+\s+\w+)*(.*)/sei", "'\\1\\3'", $stmt);
+        $stmt = preg_replace("/(.*)(ORDER BY\s+\w+\s+\w+)(?:,\s+\w+\s+\w+)*(.*)/si", "\\1\\3", $stmt);
         try {
             $rows = DB_Helper::getInstance()->getAll($stmt);
         } catch (DbException $e) {

--- a/lib/eventum/class.search_profile.php
+++ b/lib/eventum/class.search_profile.php
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: João Prado Maia <jpm@mysql.com>                             |
@@ -107,7 +107,7 @@ class Search_Profile
      * @param   string $type The type of the search profile ('issue' or 'email')
      * @return  boolean
      */
-    private function _exists($usr_id, $prj_id, $type)
+    private static function _exists($usr_id, $prj_id, $type)
     {
         $stmt = 'SELECT
                     COUNT(*) AS total
@@ -190,7 +190,7 @@ class Search_Profile
      * @param   string $profile The search profile to be saved
      * @return  boolean
      */
-    private function _update($usr_id, $prj_id, $type, $profile)
+    private static function _update($usr_id, $prj_id, $type, $profile)
     {
         $stmt = 'UPDATE
                     {{%search_profile}}


### PR DESCRIPTION
Added static keyword to methods causing PHP Strict notifications. 

Changed call to remove deprecated use of /e in preg_replace in Pager::getTotalRows.  It doesn't appear Eventum needed /e in the first place as we did not need to eval the replacement values.