### PR TITLE
auth and project cookie related refactor

### DIFF
--- a/docs/examples/htdocs/customer/example/customer_lookup.php
+++ b/docs/examples/htdocs/customer/example/customer_lookup.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate("customer/customer_lookup.tpl.html");
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();
 

--- a/htdocs/adv_search.php
+++ b/htdocs/adv_search.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('adv_search.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 // customers should not be able to see this page
 $role_id = Auth::getCurrentRole();

--- a/htdocs/ajax/dynamic_custom_field.js.php
+++ b/htdocs/ajax/dynamic_custom_field.js.php
@@ -29,7 +29,7 @@
 
 require_once __DIR__ . '/../../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!empty($_REQUEST['iss_id'])) {
     $fields = Custom_Field::getListByIssue(Auth::getCurrentProject(), $_REQUEST['iss_id']);

--- a/htdocs/ajax/update.php
+++ b/htdocs/ajax/update.php
@@ -32,7 +32,7 @@
 require_once __DIR__ . '/../../init.php';
 
 // check login
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $field_name = !empty($_POST['field_name']) ? $_POST['field_name'] : null;
 $issue_id = !empty($_POST['issue_id']) ? (int) $_POST['issue_id'] : null;

--- a/htdocs/ajax/upload.php
+++ b/htdocs/ajax/upload.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 // FIXME: no identity logged who added the file.
 try {
     // check if logged in. if not, just give error
-    if (!Auth::hasValidCookie(APP_COOKIE)) {
+    if (!AuthCookie::hasAuthCookie()) {
         throw new BadFunctionCallException(ev_gettext('Must be logged in'));
     }
 

--- a/htdocs/associate.php
+++ b/htdocs/associate.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('associate.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 if (@$_POST['cat'] == 'associate') {
     if ($_POST['target'] == 'email') {

--- a/htdocs/authorized_replier.php
+++ b/htdocs/authorized_replier.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('authorized_replier.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['iss_id'];

--- a/htdocs/clock_status.php
+++ b/htdocs/clock_status.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $usr_id = Auth::getUserID();
 

--- a/htdocs/close.php
+++ b/htdocs/close.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('close.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();

--- a/htdocs/confirm.php
+++ b/htdocs/confirm.php
@@ -33,20 +33,23 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('confirm.tpl.html');
 
-if (@$_GET['cat'] == 'newuser') {
-    $res = @User::checkHash($_GET['email'], $_GET['hash']);
+$cat = isset($_GET['cat']) ? (string)$_GET['cat'] : null;
+$email = isset($_GET['email']) ? (string)$_GET['email'] : null;
+$hash = isset($_GET['hash']) ? (string)$_GET['hash'] : null;
+if ($cat == 'newuser') {
+    $res = User::checkHash($email, $hash);
     if ($res == 1) {
-        User::confirmVisitorAccount($_GET['email']);
+        User::confirmVisitorAccount($email);
         // redirect user to login form with pretty message
-        Auth::redirect('index.php?err=8&email=' . $_GET['email']);
+        Auth::redirect('index.php?err=8&email=' . $email);
         exit;
     }
     $tpl->assign('confirm_result', $res);
-} elseif (@$_GET['cat'] == 'password') {
-    $res = @User::checkHash($_GET['email'], $_GET['hash']);
+} elseif ($cat == 'password') {
+    $res = User::checkHash($email, $hash);
     if ($res == 1) {
-        User::confirmNewPassword($_GET['email']);
-        $tpl->assign('email', $_GET['email']);
+        User::confirmNewPassword($email);
+        $tpl->assign('email', $email);
     }
     $tpl->assign('confirm_result', $res);
 }

--- a/htdocs/convert_note.php
+++ b/htdocs/convert_note.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('convert_note.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 $usr_id = Auth::getUserID();
 
 $note_id = !empty($_GET['id']) ? $_GET['id'] : $_POST['note_id'];

--- a/htdocs/csv.php
+++ b/htdocs/csv.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canExportData(Auth::getUserID())) {
     exit;

--- a/htdocs/custom_fields.php
+++ b/htdocs/custom_fields.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('custom_fields_form.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $prj_id = Auth::getCurrentProject();
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['issue_id'];

--- a/htdocs/download.php
+++ b/htdocs/download.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (stristr(APP_BASE_URL, 'https:')) {
     // fix for IE 5.5/6 with SSL sites

--- a/htdocs/duplicate.php
+++ b/htdocs/duplicate.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('duplicate.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (@$_POST['cat'] == 'mark') {
     Misc::mapMessages(Issue::markAsDuplicate($_POST['issue_id']), array(

--- a/htdocs/edit_reporter.php
+++ b/htdocs/edit_reporter.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('edit_reporter.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['iss_id'];

--- a/htdocs/emails.php
+++ b/htdocs/emails.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('emails.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessAssociateEmails(Auth::getUserID())) {
     $tpl->assign('no_access', 1);

--- a/htdocs/faq.php
+++ b/htdocs/faq.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('faq.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();

--- a/htdocs/file_upload.php
+++ b/htdocs/file_upload.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $usr_id = Auth::getUserID();
 

--- a/htdocs/get_attachment.php
+++ b/htdocs/get_attachment.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (@$_GET['cat'] == 'blocked_email') {
     $email = Note::getBlockedMessage($_GET['note_id']);

--- a/htdocs/get_remote_data.php
+++ b/htdocs/get_remote_data.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 $usr_id = Auth::getUserID();
 
 /*

--- a/htdocs/help.php
+++ b/htdocs/help.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('help/index.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 if ((empty($_GET['topic'])) || (!Help::topicExists($_GET['topic']))) {
     $topic = 'main';

--- a/htdocs/history.php
+++ b/htdocs/history.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('history.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $iss_id = $_GET['iss_id'];
 if (!Access::canViewHistory($iss_id, Auth::getUserID())) {

--- a/htdocs/index.php
+++ b/htdocs/index.php
@@ -40,7 +40,7 @@ if (!Misc::isWritableDirectory(APP_TPL_COMPILE_PATH)) {
 $tpl = new Template_Helper();
 $tpl->setTemplate('index.tpl.html');
 
-$has_valid_cookie = Auth::hasValidCookie(APP_COOKIE);
+$has_valid_cookie = AuthCookie::hasAuthCookie();
 $is_anon_user = Auth::isAnonUser();
 
 // log anonymous users out so they can use the login form

--- a/htdocs/list.php
+++ b/htdocs/list.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('list.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();
 

--- a/htdocs/mail_queue.php
+++ b/htdocs/mail_queue.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('mail_queue.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $issue_id = $_GET['iss_id'];
 

--- a/htdocs/main.php
+++ b/htdocs/main.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('main.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $prj_id = Auth::getCurrentProject();
 $role_id = Auth::getCurrentRole();

--- a/htdocs/manage/account_managers.php
+++ b/htdocs/manage/account_managers.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/account_managers.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/anonymous.php
+++ b/htdocs/manage/anonymous.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/anonymous.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 @$prj_id = $_POST['prj_id'] ? $_POST['prj_id'] : $_GET['prj_id'];
 

--- a/htdocs/manage/categories.php
+++ b/htdocs/manage/categories.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/categories.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/check_email_settings.php
+++ b/htdocs/manage/check_email_settings.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('get_emails.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, null, true);
+Auth::checkAuthentication(null, true);
 
 // we need the IMAP extension for this to work
 if (!function_exists('imap_open')) {

--- a/htdocs/manage/column_display.php
+++ b/htdocs/manage/column_display.php
@@ -35,7 +35,7 @@ $prj_id = $_REQUEST['prj_id'];
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/column_display.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/custom_fields.php
+++ b/htdocs/manage/custom_fields.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/custom_fields.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/customer_notes.php
+++ b/htdocs/manage/customer_notes.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/customer_notes.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/customize_listing.php
+++ b/htdocs/manage/customize_listing.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/customize_listing.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/email_accounts.php
+++ b/htdocs/manage/email_accounts.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/email_accounts.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $tpl->assign('all_projects', Project::getAll());
 

--- a/htdocs/manage/email_alias.php
+++ b/htdocs/manage/email_alias.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/email_alias.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, null, true);
+Auth::checkAuthentication(null, true);
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/email_responses.php
+++ b/htdocs/manage/email_responses.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/email_responses.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/faq.php
+++ b/htdocs/manage/faq.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/faq.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/field_display.php
+++ b/htdocs/manage/field_display.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/field_display.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $tpl->assign('type', 'field_display');
 

--- a/htdocs/manage/general.php
+++ b/htdocs/manage/general.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/general.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/groups.php
+++ b/htdocs/manage/groups.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/groups.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/issue_auto_creation.php
+++ b/htdocs/manage/issue_auto_creation.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/issue_auto_creation.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 @$ema_id = $_POST['ema_id'] ? $_POST['ema_id'] : $_GET['ema_id'];
 

--- a/htdocs/manage/ldap.php
+++ b/htdocs/manage/ldap.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/ldap.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/link_filters.php
+++ b/htdocs/manage/link_filters.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/link_filters.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/monitor.php
+++ b/htdocs/manage/monitor.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/monitor.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/news.php
+++ b/htdocs/manage/news.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/news.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/partners.php
+++ b/htdocs/manage/partners.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/partners.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 $tpl->assign('type', 'partners');
 
 $role_id = Auth::getCurrentRole();

--- a/htdocs/manage/phone_categories.php
+++ b/htdocs/manage/phone_categories.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/phone_categories.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/priorities.php
+++ b/htdocs/manage/priorities.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/priorities.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/private_key.php
+++ b/htdocs/manage/private_key.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/private_key.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_ADMINISTRATOR) {

--- a/htdocs/manage/products.php
+++ b/htdocs/manage/products.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/products.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/projects.php
+++ b/htdocs/manage/projects.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/projects.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/releases.php
+++ b/htdocs/manage/releases.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/releases.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/reminder_actions.php
+++ b/htdocs/manage/reminder_actions.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/reminder_actions.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $rem_id = @$_POST['rem_id'] ? $_POST['rem_id'] : $_GET['rem_id'];
 

--- a/htdocs/manage/reminder_conditions.php
+++ b/htdocs/manage/reminder_conditions.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/reminder_conditions.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $rem_id = @$_POST['rem_id'] ? $_POST['rem_id'] : $_GET['rem_id'];
 $rma_id = @$_POST['rma_id'] ? $_POST['rma_id'] : $_GET['rma_id'];

--- a/htdocs/manage/reminder_review.php
+++ b/htdocs/manage/reminder_review.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('get_emails.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, null, true);
+Auth::checkAuthentication(null, true);
 
 $tpl->displayTemplate();
 flush();

--- a/htdocs/manage/reminders.php
+++ b/htdocs/manage/reminders.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/reminders.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/resolution.php
+++ b/htdocs/manage/resolution.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/resolution.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/round_robin.php
+++ b/htdocs/manage/round_robin.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/round_robin.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/scm.php
+++ b/htdocs/manage/scm.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/scm.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_REPORTER) {

--- a/htdocs/manage/severities.php
+++ b/htdocs/manage/severities.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/severities.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/statuses.php
+++ b/htdocs/manage/statuses.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/statuses.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/time_tracking.php
+++ b/htdocs/manage/time_tracking.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/time_tracking.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 if ($role_id < User::ROLE_MANAGER) {

--- a/htdocs/manage/users.php
+++ b/htdocs/manage/users.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('manage/users.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $role_id = Auth::getCurrentRole();
 

--- a/htdocs/new.php
+++ b/htdocs/new.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();
@@ -50,7 +50,7 @@ if ($issue_prj_id > 0 && $issue_prj_id != $prj_id) {
     // Switch the project back
     $assigned_projects = Project::getAssocList($usr_id);
     if (isset($assigned_projects[$issue_prj_id])) {
-        $cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
+        $cookie = AuthCookie::getProjectCookie();
         Auth::setCurrentProject($issue_prj_id, $cookie['remember']);
         $prj_id = $issue_prj_id;
     } else {

--- a/htdocs/new.php
+++ b/htdocs/new.php
@@ -51,7 +51,7 @@ if ($issue_prj_id > 0 && $issue_prj_id != $prj_id) {
     $assigned_projects = Project::getAssocList($usr_id);
     if (isset($assigned_projects[$issue_prj_id])) {
         $cookie = AuthCookie::getProjectCookie();
-        Auth::setCurrentProject($issue_prj_id, $cookie['remember']);
+        AuthCookie::setProjectCookie($issue_prj_id, $cookie['remember']);
         $prj_id = $issue_prj_id;
     } else {
         Misc::setMessage(ev_gettext('There was an error creating your issue.'), Misc::MSG_ERROR);

--- a/htdocs/new.php
+++ b/htdocs/new.php
@@ -50,8 +50,7 @@ if ($issue_prj_id > 0 && $issue_prj_id != $prj_id) {
     // Switch the project back
     $assigned_projects = Project::getAssocList($usr_id);
     if (isset($assigned_projects[$issue_prj_id])) {
-        $cookie = AuthCookie::getProjectCookie();
-        AuthCookie::setProjectCookie($issue_prj_id, $cookie['remember']);
+        AuthCookie::setProjectCookie($issue_prj_id);
         $prj_id = $issue_prj_id;
     } else {
         Misc::setMessage(ev_gettext('There was an error creating your issue.'), Misc::MSG_ERROR);

--- a/htdocs/news.php
+++ b/htdocs/news.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('news.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 if (!empty($_GET['id'])) {

--- a/htdocs/notification.php
+++ b/htdocs/notification.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('notification.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();

--- a/htdocs/opensearch.php
+++ b/htdocs/opensearch.php
@@ -26,12 +26,11 @@
 // +----------------------------------------------------------------------+
 // | Authors: Elan Ruusamäe <glen@delfi.ee>                               |
 // +----------------------------------------------------------------------+
-//
 
 require_once __DIR__ . '/../init.php';
 
-if (!Auth::hasValidCookie(APP_COOKIE)) {
-    Header('HTTP/1.0 403 Forbidden');
+if (!AuthCookie::hasAuthCookie()) {
+    header('HTTP/1.0 403 Forbidden');
     exit(0);
 }
 

--- a/htdocs/partners.php
+++ b/htdocs/partners.php
@@ -31,7 +31,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('select_partners.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['iss_id'];
 

--- a/htdocs/phone_calls.php
+++ b/htdocs/phone_calls.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('add_phone_entry.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['iss_id'];
 

--- a/htdocs/popup.php
+++ b/htdocs/popup.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('popup.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();
 

--- a/htdocs/post_note.php
+++ b/htdocs/post_note.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('post_note.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 $usr_id = Auth::getUserID();

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -49,7 +49,7 @@ if ($cat == 'update_account') {
 $tpl = new Template_Helper();
 $tpl->setTemplate('preferences.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (Auth::isAnonUser()) {
     Auth::redirect('index.php');

--- a/htdocs/redeem_incident.php
+++ b/htdocs/redeem_incident.php
@@ -31,7 +31,7 @@
 require_once __DIR__ . '/../init.php';
 
 // This page handles marking an issue as 'redeeming' an incident.
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 $issue_id = $_REQUEST['iss_id'];

--- a/htdocs/removed_emails.php
+++ b/htdocs/removed_emails.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('removed_emails.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, null, true);
+Auth::checkAuthentication(null, true);
 
 if (@$_POST['cat'] == 'restore') {
     $res = Support::restoreEmails();

--- a/htdocs/reports/category_statuses.php
+++ b/htdocs/reports/category_statuses.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/category_statuses.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/custom_fields.php
+++ b/htdocs/reports/custom_fields.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/custom_fields.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/custom_fields_graph.php
+++ b/htdocs/reports/custom_fields_graph.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/custom_fields_weekly.php
+++ b/htdocs/reports/custom_fields_weekly.php
@@ -32,7 +32,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/custom_fields_weekly.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/estimated_dev_time.php
+++ b/htdocs/reports/estimated_dev_time.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/estimated_dev_time.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/index.php
+++ b/htdocs/reports/index.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 if (!Access::canAccessReports(Auth::getUserID())) {
     Auth::redirect(APP_RELATIVE_URL . 'main.php');
 }

--- a/htdocs/reports/issue.php
+++ b/htdocs/reports/issue.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/issue_user.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/open_issues.php
+++ b/htdocs/reports/open_issues.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/open_issues.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/recent_activity.php
+++ b/htdocs/reports/recent_activity.php
@@ -35,7 +35,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/recent_activity.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 try {
     $controller = new RecentActivity();

--- a/htdocs/reports/stalled_issues.php
+++ b/htdocs/reports/stalled_issues.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/stalled_issues.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/weekly.php
+++ b/htdocs/reports/weekly.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/weekly.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/workload_date_range.php
+++ b/htdocs/reports/workload_date_range.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/workload_date_range.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/workload_date_range_graph.php
+++ b/htdocs/reports/workload_date_range_graph.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/reports/workload_time_period.php
+++ b/htdocs/reports/workload_time_period.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('reports/workload_time_period.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 $usr_id = Auth::getUserID();
 
 if (!Access::canAccessReports(Auth::getUserID())) {

--- a/htdocs/reports/workload_time_period_graph.php
+++ b/htdocs/reports/workload_time_period_graph.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!Access::canAccessReports(Auth::getUserID())) {
     echo 'Invalid role';

--- a/htdocs/requirement.php
+++ b/htdocs/requirement.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('requirement.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 if (@$_POST['cat'] == 'set_analysis') {
     $res = Impact_Analysis::update($_POST['isr_id']);

--- a/htdocs/rss.php
+++ b/htdocs/rss.php
@@ -138,7 +138,7 @@ function authorizeRequest()
         }
 
         $usr_id = User::getUserIDByEmail($authUser);
-        Auth::createFakeCookie($usr_id);
+        AuthCookie::setDelegateCookies($usr_id);
     }
 
     // check if the required parameter 'custom_id' is really being passed

--- a/htdocs/rss.php
+++ b/htdocs/rss.php
@@ -138,7 +138,7 @@ function authorizeRequest()
         }
 
         $usr_id = User::getUserIDByEmail($authUser);
-        AuthCookie::setDelegateCookies($usr_id);
+        AuthCookie::setAuthCookie($usr_id);
     }
 
     // check if the required parameter 'custom_id' is really being passed

--- a/htdocs/select_customer.php
+++ b/htdocs/select_customer.php
@@ -34,11 +34,11 @@ $tpl->setTemplate('select_customer.tpl.html');
 session_start();
 
 // check if cookies are enabled, first of all
-if (!Auth::hasCookieSupport(APP_COOKIE)) {
+if (!AuthCookie::hasCookieSupport()) {
     Auth::redirect('index.php?err=11');
 }
 
-if (!Auth::hasValidCookie(APP_COOKIE)) {
+if (!AuthCookie::hasAuthCookie()) {
     Auth::redirect('index.php?err=5');
 }
 

--- a/htdocs/select_project.php
+++ b/htdocs/select_project.php
@@ -36,17 +36,17 @@ $tpl->setTemplate('select_project.tpl.html');
 session_start();
 
 // check if cookies are enabled, first of all
-if (!Auth::hasCookieSupport(APP_COOKIE)) {
+if (!AuthCookie::hasCookieSupport()) {
     Auth::redirect('index.php?err=11');
 }
 
-if (!Auth::hasValidCookie(APP_COOKIE)) {
+if (!AuthCookie::hasAuthCookie()) {
     Auth::redirect('index.php?err=5');
 }
 
 if (@$_GET['err'] == '') {
-    $cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
-    if ($cookie['remember'] && $cookie['prj_id'] != false) {
+    $cookie = AuthCookie::getProjectCookie();
+    if ($cookie['remember'] && $cookie['prj_id']) {
         if (!empty($_GET['url'])) {
             Auth::redirect($_GET['url']);
         } else {

--- a/htdocs/select_project.php
+++ b/htdocs/select_project.php
@@ -90,7 +90,7 @@ if (@$_GET['err'] == '') {
 }
 
 if (@$_GET['err'] != '') {
-    Auth::removeCookie(APP_PROJECT_COOKIE);
+    AuthCookie::removeProjectCookie();
     $tpl->assign('err', $_GET['err']);
 }
 

--- a/htdocs/select_project.php
+++ b/htdocs/select_project.php
@@ -62,7 +62,7 @@ if (@$_GET['err'] == '') {
     $assigned_projects = Project::getAssocList(Auth::getUserID());
     if (count($assigned_projects) == 1) {
         list($prj_id) = each($assigned_projects);
-        Auth::setCurrentProject($prj_id, 0);
+        AuthCookie::setProjectCookie($prj_id);
         checkCustomerAuthentication($prj_id);
 
         if (!empty($_GET['url'])) {
@@ -81,7 +81,7 @@ if (@$_GET['err'] == '') {
             $prj_id = $matches[1];
         }
         if (!empty($assigned_projects[$prj_id])) {
-            Auth::setCurrentProject($prj_id, 0);
+            AuthCookie::setProjectCookie($prj_id);
             checkCustomerAuthentication($prj_id);
             Auth::redirect($_GET['url']);
         }
@@ -107,7 +107,7 @@ if ($select_prj) {
         if (empty($_POST['remember'])) {
             $_POST['remember'] = 0;
         }
-        Auth::setCurrentProject($prj_id, $_POST['remember']);
+        AuthCookie::setProjectCookie($prj_id, $_POST['remember']);
         checkCustomerAuthentication($prj_id);
 
         if (!empty($_POST['url'])) {

--- a/htdocs/self_assign.php
+++ b/htdocs/self_assign.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('self_assign.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 $usr_id = Auth::getUserID();
 $prj_id = Auth::getCurrentProject();
 $issue_id = $_REQUEST['iss_id'];

--- a/htdocs/send.php
+++ b/htdocs/send.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('send.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $prj_id = Auth::getCurrentProject();
 $usr_id = Auth::getUserID();

--- a/htdocs/signup.php
+++ b/htdocs/signup.php
@@ -34,7 +34,7 @@ $tpl = new Template_Helper();
 $tpl->setTemplate('signup.tpl.html');
 
 // log anonymous users out so they can use the signup form
-if (Auth::hasValidCookie(APP_COOKIE) && Auth::isAnonUser()) {
+if (AuthCookie::hasAuthCookie() && Auth::isAnonUser()) {
     Auth::logout();
 }
 

--- a/htdocs/spell_check.php
+++ b/htdocs/spell_check.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('spell_check.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (!empty($_GET['form_name'])) {
     // show temporary form

--- a/htdocs/stats_chart.php
+++ b/htdocs/stats_chart.php
@@ -31,7 +31,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $type = isset($_GET['plot']) ? (string) $_GET['plot'] : null;
 $hide_closed = isset($_REQUEST['hide_closed']) ? $_REQUEST['hide_closed'] : false;

--- a/htdocs/switch.php
+++ b/htdocs/switch.php
@@ -36,9 +36,7 @@ Auth::checkAuthentication();
 $prj_id = $_POST['current_project'];
 $url = $_SERVER['HTTP_REFERER'];
 
-// get the 'remember' setting of the project cookie
-$cookie = AuthCookie::getProjectCookie();
-AuthCookie::setProjectCookie($prj_id, $cookie['remember']);
+AuthCookie::setProjectCookie($prj_id);
 Misc::setMessage(ev_gettext('The project has been switched'), Misc::MSG_INFO);
 
 // if url is 'view.php', use 'list.php',

--- a/htdocs/switch.php
+++ b/htdocs/switch.php
@@ -38,7 +38,7 @@ $url = $_SERVER['HTTP_REFERER'];
 
 // get the 'remember' setting of the project cookie
 $cookie = AuthCookie::getProjectCookie();
-Auth::setCurrentProject($prj_id, $cookie['remember']);
+AuthCookie::setProjectCookie($prj_id, $cookie['remember']);
 Misc::setMessage(ev_gettext('The project has been switched'), Misc::MSG_INFO);
 
 // if url is 'view.php', use 'list.php',

--- a/htdocs/switch.php
+++ b/htdocs/switch.php
@@ -31,13 +31,13 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $prj_id = $_POST['current_project'];
 $url = $_SERVER['HTTP_REFERER'];
 
 // get the 'remember' setting of the project cookie
-$cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
+$cookie = AuthCookie::getProjectCookie();
 Auth::setCurrentProject($prj_id, $cookie['remember']);
 Misc::setMessage(ev_gettext('The project has been switched'), Misc::MSG_INFO);
 

--- a/htdocs/time_tracking.php
+++ b/htdocs/time_tracking.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('add_time_tracking.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : $_GET['iss_id'];
 

--- a/htdocs/update.php
+++ b/htdocs/update.php
@@ -59,7 +59,7 @@ $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
 if (!empty($iss_prj_id) && $iss_prj_id != $prj_id && in_array($iss_prj_id, $associated_projects)) {
     $cookie = AuthCookie::getProjectCookie();
-    Auth::setCurrentProject($iss_prj_id, $cookie['remember']);
+    AuthCookie::setProjectCookie($iss_prj_id, $cookie['remember']);
     $auto_switched_from = $iss_prj_id;
     $prj_id = $iss_prj_id;
     Misc::setMessage(ev_gettext('Note: Project automatically switched to "%1$s" from "%2$s".',

--- a/htdocs/update.php
+++ b/htdocs/update.php
@@ -40,7 +40,7 @@ $tpl = new Template_Helper();
 $tpl->setTemplate('update.tpl.html');
 $tpl->assign('user_prefs', Prefs::get($usr_id));
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $issue_id = @$_POST['issue_id'] ? $_POST['issue_id'] : @$_GET['id'];
 $tpl->assign('issue_id', $issue_id);
@@ -57,9 +57,9 @@ Workflow::prePage($prj_id, 'update');
 // check if issue exists in another project and if it does, switch projects
 $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
-if ((!empty($iss_prj_id)) && ($iss_prj_id != $prj_id) && (in_array($iss_prj_id, $associated_projects))) {
-    $cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
-    Auth::setCurrentProject($iss_prj_id, $cookie['remember'], true);
+if (!empty($iss_prj_id) && $iss_prj_id != $prj_id && in_array($iss_prj_id, $associated_projects)) {
+    $cookie = AuthCookie::getProjectCookie();
+    Auth::setCurrentProject($iss_prj_id, $cookie['remember']);
     $auto_switched_from = $iss_prj_id;
     $prj_id = $iss_prj_id;
     Misc::setMessage(ev_gettext('Note: Project automatically switched to "%1$s" from "%2$s".',

--- a/htdocs/update.php
+++ b/htdocs/update.php
@@ -58,8 +58,7 @@ Workflow::prePage($prj_id, 'update');
 $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
 if (!empty($iss_prj_id) && $iss_prj_id != $prj_id && in_array($iss_prj_id, $associated_projects)) {
-    $cookie = AuthCookie::getProjectCookie();
-    AuthCookie::setProjectCookie($iss_prj_id, $cookie['remember']);
+    AuthCookie::setProjectCookie($iss_prj_id);
     $auto_switched_from = $iss_prj_id;
     $prj_id = $iss_prj_id;
     Misc::setMessage(ev_gettext('Note: Project automatically switched to "%1$s" from "%2$s".',

--- a/htdocs/validate.php
+++ b/htdocs/validate.php
@@ -30,7 +30,7 @@
 
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $valid_functions = array('validateIssueNumbers');
 $action = Misc::escapeString($_REQUEST['action']);

--- a/htdocs/view.php
+++ b/htdocs/view.php
@@ -34,7 +34,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('view.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 $prj_id = Auth::getCurrentProject();
 $usr_id = Auth::getUserID();
@@ -50,8 +50,8 @@ $tpl->assign('issue_id', $issue_id);
 $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
 if ((!empty($iss_prj_id)) && ($iss_prj_id != $prj_id) && (in_array($iss_prj_id, $associated_projects))) {
-    $cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
-    Auth::setCurrentProject($iss_prj_id, $cookie['remember'], true);
+    $cookie = AuthCookie::getProjectCookie();
+    Auth::setCurrentProject($iss_prj_id, $cookie['remember']);
     $auto_switched_from = $prj_id;
     $prj_id = $iss_prj_id;
 }
@@ -92,7 +92,8 @@ if (!Issue::canAccess($issue_id, $usr_id)) {
             $options = Search::saveSearchParams();
             $sides = Issue::getSides($issue_id, $options);
 
-            $cookie = Auth::getCookieInfo(APP_PROJECT_COOKIE);
+            // FIXME: this $cookie seems unused
+            $cookie = AuthCookie::getProjectCookie();
             if (!empty($auto_switched_from)) {
                 $tpl->assign(array(
                     'project_auto_switched' =>  1,

--- a/htdocs/view.php
+++ b/htdocs/view.php
@@ -50,8 +50,7 @@ $tpl->assign('issue_id', $issue_id);
 $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
 if ((!empty($iss_prj_id)) && ($iss_prj_id != $prj_id) && (in_array($iss_prj_id, $associated_projects))) {
-    $cookie = AuthCookie::getProjectCookie();
-    AuthCookie::setProjectCookie($iss_prj_id, $cookie['remember']);
+    AuthCookie::setProjectCookie($iss_prj_id);
     $auto_switched_from = $prj_id;
     $prj_id = $iss_prj_id;
 }

--- a/htdocs/view.php
+++ b/htdocs/view.php
@@ -51,7 +51,7 @@ $iss_prj_id = Issue::getProjectID($issue_id);
 $auto_switched_from = false;
 if ((!empty($iss_prj_id)) && ($iss_prj_id != $prj_id) && (in_array($iss_prj_id, $associated_projects))) {
     $cookie = AuthCookie::getProjectCookie();
-    Auth::setCurrentProject($iss_prj_id, $cookie['remember']);
+    AuthCookie::setProjectCookie($iss_prj_id, $cookie['remember']);
     $auto_switched_from = $prj_id;
     $prj_id = $iss_prj_id;
 }

--- a/htdocs/view_email.php
+++ b/htdocs/view_email.php
@@ -36,7 +36,7 @@ $prj_id = Auth::getCurrentProject();
 $tpl = new Template_Helper();
 $tpl->setTemplate('view_email.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 $issue_id = Support::getIssueFromEmail($_GET['id']);
 
 if (($issue_id != 0 && !Issue::canAccess($issue_id, $usr_id)) ||

--- a/htdocs/view_headers.php
+++ b/htdocs/view_headers.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('view_headers.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 
 if (@$_GET['cat'] == 'note') {
     $headers = Note::getBlockedMessage($_GET['id']);

--- a/htdocs/view_note.php
+++ b/htdocs/view_note.php
@@ -33,7 +33,7 @@ require_once __DIR__ . '/../init.php';
 $tpl = new Template_Helper();
 $tpl->setTemplate('view_note.tpl.html');
 
-Auth::checkAuthentication(APP_COOKIE, 'index.php?err=5', true);
+Auth::checkAuthentication('index.php?err=5', true);
 $usr_id = Auth::getUserID();
 
 $note_id = $_GET['id'];

--- a/irc/restart.php
+++ b/irc/restart.php
@@ -1,7 +1,7 @@
 <?php
 require_once __DIR__ . '/../init.php';
 
-Auth::checkAuthentication(APP_COOKIE);
+Auth::checkAuthentication();
 
 if (Auth::getCurrentRole() < User::ROLE_DEVELOPER) {
     echo 'Invalid role';

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -151,13 +151,18 @@ class AuthCookie
     }
 
     /**
-     * Method used to check whether a cookie is valid or not.
+     * Method to check if the user has a valid auth cookie.
+     * The cookie contents is validated for hash matching and user id from database.
      *
-     * @param array $cookie The unserialized contents of the cookie
      * @return boolean
      */
-    private static function isValidCookie($cookie)
+    public static function hasAuthCookie()
     {
+        if (empty($_COOKIE[APP_COOKIE])) {
+            return false;
+        }
+        $cookie = unserialize(base64_decode($_COOKIE[APP_COOKIE]));
+
         if (empty($cookie['email']) || empty($cookie['hash'])) {
             return false;
         }
@@ -169,21 +174,6 @@ class AuthCookie
 
         $usr_id = User::getUserIDByEmail($cookie['email']);
         return !!$usr_id;
-    }
-
-    /**
-     * Method to check if the user has a valid auth cookie.
-     *
-     * @return boolean
-     */
-    public static function hasAuthCookie()
-    {
-        if (empty($_COOKIE[APP_COOKIE])) {
-            return false;
-        }
-        $cookie = unserialize(base64_decode($_COOKIE[APP_COOKIE]));
-
-        return self::isValidCookie($cookie);
     }
 
     /**

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -158,12 +158,8 @@ class AuthCookie
      */
     public static function hasAuthCookie()
     {
-        if (empty($_COOKIE[APP_COOKIE])) {
-            return false;
-        }
-        $cookie = unserialize(base64_decode($_COOKIE[APP_COOKIE]));
-
-        if (empty($cookie['email']) || empty($cookie['hash'])) {
+        $cookie = self::getDecodedCookie(APP_COOKIE);
+        if (!$cookie || empty($cookie['email']) || empty($cookie['hash'])) {
             return false;
         }
 
@@ -186,7 +182,6 @@ class AuthCookie
         // check for any cookie being present
         return !empty($_COOKIE);
     }
-
 
     /**
      * Method used to set auth cookie in user's browser.

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -66,15 +66,17 @@ class AuthCookie
     /**
      * Get cookie used for user authentication
      *
+     * @param bool|true $permanent
      * @return string
      */
-    public function generateCookie()
+    public function generateCookie($permanent = true)
     {
         $time = time();
         $email = $this->getEmail();
         $cookie = array(
             'email' => $email,
             'login_time' => $time,
+            'permanent' => $permanent,
             'hash' => $this->generateHash($time, $email),
         );
 
@@ -193,7 +195,7 @@ class AuthCookie
     public static function setAuthCookie($email, $permanent = true)
     {
         $ac = new self(null, $email);
-        $cookie = $ac->generateCookie();
+        $cookie = $ac->generateCookie($permanent);
         Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : null);
     }
 

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -85,13 +85,14 @@ class AuthCookie
      * Get cookie used to save project id
      *
      * @param int $prj_id
+     * @param bool $remember
      * @return string
      */
-    public static function generateProjectCookie($prj_id)
+    public static function generateProjectCookie($prj_id, $remember = false)
     {
         $cookie = array(
             'prj_id' => $prj_id,
-            'remember' => false,
+            'remember' => $remember,
         );
 
         return base64_encode(serialize($cookie));
@@ -209,6 +210,20 @@ class AuthCookie
         $ac = new AuthCookie(null, $email);
         $cookie = $ac->generateCookie();
         Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : 0);
+    }
+
+    /**
+     * Sets the current selected project for the user session.
+     *
+     * @param int $prj_id The project ID
+     * @param bool $remember Whether to automatically remember the setting or not
+     */
+    public static function setProjectCookie($prj_id, $remember = false)
+    {
+        $cookie = self::generateProjectCookie($prj_id, $remember);
+
+        Auth::setCookie(APP_PROJECT_COOKIE, $cookie, APP_PROJECT_COOKIE_EXPIRE);
+        $_COOKIE[APP_PROJECT_COOKIE] = $cookie;
     }
 
     /**

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -209,7 +209,7 @@ class AuthCookie
     {
         $ac = new AuthCookie(null, $email);
         $cookie = $ac->generateCookie();
-        Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : 0);
+        Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : null);
     }
 
     /**

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -192,7 +192,7 @@ class AuthCookie
      */
     public static function setAuthCookie($email, $permanent = true)
     {
-        $ac = new AuthCookie(null, $email);
+        $ac = new self(null, $email);
         $cookie = $ac->generateCookie();
         Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : null);
     }
@@ -227,7 +227,7 @@ class AuthCookie
                 $user_id = null;
                 $email = $user;
             }
-            $ac = new AuthCookie($user_id, $email);
+            $ac = new self($user_id, $email);
             $_COOKIE[APP_COOKIE] = $ac->generateCookie();
         }
 

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -1,0 +1,269 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 encoding=utf-8: */
+// +----------------------------------------------------------------------+
+// | Eventum - Issue Tracking System                                      |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2015 Eventum Team.                                     |
+// |                                                                      |
+// | This program is free software; you can redistribute it and/or modify |
+// | it under the terms of the GNU General Public License as published by |
+// | the Free Software Foundation; either version 2 of the License, or    |
+// | (at your option) any later version.                                  |
+// |                                                                      |
+// | This program is distributed in the hope that it will be useful,      |
+// | but WITHOUT ANY WARRANTY; without even the implied warranty of       |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        |
+// | GNU General Public License for more details.                         |
+// |                                                                      |
+// | You should have received a copy of the GNU General Public License    |
+// | along with this program; if not, write to:                           |
+// |                                                                      |
+// | Free Software Foundation, Inc.                                       |
+// | 51 Franklin Street, Suite 330                                        |
+// | Boston, MA 02110-1301, USA.                                          |
+// +----------------------------------------------------------------------+
+// | Authors: Elan Ruusamäe <glen@delfi.ee>                               |
+// +----------------------------------------------------------------------+
+
+class AuthCookie
+{
+    /** @var int */
+    private $usr_id;
+
+    /** @var string */
+    private $email;
+
+    /**
+     * @param int $usr_id
+     */
+    public function __construct($usr_id = null, $email = null)
+    {
+        $this->usr_id = $usr_id;
+        $this->email = $email;
+    }
+
+
+    /**
+     * Get email. Retrieve by user id if neccessary.
+     *
+     * @return string
+     */
+    private function getEmail()
+    {
+        if (!$this->email) {
+            if (!$this->usr_id) {
+                throw new LogicException("Need usr_id or email");
+            }
+
+            $user_details = User::getDetails($this->usr_id);
+            $this->email = $user_details['usr_email'];
+        }
+
+        return $this->email;
+
+    }
+
+    /**
+     * Get cookie used for user authentication
+     *
+     * @return string
+     */
+    public function generateCookie()
+    {
+        $time = time();
+        $email = $this->getEmail();
+        $cookie = array(
+            'email' => $email,
+            'login_time' => $time,
+            'hash' => $this->generateHash($time, $email),
+        );
+
+        return base64_encode(serialize($cookie));
+    }
+
+    /**
+     * Get cookie used to save project id
+     *
+     * @param int $prj_id
+     * @return string
+     */
+    public static function generateProjectCookie($prj_id)
+    {
+        $cookie = array(
+            'prj_id' => $prj_id,
+            'remember' => false,
+        );
+
+        return base64_encode(serialize($cookie));
+    }
+
+    /**
+     * Get structure of authentication cookie.
+     * Requires cookie being valid and 'email' key being present
+     *
+     * @return array|null
+     */
+    public static function getAuthCookie()
+    {
+        if (!self::hasAuthCookie()) {
+            return null;
+        }
+
+        $cookie = self::getDecodedCookie(APP_COOKIE);
+        if (!$cookie || empty($cookie['email'])) {
+            return null;
+        }
+
+        return $cookie;
+    }
+
+    /**
+     * Get structure of project cookie.
+     * Requires prj_id being present or returns null.
+     *
+     * @return array|null
+     */
+    public static function getProjectCookie()
+    {
+        $cookie = self::getDecodedCookie(APP_PROJECT_COOKIE);
+        if (!$cookie || empty($cookie['prj_id'])) {
+            return null;
+        }
+
+        return $cookie;
+    }
+
+    /**
+     * Method used to remove auth cookie from the user's browser.
+     */
+    public static function removeAuthCookie()
+    {
+        Auth::removeCookie(APP_COOKIE);
+    }
+
+    /**
+     * Method used to remove project cookie from the user's browser.
+     */
+    public static function removeProjectCookie()
+    {
+        Auth::removeCookie(APP_PROJECT_COOKIE);
+    }
+
+    /**
+     * Method used to check whether a cookie is valid or not.
+     *
+     * @param array $cookie The unserialized contents of the cookie
+     * @return  boolean
+     */
+    public static function isValidCookie($cookie)
+    {
+        if (empty($cookie['email']) || empty($cookie['hash'])) {
+            return false;
+        }
+
+        $hash = self::generateHash($cookie['login_time'], $cookie['email']);
+        if ($cookie['hash'] != $hash) {
+            return false;
+        }
+
+        $usr_id = User::getUserIDByEmail($cookie['email']);
+        return !!$usr_id;
+    }
+
+    /**
+     * Method to check if the user has a valid auth cookie.
+     *
+     * @return boolean
+     */
+    public static function hasAuthCookie()
+    {
+        if (empty($_COOKIE[APP_COOKIE])) {
+            return false;
+        }
+        $cookie = unserialize(base64_decode($_COOKIE[APP_COOKIE]));
+
+        return AuthCookie::isValidCookie($cookie);
+    }
+
+    /**
+     * Method to check if the user has cookie support enabled in his browser or not.
+     *
+     * @return bool
+     */
+    public static function hasCookieSupport()
+    {
+        return in_array(APP_COOKIE, array_keys($_COOKIE));
+    }
+
+
+    /**
+     * Method used to set auth cookie in user's browser.
+     *
+     * @param   string $email The email address to be stored in the cookie
+     * @param   boolean $permanent Set to false to make session cookie (Expires when browser is closed)
+     * @return  void
+     */
+    public static function setAuthCookie($email, $permanent = true)
+    {
+        $ac = new AuthCookie(null, $email);
+        $cookie = $ac->generateCookie();
+        Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : 0);
+    }
+
+    /**
+     * Creates a fake $_COOKIE entries so processes not run from a browser can access current user and project
+     *
+     * @param int|string $user User Id or User email.
+     * @param int $prj_id The ID of the project.
+     */
+    public static function setDelegateCookies($user = null, $prj_id = null)
+    {
+        if ($user) {
+            if (is_numeric($user)) {
+                $user_id = $user;
+                $email = null;
+            } else {
+                $user_id = null;
+                $email = $user;
+            }
+            $ac = new AuthCookie($user_id, $email);
+            $_COOKIE[APP_COOKIE] = $ac->generateCookie();
+        }
+
+        if ($prj_id) {
+            $_COOKIE[APP_PROJECT_COOKIE] = self::generateProjectCookie($prj_id);
+        }
+    }
+
+    /**
+     * Generate hash based on time and email
+     *
+     * @param int $time
+     * @param string $email
+     * @return string
+     */
+    private static function generateHash($time, $email)
+    {
+        return md5(Auth::privateKey() . $time . $email);
+    }
+
+    /**
+     * Method used to get the unserialized contents of the specified cookie
+     * name.
+     *
+     * @param   string $cookie_name The name of the cookie to check for
+     * @return  array The unserialized contents of the cookie
+     */
+    private static function getDecodedCookie($cookie_name)
+    {
+        if (!isset($_COOKIE[$cookie_name])) {
+            return null;
+        }
+        $data = base64_decode($_COOKIE[$cookie_name], true);
+        if ($data === false) {
+            return null;
+        }
+
+        return unserialize($data);
+    }
+}

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -222,23 +222,6 @@ class AuthCookie
     }
 
     /**
-     * Setups $_COOKIE entries so processes not run from a browser can access current user and project
-     *
-     * @param int|string $user User Id or User email.
-     * @param int $prj_id The ID of the project.
-     */
-    public static function setDelegateCookies($user = null, $prj_id = null)
-    {
-        if ($user) {
-            self::setAuthCookie($user);
-        }
-
-        if ($prj_id) {
-            self::setProjectCookie($prj_id);
-        }
-    }
-
-    /**
      * Generate hash based on time and email
      *
      * @param int $time

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -188,15 +188,23 @@ class AuthCookie
     /**
      * Method used to set auth cookie in user's browser.
      *
-     * @param   string $email The email address to be stored in the cookie
-     * @param   boolean $permanent Set to false to make session cookie (Expires when browser is closed)
-     * @return  void
+     * @param int|string $user User Id or User email.
+     * @param boolean $permanent Set to false to make session cookie (Expires when browser is closed)
      */
-    public static function setAuthCookie($email, $permanent = true)
+    public static function setAuthCookie($user, $permanent = true)
     {
-        $ac = new self(null, $email);
+        if (is_numeric($user)) {
+            $user_id = $user;
+            $email = null;
+        } else {
+            $user_id = null;
+            $email = $user;
+        }
+
+        $ac = new self($user_id, $email);
         $cookie = $ac->generateCookie($permanent);
         Auth::setCookie(APP_COOKIE, $cookie, $permanent ? APP_COOKIE_EXPIRE : null);
+        $_COOKIE[APP_COOKIE] = $cookie;
     }
 
     /**
@@ -214,7 +222,7 @@ class AuthCookie
     }
 
     /**
-     * Creates a fake $_COOKIE entries so processes not run from a browser can access current user and project
+     * Setups $_COOKIE entries so processes not run from a browser can access current user and project
      *
      * @param int|string $user User Id or User email.
      * @param int $prj_id The ID of the project.
@@ -222,19 +230,11 @@ class AuthCookie
     public static function setDelegateCookies($user = null, $prj_id = null)
     {
         if ($user) {
-            if (is_numeric($user)) {
-                $user_id = $user;
-                $email = null;
-            } else {
-                $user_id = null;
-                $email = $user;
-            }
-            $ac = new self($user_id, $email);
-            $_COOKIE[APP_COOKIE] = $ac->generateCookie();
+            self::setAuthCookie($user);
         }
 
         if ($prj_id) {
-            $_COOKIE[APP_PROJECT_COOKIE] = self::generateProjectCookie($prj_id);
+            self::setProjectCookie($prj_id);
         }
     }
 

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -154,9 +154,9 @@ class AuthCookie
      * Method used to check whether a cookie is valid or not.
      *
      * @param array $cookie The unserialized contents of the cookie
-     * @return  boolean
+     * @return boolean
      */
-    public static function isValidCookie($cookie)
+    private static function isValidCookie($cookie)
     {
         if (empty($cookie['email']) || empty($cookie['hash'])) {
             return false;
@@ -183,7 +183,7 @@ class AuthCookie
         }
         $cookie = unserialize(base64_decode($_COOKIE[APP_COOKIE]));
 
-        return AuthCookie::isValidCookie($cookie);
+        return self::isValidCookie($cookie);
     }
 
     /**

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -34,14 +34,14 @@ class AuthCookie
     private $email;
 
     /**
-     * @param int $usr_id
+     * @param int $usr_id optional user id
+     * @param string $email optional user email
      */
     public function __construct($usr_id = null, $email = null)
     {
         $this->usr_id = $usr_id;
         $this->email = $email;
     }
-
 
     /**
      * Get email. Retrieve by user id if neccessary.

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -192,7 +192,8 @@ class AuthCookie
      */
     public static function hasCookieSupport()
     {
-        return in_array(APP_COOKIE, array_keys($_COOKIE));
+        // check for any cookie being present
+        return !empty($_COOKIE);
     }
 
 

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -94,7 +94,8 @@ class AuthCookie
     {
         $cookie = array(
             'prj_id' => $prj_id,
-            'remember' => $remember,
+            // it's stored as number, probably to save bytes in cookie size
+            'remember' => (int)$remember,
         );
 
         return base64_encode(serialize($cookie));
@@ -209,12 +210,19 @@ class AuthCookie
 
     /**
      * Sets the current selected project for the user session.
+     * If rememner is NULL, then existing value is attempted to autodetect from existing cookie
      *
      * @param int $prj_id The project ID
      * @param bool $remember Whether to automatically remember the setting or not
      */
-    public static function setProjectCookie($prj_id, $remember = false)
+    public static function setProjectCookie($prj_id, $remember = null)
     {
+        // try to preserve "remember" from existing cookie
+        if ($remember === null) {
+            $cookie = self::getProjectCookie();
+            $remember = $cookie ? (bool)$cookie['remember'] : false;
+        }
+
         $cookie = self::generateProjectCookie($prj_id, $remember);
 
         Auth::setCookie(APP_PROJECT_COOKIE, $cookie, APP_PROJECT_COOKIE_EXPIRE);

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -203,7 +203,7 @@ class AuthCookie
      */
     private static function getDecodedCookie($cookie_name)
     {
-        if (!isset($_COOKIE[$cookie_name])) {
+        if (empty($_COOKIE[$cookie_name])) {
             return null;
         }
         $data = base64_decode($_COOKIE[$cookie_name], true);

--- a/lib/eventum/auth/class.cas_auth_backend.php
+++ b/lib/eventum/auth/class.cas_auth_backend.php
@@ -54,12 +54,12 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
 
     public function checkAuthentication()
     {
-        if (phpCAS::isAuthenticated() && !AuthCookie::isValidCookie(AuthCookie::getAuthCookie())) {
+        if (phpCAS::isAuthenticated() && !AuthCookie::hasAuthCookie()) {
             $this->loginCallback();
         }
 
         // force CAS authentication
-        $auth = phpCAS::forceAuthentication();
+        phpCAS::forceAuthentication();
     }
 
     public function logout()

--- a/lib/eventum/auth/class.cas_auth_backend.php
+++ b/lib/eventum/auth/class.cas_auth_backend.php
@@ -54,7 +54,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
 
     public function checkAuthentication()
     {
-        if (phpCAS::isAuthenticated() && !Auth::isValidCookie(Auth::getCookieInfo(APP_COOKIE))) {
+        if (phpCAS::isAuthenticated() && !AuthCookie::isValidCookie(AuthCookie::getAuthCookie())) {
             $this->loginCallback();
         }
 
@@ -76,7 +76,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
         $usr_id = User::getUserIDByEmail($attributes['mail'], true);
         $user = User::getDetails($usr_id);
 
-        Auth::createLoginCookie(APP_COOKIE, $user['usr_email'], true);
+        AuthCookie::setAuthCookie($user['usr_email'], true);
     }
 
     public function updateLocalUserFromBackend($remote)
@@ -340,7 +340,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
             'default_role' => array(),
         );
 
-        if (Auth::hasValidCookie(APP_COOKIE)) {
+        if (AuthCookie::hasAuthCookie()) {
             // ensure there is entry for current project
             $prj_id = Auth::getCurrentProject();
 

--- a/lib/eventum/auth/class.ldap_auth_backend.php
+++ b/lib/eventum/auth/class.ldap_auth_backend.php
@@ -463,7 +463,7 @@ class LDAP_Auth_Backend implements Auth_Backend_Interface
             'default_role' => array(),
         );
 
-        if (Auth::hasValidCookie(APP_COOKIE)) {
+        if (AuthCookie::hasAuthCookie()) {
             // ensure there is entry for current project
             $prj_id = Auth::getCurrentProject();
 

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -111,7 +111,7 @@ class Auth
                     $prj_id = reset(array_keys(Project::getAssocList($anon_usr_id)));
                     AuthCookie::setDelegateCookies($anon_usr_id, $prj_id);
                     AuthCookie::setAuthCookie(APP_ANON_USER, false);
-                    self::setCurrentProject($prj_id, true);
+                    AuthCookie::setProjectCookie($prj_id, true);
                     Session::init($anon_usr_id);
                 } else {
                     // check for valid HTTP_BASIC params
@@ -121,7 +121,7 @@ class Auth
                             $prj_id = reset(array_keys(Project::getAssocList($usr_id)));
                             AuthCookie::setDelegateCookies($usr_id, $prj_id);
                             AuthCookie::setAuthCookie(APP_ANON_USER);
-                            self::setCurrentProject($prj_id, true);
+                            AuthCookie::setProjectCookie($prj_id, true);
                         } else {
                             header('WWW-Authenticate: Basic realm="Eventum"');
                             header('HTTP/1.0 401 Unauthorized');
@@ -173,7 +173,7 @@ class Auth
 
             // auto switch project
             if (isset($_GET['switch_prj_id'])) {
-                self::setCurrentProject($_GET['switch_prj_id'], false);
+                AuthCookie::setProjectCookie($_GET['switch_prj_id']);
                 self::redirect($_SERVER['PHP_SELF'] . '?' . str_replace('switch_prj_id=' . $_GET['switch_prj_id'], '', $_SERVER['QUERY_STRING']));
             }
 
@@ -181,7 +181,7 @@ class Auth
             AuthCookie::setAuthCookie($cookie['email'], $cookie['permanent']);
             // renew the project cookie as well
             $prj_cookie = AuthCookie::getProjectCookie();
-            self::setCurrentProject($prj_id, $prj_cookie['remember']);
+            AuthCookie::setProjectCookie($prj_id, $prj_cookie['remember']);
         } catch (AuthException $e) {
             $tpl = new Template_Helper();
             $tpl->setTemplate('authentication_error.tpl.html');
@@ -504,24 +504,6 @@ class Auth
         $crm = CRM::getInstance(self::getCurrentProject());
 
         return $crm->getContact(User::getCustomerContactID(self::getUserID()));
-    }
-
-    /**
-     * Sets the current selected project for the user session.
-     *
-     * @param   integer $prj_id The project ID
-     * @param   integer $remember Whether to automatically remember the setting or not
-     * @return  void
-     */
-    public static function setCurrentProject($prj_id, $remember)
-    {
-        $cookie = array(
-            'prj_id'   => $prj_id,
-            'remember' => $remember,
-        );
-        $cookie = base64_encode(serialize($cookie));
-        self::setCookie(APP_PROJECT_COOKIE, $cookie, APP_PROJECT_COOKIE_EXPIRE);
-        $_COOKIE[APP_PROJECT_COOKIE] = $cookie;
     }
 
     /**

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -109,7 +109,6 @@ class Auth
                 if (APP_ANON_USER) {
                     $anon_usr_id = User::getUserIDByEmail(APP_ANON_USER);
                     $prj_id = reset(array_keys(Project::getAssocList($anon_usr_id)));
-                    AuthCookie::setDelegateCookies($anon_usr_id, $prj_id);
                     AuthCookie::setAuthCookie(APP_ANON_USER, false);
                     AuthCookie::setProjectCookie($prj_id, true);
                     Session::init($anon_usr_id);
@@ -119,7 +118,6 @@ class Auth
                         if (Auth::isCorrectPassword($_SERVER['PHP_AUTH_USER'], $_SERVER['PHP_AUTH_PW'])) {
                             $usr_id = User::getUserIDByEmail($_SERVER['PHP_AUTH_USER'], true);
                             $prj_id = reset(array_keys(Project::getAssocList($usr_id)));
-                            AuthCookie::setDelegateCookies($usr_id, $prj_id);
                             AuthCookie::setAuthCookie(APP_ANON_USER);
                             AuthCookie::setProjectCookie($prj_id, true);
                         } else {

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -397,7 +397,7 @@ class Auth
     public static function getUserID()
     {
         $info = AuthCookie::getAuthCookie();
-        if ($info) {
+        if (!$info) {
             return '';
         }
 

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -110,7 +110,7 @@ class Auth
                     $anon_usr_id = User::getUserIDByEmail(APP_ANON_USER);
                     $prj_id = reset(array_keys(Project::getAssocList($anon_usr_id)));
                     AuthCookie::setAuthCookie(APP_ANON_USER, false);
-                    AuthCookie::setProjectCookie($prj_id, true);
+                    AuthCookie::setProjectCookie($prj_id);
                     Session::init($anon_usr_id);
                 } else {
                     // check for valid HTTP_BASIC params
@@ -119,7 +119,7 @@ class Auth
                             $usr_id = User::getUserIDByEmail($_SERVER['PHP_AUTH_USER'], true);
                             $prj_id = reset(array_keys(Project::getAssocList($usr_id)));
                             AuthCookie::setAuthCookie(APP_ANON_USER);
-                            AuthCookie::setProjectCookie($prj_id, true);
+                            AuthCookie::setProjectCookie($prj_id);
                         } else {
                             header('WWW-Authenticate: Basic realm="Eventum"');
                             header('HTTP/1.0 401 Unauthorized');
@@ -178,8 +178,7 @@ class Auth
             // if the current session is still valid, then renew the expiration
             AuthCookie::setAuthCookie($cookie['email'], $cookie['permanent']);
             // renew the project cookie as well
-            $prj_cookie = AuthCookie::getProjectCookie();
-            AuthCookie::setProjectCookie($prj_id, $prj_cookie['remember']);
+            AuthCookie::setProjectCookie($prj_id);
         } catch (AuthException $e) {
             $tpl = new Template_Helper();
             $tpl->setTemplate('authentication_error.tpl.html');

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -135,7 +135,7 @@ class Routing
             $full_message = preg_replace("/^(reply-to:).*\n/im", '', $full_message, 1);
         }
 
-        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID);
+        AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
 
         $structure = Mime_Helper::decode($full_message, true, true);
 
@@ -184,7 +184,8 @@ class Routing
         }
 
         $prj_id = Issue::getProjectID($issue_id);
-        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $prj_id);
+        AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
+        AuthCookie::setProjectCookie($prj_id);
 
         if (Mime_Helper::hasAttachments($structure)) {
             $has_attachments = 1;
@@ -357,7 +358,8 @@ class Routing
         } else {
             $unknown_user = false;
         }
-        AuthCookie::setDelegateCookies($sender_usr_id, $prj_id);
+        AuthCookie::setAuthCookie($sender_usr_id);
+        AuthCookie::setProjectCookie($prj_id);
 
         // parse the Cc: list, if any, and add these internal users to the issue notification list
         $addresses = array();
@@ -482,7 +484,8 @@ class Routing
             }
         }
 
-        AuthCookie::setDelegateCookies(User::getUserIDByEmail($sender_email), $prj_id);
+        AuthCookie::setAuthCookie(User::getUserIDByEmail($sender_email));
+        AuthCookie::setProjectCookie($prj_id);
 
         $body = $structure->body;
 

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -135,7 +135,7 @@ class Routing
             $full_message = preg_replace("/^(reply-to:).*\n/im", '', $full_message, 1);
         }
 
-        Auth::createFakeCookie(APP_SYSTEM_USER_ID);
+        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID);
 
         $structure = Mime_Helper::decode($full_message, true, true);
 
@@ -184,7 +184,7 @@ class Routing
         }
 
         $prj_id = Issue::getProjectID($issue_id);
-        Auth::createFakeCookie(APP_SYSTEM_USER_ID, $prj_id);
+        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $prj_id);
 
         if (Mime_Helper::hasAttachments($structure)) {
             $has_attachments = 1;
@@ -357,7 +357,7 @@ class Routing
         } else {
             $unknown_user = false;
         }
-        Auth::createFakeCookie($sender_usr_id, $prj_id);
+        AuthCookie::setDelegateCookies($sender_usr_id, $prj_id);
 
         // parse the Cc: list, if any, and add these internal users to the issue notification list
         $addresses = array();
@@ -482,7 +482,7 @@ class Routing
             }
         }
 
-        Auth::createFakeCookie(User::getUserIDByEmail($sender_email), $prj_id);
+        AuthCookie::setDelegateCookies(User::getUserIDByEmail($sender_email), $prj_id);
 
         $body = $structure->body;
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -488,7 +488,7 @@ class Support
      */
     public static function getEmailInfo($mbox, $info, $num)
     {
-        Auth::createFakeCookie(APP_SYSTEM_USER_ID);
+        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID);
 
         // check if the current message was already seen
         if ($info['ema_get_only_new']) {
@@ -665,7 +665,7 @@ class Support
             $t['issue_id'] = 0;
         } else {
             $prj_id = Issue::getProjectID($t['issue_id']);
-            Auth::createFakeCookie(APP_SYSTEM_USER_ID, $prj_id);
+            AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $prj_id);
         }
         if ($should_create_array['type'] == 'note') {
             // assume that this is not a valid note
@@ -679,7 +679,7 @@ class Support
                     if ($role_id > User::ROLE_CUSTOMER) {
                         // actually a valid user so insert the note
 
-                        Auth::createFakeCookie($usr_id, $prj_id);
+                        AuthCookie::setDelegateCookies($usr_id, $prj_id);
 
                         $users = Project::getUserEmailAssocList($prj_id, 'active', User::ROLE_CUSTOMER);
                         $user_emails = array_map(function ($s) { return strtolower($s); }, array_values($users));
@@ -935,7 +935,7 @@ class Support
         // check whether we need to create a new issue or not
         if (($info['ema_issue_auto_creation'] == 'enabled') && ($should_create_issue) && (!Notification::isBounceMessage($sender_email))) {
             $options = Email_Account::getIssueAutoCreationOptions($info['ema_id']);
-            Auth::createFakeCookie(APP_SYSTEM_USER_ID, $info['ema_prj_id']);
+            AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $info['ema_prj_id']);
             $issue_id = Issue::createFromEmail($info['ema_prj_id'], APP_SYSTEM_USER_ID,
                     $from, Mime_Helper::decodeQuotedPrintable($subject), $message_body, @$options['category'],
                     @$options['priority'], @$options['users'], $date, $message_id, $severity, $customer_id, $contact_id,

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -488,7 +488,7 @@ class Support
      */
     public static function getEmailInfo($mbox, $info, $num)
     {
-        AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID);
+        AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
 
         // check if the current message was already seen
         if ($info['ema_get_only_new']) {
@@ -665,7 +665,8 @@ class Support
             $t['issue_id'] = 0;
         } else {
             $prj_id = Issue::getProjectID($t['issue_id']);
-            AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $prj_id);
+            AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
+            AuthCookie::setProjectCookie($prj_id);
         }
         if ($should_create_array['type'] == 'note') {
             // assume that this is not a valid note
@@ -679,7 +680,8 @@ class Support
                     if ($role_id > User::ROLE_CUSTOMER) {
                         // actually a valid user so insert the note
 
-                        AuthCookie::setDelegateCookies($usr_id, $prj_id);
+                        AuthCookie::setAuthCookie($usr_id);
+                        AuthCookie::setProjectCookie($prj_id);
 
                         $users = Project::getUserEmailAssocList($prj_id, 'active', User::ROLE_CUSTOMER);
                         $user_emails = array_map(function ($s) { return strtolower($s); }, array_values($users));
@@ -935,7 +937,8 @@ class Support
         // check whether we need to create a new issue or not
         if (($info['ema_issue_auto_creation'] == 'enabled') && ($should_create_issue) && (!Notification::isBounceMessage($sender_email))) {
             $options = Email_Account::getIssueAutoCreationOptions($info['ema_id']);
-            AuthCookie::setDelegateCookies(APP_SYSTEM_USER_ID, $info['ema_prj_id']);
+            AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
+            AuthCookie::setProjectCookie($info['ema_prj_id']);
             $issue_id = Issue::createFromEmail($info['ema_prj_id'], APP_SYSTEM_USER_ID,
                     $from, Mime_Helper::decodeQuotedPrintable($subject), $message_body, @$options['category'],
                     @$options['priority'], @$options['users'], $date, $message_id, $severity, $customer_id, $contact_id,

--- a/lib/eventum/rpc/RemoteApi.php
+++ b/lib/eventum/rpc/RemoteApi.php
@@ -41,16 +41,6 @@ class RemoteApiException extends RuntimeException
 class RemoteApi
 {
     /**
-     * Setup current project id
-     *
-     * @param int $prj_id
-     */
-    private static function setProjectId($prj_id)
-    {
-        AuthCookie::setDelegateCookies(null, $prj_id);
-    }
-
-    /**
      * @param int $prj_id
      * @return struct
      * @access protected
@@ -81,7 +71,7 @@ class RemoteApi
      */
     public function getSimpleIssueDetails($issue_id)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $details = Issue::getDetails($issue_id);
         if (empty($details)) {
@@ -107,7 +97,7 @@ class RemoteApi
      */
     public function getOpenIssues($prj_id, $show_all_issues, $status)
     {
-        self::setProjectId($prj_id);
+        AuthCookie::setProjectCookie($prj_id);
         $status_id = Status::getStatusID($status);
         $usr_id = Auth::getUserID();
 
@@ -215,7 +205,7 @@ class RemoteApi
      */
     public function getIssueDetails($issue_id)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $res = Issue::getDetails($issue_id);
 
@@ -308,7 +298,7 @@ class RemoteApi
      */
     public function assignIssue($issue_id, $project_id, $developer)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $usr_id = Auth::getUserID();
 
@@ -341,7 +331,7 @@ class RemoteApi
      */
     public function takeIssue($issue_id, $project_id)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         // check if issue currently is un-assigned
         $current_assignees = Issue::getAssignedUsers($issue_id);
@@ -417,7 +407,7 @@ class RemoteApi
      */
     public function getFileList($issue_id)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $res = Attachment::getList($issue_id);
         if (empty($res)) {
@@ -529,7 +519,7 @@ class RemoteApi
         $usr_id = Auth::getUserID();
         $status_id = Status::getStatusID($new_status);
 
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $res = Issue::close($usr_id, $issue_id, $send_notification, $resolution_id, $status_id, $note);
         if ($res == -1) {
@@ -656,7 +646,7 @@ class RemoteApi
      */
     public function getNoteListing($issue_id)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
         $notes = Note::getListing($issue_id);
 
         return $notes;
@@ -689,7 +679,7 @@ class RemoteApi
      */
     public function convertNote($issue_id, $note_id, $target, $authorize_sender)
     {
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         $res = Note::convertNote($note_id, $target, $authorize_sender);
         if (empty($res)) {
@@ -756,7 +746,8 @@ class RemoteApi
 
         // we have to set a project so the template class works, even though the weekly report doesn't actually need it
         $projects = Project::getAssocList(Auth::getUserID());
-        self::setProjectId(current(array_keys($projects)));
+        $prj_id = current(array_keys($projects));
+        AuthCookie::setProjectCookie($prj_id);
         $prj_id = Auth::getCurrentProject();
 
         // figure out the correct week
@@ -874,7 +865,7 @@ class RemoteApi
     public function sendDraft($issue_id, $draft_id)
     {
         $draft = Draft::getDraftBySequence($issue_id, $draft_id);
-        self::setProjectId(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
 
         if (count($draft) < 1 || !is_array($draft)) {
             throw new RemoteApiException('Draft #' . $draft_id . " does not exist for issue #$issue_id");
@@ -897,7 +888,7 @@ class RemoteApi
     public function redeemIssue($issue_id, $types)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::setProjectId($prj_id);
+        AuthCookie::setProjectCookie($prj_id);
         $customer_id = Issue::getCustomerID($issue_id);
 
         if (!CRM::hasCustomerIntegration($prj_id)) {
@@ -946,7 +937,7 @@ class RemoteApi
     public function unredeemIssue($issue_id, $types)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::setProjectId($prj_id);
+        AuthCookie::setProjectCookie($prj_id);
 
         // FIXME: $customer_id unused
         $customer_id = Issue::getCustomerID($issue_id);
@@ -993,7 +984,7 @@ class RemoteApi
     public function getIncidentTypes($issue_id, $redeemed_only)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::setProjectId($prj_id);
+        AuthCookie::setProjectCookie($prj_id);
         // FIXME: $customer_id unused
         $customer_id = Issue::getCustomerID($issue_id);
 

--- a/lib/eventum/rpc/RemoteApi.php
+++ b/lib/eventum/rpc/RemoteApi.php
@@ -41,14 +41,13 @@ class RemoteApiException extends RuntimeException
 class RemoteApi
 {
     /**
-     * Setups creation of the auth cookie
+     * Setup current project id
      *
-     * @param string $email
-     * @param bool $project
+     * @param int $prj_id
      */
-    public static function createFakeCookie($email, $project = null)
+    private static function setProjectId($prj_id)
     {
-        AuthCookie::setDelegateCookies($email, $project);
+        AuthCookie::setDelegateCookies(null, $prj_id);
     }
 
     /**
@@ -82,7 +81,7 @@ class RemoteApi
      */
     public function getSimpleIssueDetails($issue_id)
     {
-        self::createFakeCookie(null, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $details = Issue::getDetails($issue_id);
         if (empty($details)) {
@@ -108,7 +107,7 @@ class RemoteApi
      */
     public function getOpenIssues($prj_id, $show_all_issues, $status)
     {
-        self::createFakeCookie(false, $prj_id);
+        self::setProjectId($prj_id);
         $status_id = Status::getStatusID($status);
         $usr_id = Auth::getUserID();
 
@@ -216,7 +215,7 @@ class RemoteApi
      */
     public function getIssueDetails($issue_id)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $res = Issue::getDetails($issue_id);
 
@@ -309,7 +308,7 @@ class RemoteApi
      */
     public function assignIssue($issue_id, $project_id, $developer)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $usr_id = Auth::getUserID();
 
@@ -342,7 +341,7 @@ class RemoteApi
      */
     public function takeIssue($issue_id, $project_id)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         // check if issue currently is un-assigned
         $current_assignees = Issue::getAssignedUsers($issue_id);
@@ -418,7 +417,7 @@ class RemoteApi
      */
     public function getFileList($issue_id)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $res = Attachment::getList($issue_id);
         if (empty($res)) {
@@ -530,7 +529,7 @@ class RemoteApi
         $usr_id = Auth::getUserID();
         $status_id = Status::getStatusID($new_status);
 
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $res = Issue::close($usr_id, $issue_id, $send_notification, $resolution_id, $status_id, $note);
         if ($res == -1) {
@@ -657,7 +656,7 @@ class RemoteApi
      */
     public function getNoteListing($issue_id)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
         $notes = Note::getListing($issue_id);
 
         return $notes;
@@ -690,7 +689,7 @@ class RemoteApi
      */
     public function convertNote($issue_id, $note_id, $target, $authorize_sender)
     {
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         $res = Note::convertNote($note_id, $target, $authorize_sender);
         if (empty($res)) {
@@ -757,7 +756,7 @@ class RemoteApi
 
         // we have to set a project so the template class works, even though the weekly report doesn't actually need it
         $projects = Project::getAssocList(Auth::getUserID());
-        self::createFakeCookie(false, current(array_keys($projects)));
+        self::setProjectId(current(array_keys($projects)));
         $prj_id = Auth::getCurrentProject();
 
         // figure out the correct week
@@ -875,7 +874,7 @@ class RemoteApi
     public function sendDraft($issue_id, $draft_id)
     {
         $draft = Draft::getDraftBySequence($issue_id, $draft_id);
-        self::createFakeCookie(false, Issue::getProjectID($issue_id));
+        self::setProjectId(Issue::getProjectID($issue_id));
 
         if (count($draft) < 1 || !is_array($draft)) {
             throw new RemoteApiException('Draft #' . $draft_id . " does not exist for issue #$issue_id");
@@ -898,7 +897,7 @@ class RemoteApi
     public function redeemIssue($issue_id, $types)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::createFakeCookie(false, $prj_id);
+        self::setProjectId($prj_id);
         $customer_id = Issue::getCustomerID($issue_id);
 
         if (!CRM::hasCustomerIntegration($prj_id)) {
@@ -947,7 +946,7 @@ class RemoteApi
     public function unredeemIssue($issue_id, $types)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::createFakeCookie(false, $prj_id);
+        self::setProjectId($prj_id);
 
         // FIXME: $customer_id unused
         $customer_id = Issue::getCustomerID($issue_id);
@@ -994,7 +993,7 @@ class RemoteApi
     public function getIncidentTypes($issue_id, $redeemed_only)
     {
         $prj_id = Issue::getProjectID($issue_id);
-        self::createFakeCookie(false, $prj_id);
+        self::setProjectId($prj_id);
         // FIXME: $customer_id unused
         $customer_id = Issue::getCustomerID($issue_id);
 

--- a/lib/eventum/rpc/RemoteApi.php
+++ b/lib/eventum/rpc/RemoteApi.php
@@ -41,27 +41,14 @@ class RemoteApiException extends RuntimeException
 class RemoteApi
 {
     /**
-     * Fakes the creation of the login cookie
+     * Setups creation of the auth cookie
      *
      * @param string $email
      * @param bool $project
      */
-    public static function createFakeCookie($email, $project = false)
+    public static function createFakeCookie($email, $project = null)
     {
-        if ($email) {
-            $cookie = array(
-                'email' => $email,
-            );
-            $_COOKIE[APP_COOKIE] = base64_encode(serialize($cookie));
-        }
-
-        if ($project) {
-            $cookie = array(
-                'prj_id'   => $project,
-                'remember' => false,
-            );
-            $_COOKIE[APP_PROJECT_COOKIE] = base64_encode(serialize($cookie));
-        }
+        AuthCookie::setDelegateCookies($email, $project);
     }
 
     /**

--- a/lib/eventum/rpc/XmlRpcServer.php
+++ b/lib/eventum/rpc/XmlRpcServer.php
@@ -264,7 +264,7 @@ class XmlRpcServer
                     );
                 }
 
-                RemoteApi::createFakeCookie($email);
+                AuthCookie::setDelegateCookies($email);
             }
 
             if ($pdesc) {

--- a/lib/eventum/rpc/XmlRpcServer.php
+++ b/lib/eventum/rpc/XmlRpcServer.php
@@ -264,7 +264,7 @@ class XmlRpcServer
                     );
                 }
 
-                AuthCookie::setDelegateCookies($email);
+                AuthCookie::setAuthCookie($email);
             }
 
             if ($pdesc) {

--- a/tests/AuthCookieTest.php
+++ b/tests/AuthCookieTest.php
@@ -5,13 +5,14 @@ class AuthCookieTest extends PHPUnit_Framework_TestCase
     public function testAuthCookie()
     {
         $usr_id = APP_ADMIN_USER_ID;
-        $ac = new AuthCookie($usr_id);
-        $this->assertNotNull($ac->generateCookie());
+        AuthCookie::setAuthCookie($usr_id);
+        $this->assertNotEmpty(Auth::getUserID());
     }
 
     public function testProjectCookie()
     {
         $prj_id = 1;
-        $this->assertNotNull(AuthCookie::generateProjectCookie($prj_id));
+        AuthCookie::setProjectCookie($prj_id);
+        $this->assertNotNull(Auth::getCurrentProject());
     }
 }

--- a/tests/AuthCookieTest.php
+++ b/tests/AuthCookieTest.php
@@ -1,0 +1,17 @@
+<?php
+
+class AuthCookieTest extends PHPUnit_Framework_TestCase
+{
+    public function testAuthCookie()
+    {
+        $usr_id = APP_ADMIN_USER_ID;
+        $ac = new AuthCookie($usr_id);
+        $this->assertNotNull($ac->generateCookie());
+    }
+
+    public function testProjectCookie()
+    {
+        $prj_id = 1;
+        $this->assertNotNull(AuthCookie::generateProjectCookie($prj_id));
+    }
+}


### PR DESCRIPTION
Move auth related cookie code to `AuthCookie` class.

Includes internal refactor and cleanups.
all `APP_COOKIE` and `APP_PROJECT_COOKIE` related methods are in `AuthCookie` class.
