### PR TITLE
refactor password handling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -51,6 +51,7 @@
 		"ext-session": "*",
 		"ext-spl": "*",
 		"fonts/liberation":"*",
+		"ircmaxell/password-compat": "~1.0.4",
 		"ircmaxell/random-lib": "~1.1.0",
 		"pear-pear.php.net/mail_mimedecode": "*",
 		"pear-pear.php.net/math_stats": "*",

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -83,7 +83,13 @@ if ($cat == 'update_account') {
         Misc::setMessage(ev_gettext('Please set different password than current'), Misc::MSG_ERROR);
         $res = -2;
     } else {
-        $res = Auth::updatePassword($usr_id, $_POST['new_password']);
+        try {
+            User::updatePassword($usr_id, $_POST['new_password']);
+            $res = 1;
+        } catch (Exception $e) {
+            error_log($e->getMessage());
+            $res = -1;
+        }
     }
 }
 

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -72,8 +72,15 @@ if ($cat == 'update_account') {
 } elseif ($cat == 'update_email') {
     $res = User::updateEmail($usr_id);
 } elseif ($cat == 'update_password') {
-
-    if ($_POST['new_password'] != $_POST['confirm_password']) {
+    // verify current password
+    if (!Auth::isCorrectPassword(Auth::getUserLogin(), $_POST['password'])) {
+        Misc::setMessage(ev_gettext('Incorrect password'), Misc::MSG_ERROR);
+        $res = -3;
+    } elseif ($_POST['new_password'] != $_POST['confirm_password']) {
+        Misc::setMessage(ev_gettext('New passwords mismatch'), Misc::MSG_ERROR);
+        $res = -2;
+    } elseif ($_POST['password'] == $_POST['new_password']) {
+        Misc::setMessage(ev_gettext('Please set different password than current'), Misc::MSG_ERROR);
         $res = -2;
     } else {
         $res = Auth::updatePassword($usr_id, $_POST['new_password']);

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -72,12 +72,17 @@ if ($cat == 'update_account') {
 } elseif ($cat == 'update_email') {
     $res = User::updateEmail($usr_id);
 } elseif ($cat == 'update_password') {
-    $res = Auth::updatePassword($usr_id, $_POST['new_password'], $_POST['confirm_password']);
+
+    if ($_POST['new_password'] != $_POST['confirm_password']) {
+        $res = -2;
+    } else {
+        $res = Auth::updatePassword($usr_id, $_POST['new_password']);
+    }
 }
 
 if ($res == 1) {
     Misc::setMessage(ev_gettext('Your information has been updated'));
-} elseif ($res == -1) {
+} else {
     Misc::setMessage(ev_gettext('Sorry, there was an error updating your information'), Misc::MSG_ERROR);
 }
 

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -82,7 +82,7 @@ if ($cat == 'update_account') {
 
 if ($res == 1) {
     Misc::setMessage(ev_gettext('Your information has been updated'));
-} else {
+} elseif ($res !== null) {
     Misc::setMessage(ev_gettext('Sorry, there was an error updating your information'), Misc::MSG_ERROR);
 }
 

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -52,9 +52,14 @@ class AuthPassword
      * @param string $hash The hash to verify against
      * @param string $password The password to verify
      * @return boolean If the password matches the hash
+     * @throws InvalidArgumentException in case non-strings were passed as hash or password
      */
     public static function verify($password, $hash)
     {
+        if (!is_string($password) || !is_string($hash)) {
+            throw new InvalidArgumentException("password and hash need to be strings");
+        }
+
         // verify passwords do in constant time, i.e always do all checks
         $cmp = 0;
 
@@ -76,7 +81,7 @@ class AuthPassword
      */
     private static function cmp($str1, $str2)
     {
-        if (!is_string($str1) || Misc::countBytes($str1) != Misc::countBytes($str2) || Misc::countBytes($str1) <= 13) {
+        if (Misc::countBytes($str1) != Misc::countBytes($str2) || Misc::countBytes($str1) <= 13) {
             return false;
         }
 

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -1,0 +1,60 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 encoding=utf-8: */
+// +----------------------------------------------------------------------+
+// | Eventum - Issue Tracking System                                      |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2015 Eventum Team.                                     |
+// |                                                                      |
+// | This program is free software; you can redistribute it and/or modify |
+// | it under the terms of the GNU General Public License as published by |
+// | the Free Software Foundation; either version 2 of the License, or    |
+// | (at your option) any later version.                                  |
+// |                                                                      |
+// | This program is distributed in the hope that it will be useful,      |
+// | but WITHOUT ANY WARRANTY; without even the implied warranty of       |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        |
+// | GNU General Public License for more details.                         |
+// |                                                                      |
+// | You should have received a copy of the GNU General Public License    |
+// | along with this program; if not, write to:                           |
+// |                                                                      |
+// | Free Software Foundation, Inc.                                       |
+// | 51 Franklin Street, Suite 330                                        |
+// | Boston, MA 02110-1301, USA.                                          |
+// +----------------------------------------------------------------------+
+// | Authors: Elan Ruusamäe <glen@delfi.ee>                               |
+// +----------------------------------------------------------------------+
+
+/**
+ * Class dealing with user passwords
+ */
+class AuthPassword
+{
+    /**
+     * Hash the password
+     *
+     * @param string $password The password to hash
+     * @return string|false The hashed password, or false on error.
+     */
+    public static function hash($password)
+    {
+        if (APP_HASH_TYPE == 'MD5-64') {
+            return base64_encode(pack('H*', md5($password)));
+        } else {
+            // default to md5
+            return md5($password);
+        }
+    }
+
+    /**
+     * Verify a password against a hash
+     *
+     * @param string $hash The hash to verify against
+     * @param string $password The password to verify
+     * @return boolean If the password matches the hash
+     */
+    public static function verify($password, $hash)
+    {
+        return $hash == self::hash($password);
+    }
+}

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -50,19 +50,15 @@ class AuthPassword
      */
     public static function verify($password, $hash)
     {
-        $res = password_verify($password, $hash);
-        if ($res) {
-            return $res;
-        }
-
-        // try legacy authentication methods
-        // try to do in constant time, i.e always do both checks
-        $md5_64 = base64_encode(pack('H*', md5($password)));
-        $md5 = md5($password);
-
+        // verify passwords do in constant time, i.e always do all checks
         $cmp = 0;
-        $cmp |= (int)self::cmp($hash, $md5_64);
-        $cmp |= (int)self::cmp($hash, $md5);
+
+        $cmp |= (int)password_verify($password, $hash);
+
+        // legacy authentication methods
+        $cmp |= (int)self::cmp($hash, base64_encode(pack('H*', md5($password))));
+        $cmp |= (int)self::cmp($hash, md5($password));
+
         return (bool)$cmp;
     }
 

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -38,16 +38,11 @@ class AuthPassword
      */
     public static function hash($password)
     {
-        if (APP_HASH_TYPE == 'MD5-64') {
-            return base64_encode(pack('H*', md5($password)));
-        } else {
-            // default to md5
-            return md5($password);
-        }
+        return password_hash($password, PASSWORD_DEFAULT);
     }
 
     /**
-     * Verify a password against a hash
+     * Verify a password against a hash using a timing attack resistant approach
      *
      * @param string $hash The hash to verify against
      * @param string $password The password to verify
@@ -55,6 +50,20 @@ class AuthPassword
      */
     public static function verify($password, $hash)
     {
-        return $hash == self::hash($password);
+        $res = password_verify($password, $hash);
+        if ($res) {
+            return $res;
+        }
+
+        // try legacy authentication methods
+        if (base64_encode(pack('H*', md5($password))) == $hash) {
+            return true;
+        }
+
+        if (md5($password) == $hash) {
+            return true;
+        }
+
+        return false;
     }
 }

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -34,11 +34,16 @@ class AuthPassword
      * Hash the password
      *
      * @param string $password The password to hash
-     * @return string|false The hashed password, or false on error.
+     * @return string The hashed password, throws on error.
+     * @throws RuntimeException
      */
     public static function hash($password)
     {
-        return password_hash($password, PASSWORD_DEFAULT);
+        $res = password_hash($password, PASSWORD_DEFAULT);
+        if (!$res) {
+            throw new RuntimeException("password hashing failed");
+        }
+        return $res;
     }
 
     /**

--- a/lib/eventum/auth/AuthPassword.php
+++ b/lib/eventum/auth/AuthPassword.php
@@ -60,7 +60,7 @@ class AuthPassword
             throw new InvalidArgumentException("password and hash need to be strings");
         }
 
-        // verify passwords do in constant time, i.e always do all checks
+        // verify passwords in constant time, i.e always do all checks
         $cmp = 0;
 
         $cmp |= (int)password_verify($password, $hash);

--- a/lib/eventum/auth/class.mysql_auth_backend.php
+++ b/lib/eventum/auth/class.mysql_auth_backend.php
@@ -44,7 +44,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
     {
         $usr_id = User::getUserIDByEmail($login, true);
         $user = User::getDetails($usr_id);
-        if ($user['usr_password'] == Auth::hashPassword($password)) {
+        if ($user['usr_password'] == self::hashPassword($password)) {
             self::resetFailedLogins($usr_id);
 
             return true;
@@ -70,7 +70,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
                     usr_password=?
                  WHERE
                     usr_id=?';
-        $params = array(Auth::hashPassword($password), $usr_id);
+        $params = array(self::hashPassword($password), $usr_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
@@ -162,6 +162,22 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
         }
 
         return $res == 1;
+    }
+
+    /**
+     * Hashes the password according to APP_HASH_TYPE constant
+     *
+     * @param   string $password The plain text password
+     * @return  string The hashed password
+     */
+    private static function hashPassword($password)
+    {
+        if (APP_HASH_TYPE == 'MD5-64') {
+            return base64_encode(pack('H*', md5($password)));
+        } else {
+            // default to md5
+            return md5($password);
+        }
     }
 
     public function canUserUpdateName($usr_id)

--- a/lib/eventum/auth/class.mysql_auth_backend.php
+++ b/lib/eventum/auth/class.mysql_auth_backend.php
@@ -77,7 +77,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
             return false;
         }
 
-        # NOTE: this will say updated failed if password is identical to old one
+        # NOTE: this will say update failed if password is identical to old one
         $updated = DB_Helper::getInstance()->affectedRows();
 
         return $updated > 0;

--- a/lib/eventum/auth/class.mysql_auth_backend.php
+++ b/lib/eventum/auth/class.mysql_auth_backend.php
@@ -44,22 +44,21 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
     {
         $usr_id = User::getUserIDByEmail($login, true);
         $user = User::getDetails($usr_id);
-        if ($user['usr_password'] == self::hashPassword($password)) {
+
+        if (AuthPassword::verify($password, $user['usr_password'])) {
             self::resetFailedLogins($usr_id);
-
             return true;
-        } else {
-            self::incrementFailedLogins($usr_id);
-
-            return false;
         }
+
+        self::incrementFailedLogins($usr_id);
+        return false;
     }
 
     /**
      * Method used to update the account password for a specific user.
      *
      * @param   integer $usr_id The user ID
-     * @param   string  $password The password.
+     * @param   string $password The password.
      * @return  boolean
      */
     public function updatePassword($usr_id, $password)
@@ -70,7 +69,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
                     usr_password=?
                  WHERE
                     usr_id=?';
-        $params = array(self::hashPassword($password), $usr_id);
+        $params = array(AuthPassword::hash($password), $usr_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
         } catch (DbException $e) {
@@ -88,7 +87,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
         return User::getUserIDByEmail($login, true);
     }
 
-     /**
+    /**
      * Increment the failed logins attempts for this user
      *
      * @param   integer $usr_id The ID of the user
@@ -164,22 +163,6 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
         return $res == 1;
     }
 
-    /**
-     * Hashes the password according to APP_HASH_TYPE constant
-     *
-     * @param   string $password The plain text password
-     * @return  string The hashed password
-     */
-    private static function hashPassword($password)
-    {
-        if (APP_HASH_TYPE == 'MD5-64') {
-            return base64_encode(pack('H*', md5($password)));
-        } else {
-            // default to md5
-            return md5($password);
-        }
-    }
-
     public function canUserUpdateName($usr_id)
     {
         return true;
@@ -219,6 +202,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
 
     /**
      * Called when a user logs out.
+     *
      * @return mixed
      */
     public function logout()

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -350,24 +350,21 @@ class Auth
     }
 
     /**
-     * Method used to update the account password for a specific user.
+     * Method to set the user password.
+     * It calls out auth backend, which will store the password hash.
      *
-     * @param   integer $usr_id The user ID
-     * @param $password
-     * @param $password_confirm
-     * @param   boolean $send_notification Whether to send the notification email or not
-     * @return  integer 1 if the update worked, -1 otherwise
+     * @param integer $usr_id The user ID
+     * @param string $password Plain text user password
+     * @param boolean $send_notification Whether to send the notification email or not
+     * @return integer 1 if the update worked, -1 otherwise
      */
-    public static function updatePassword($usr_id, $password, $password_confirm, $send_notification = false)
+    public static function updatePassword($usr_id, $password, $send_notification = false)
     {
-        if ($password != $password_confirm) {
-            return -2;
-        }
-
         $res = self::getAuthBackend()->updatePassword($usr_id, $password);
         if (!$res) {
             return -1;
         }
+
         if ($send_notification) {
             Notification::notifyUserPassword($usr_id, $password);
         }

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -350,34 +350,6 @@ class Auth
     }
 
     /**
-     * Method to set the user password.
-     * It calls out auth backend, which will store the password hash.
-     *
-     * @param integer $usr_id The user ID
-     * @param string $password Plain text user password
-     * @param boolean $send_notification Whether to send the notification email or not
-     * @return integer 1 if the update worked, -1 otherwise
-     */
-    public static function updatePassword($usr_id, $password, $send_notification = false)
-    {
-        // reject setting empty password
-        if ($password == '') {
-            return -1;
-        }
-
-        $res = self::getAuthBackend()->updatePassword($usr_id, $password);
-        if (!$res) {
-            return -1;
-        }
-
-        if ($send_notification) {
-            Notification::notifyUserPassword($usr_id, $password);
-        }
-
-        return 1;
-    }
-
-    /**
      * Returns the true if the account is currently locked becouse of Back-Off lock
      *
      * @param   string $usr_id The user id to check for

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -360,6 +360,11 @@ class Auth
      */
     public static function updatePassword($usr_id, $password, $send_notification = false)
     {
+        // reject setting empty password
+        if ($password == '') {
+            return -1;
+        }
+
         $res = self::getAuthBackend()->updatePassword($usr_id, $password);
         if (!$res) {
             return -1;

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -574,22 +574,6 @@ class Auth
     }
 
     /**
-     * Hashes the password according to APP_HASH_TYPE constant
-     *
-     * @param   string $password The plain text password
-     * @return  string The hashed password
-     */
-    public static function hashPassword($password)
-    {
-        if (APP_HASH_TYPE == 'MD5-64') {
-            return base64_encode(pack('H*', md5($password)));
-        } else {
-            // default to md5
-            return md5($password);
-        }
-    }
-
-    /**
      * Returns the user ID for the specified login. This can be the email address, an alias,
      * the external login id or any other info the backend can handle.
      *

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -948,39 +948,6 @@ class User
     }
 
     /**
-     * Method used to update the account password for a specific user.
-     *
-     * @param   integer $usr_id The user ID
-     * @param   boolean $send_notification Whether to send the notification email or not
-     * @return  integer 1 if the update worked, -1 otherwise
-     */
-    public static function updatePassword($usr_id, $send_notification = false)
-    {
-        if ($_POST['new_password'] != $_POST['confirm_password']) {
-            return -2;
-        }
-        $stmt = 'UPDATE
-                    {{%user}}
-                 SET
-                    usr_password=?
-                 WHERE
-                    usr_id=?';
-        try {
-            DB_Helper::getInstance()->query(
-                $stmt, array(Auth::hashPassword($_POST['new_password']), $usr_id)
-            );
-        } catch (DbException $e) {
-            return -1;
-        }
-
-        if ($send_notification) {
-            Notification::notifyUserPassword($usr_id, $_POST['new_password']);
-        }
-
-        return 1;
-    }
-
-    /**
      * Method used to update the account full name for a specific user.
      *
      * @param   integer $usr_id The user ID

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -395,7 +395,7 @@ class User
         $usr_id = self::getUserIDByEmail($email);
         // create the new password
         $password = substr(md5(microtime() . uniqid('')), 0, 12);
-        Auth::updatePassword($usr_id, $password, $password, true);
+        Auth::updatePassword($usr_id, $password, true);
     }
 
     public static function getUserIDByExternalID($external_id)

--- a/templates/preferences.tpl.html
+++ b/templates/preferences.tpl.html
@@ -24,10 +24,17 @@
         }
         return true;
     }
+
     function validatePassword()
     {
+        if (Validation.isWhitespace(Eventum.getField('password').val())) {
+            alert('{t escape=js}Please input current password.{/t}');
+            Validation.selectField('password');
+            return false;
+        }
+
         var new_password = Eventum.getField('new_password').val();
-        if ((Validation.isWhitespace(new_password)) || (new_password.length < 6)) {
+        if (Validation.isWhitespace(new_password) || new_password.length < 6) {
             alert('{t escape=js}Please enter your new password with at least 6 characters.{/t}');
             Validation.selectField('new_password');
             return false;
@@ -39,6 +46,7 @@
         }
         return true;
     }
+
     function validateAccount()
     {
         return true;
@@ -110,6 +118,10 @@
             </th>
             <td>
                 <table>
+                    <tr>
+                        <td align="right">{t}Current Password{/t}:</td>
+                        <td><input type="password" name="password" size="20" autocomplete="off"> {include file="error_icon.tpl.html" field="password"}</td>
+                    </tr>
                     <tr>
                         <td align="right">{t}New Password{/t}:</td>
                         <td><input type="password" name="new_password" size="20" autocomplete="off"> {include file="error_icon.tpl.html" field="new_password"}</td>

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -38,6 +38,28 @@ class PasswordAuthTest extends PHPUnit_Framework_TestCase
         $this->assertFalse($res);
     }
 
+    /**
+     * @expectedException InvalidArgumentException
+     * @dataProvider AuthPasswordInvalidArgumentData
+     */
+    public function testAuthPasswordInvalidArguments($password, $hash)
+    {
+        AuthPassword::verify($password, $hash);
+    }
+
+    public function AuthPasswordInvalidArgumentData()
+    {
+        return array(
+            array(null, '123'),
+            array('a', null),
+            array('a', 10),
+            array(-1, "10"),
+            array("", array()),
+            array(array(), ""),
+            array("", new stdClass()),
+            array(new stdClass(), ""),
+        );
+    }
 
     public function testPasswordHash()
     {

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -1,0 +1,11 @@
+<?php
+
+class PasswordAuthTest extends PHPUnit_Framework_TestCase
+{
+    public function testPasswordHash() {
+        $password = "Tr0ub4dour&3";
+        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $length = Misc::countBytes($hash);
+        $this->assertEquals(60, $length);
+    }
+}

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -17,6 +17,28 @@ class PasswordAuthTest extends PHPUnit_Framework_TestCase
         'md5' => '6125582d980e736238e9eb1ab73d6517',
     );
 
+
+    public function testAuthPassword()
+    {
+        // success
+        $res = AuthPassword::verify($this->password, $this->hashes['password_hash']);
+        $this->assertTrue($res);
+        $res = AuthPassword::verify($this->password, $this->hashes['md5-64']);
+        $this->assertTrue($res);
+        $res = AuthPassword::verify($this->password, $this->hashes['md5']);
+        $this->assertTrue($res);
+
+        // failures
+        $password = 'meh';
+        $res = AuthPassword::verify($password, $this->hashes['password_hash']);
+        $this->assertFalse($res);
+        $res = AuthPassword::verify($password, $this->hashes['md5-64']);
+        $this->assertFalse($res);
+        $res = AuthPassword::verify($password, $this->hashes['md5']);
+        $this->assertFalse($res);
+    }
+
+
     public function testPasswordHash()
     {
         $hash = password_hash($this->password, PASSWORD_DEFAULT);

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -2,36 +2,53 @@
 
 class PasswordAuthTest extends PHPUnit_Framework_TestCase
 {
+    /** @var string */
+    private $password = 'Tr0ub4dour&3';
+
+    /** @var array */
+    private $hashes = array(
+        // hash created with password_hash($password, PASSWORD_DEFAULT)
+        'password_hash' => '$2y$10$xRKqEPixGvSdeopyfzQACe2Tppb43OljoFfGUBdPTkgtpdvjvCEJO',
+
+        // hash created with MD5-64
+        'md5-64' => 'YSVYLZgOc2I46esatz1lFw==',
+
+        // hash created with md5
+        'md5' => '6125582d980e736238e9eb1ab73d6517',
+    );
+
     public function testPasswordHash()
     {
-        $password = "Tr0ub4dour&3";
-        $hash = password_hash($password, PASSWORD_DEFAULT);
+        $hash = password_hash($this->password, PASSWORD_DEFAULT);
         $length = Misc::countBytes($hash);
         $this->assertEquals(60, $length);
     }
 
     public function testPasswordGetInfo()
     {
-        // hash created with password_hash($password, PASSWORD_DEFAULT)
-        $hash = '$2y$10$xRKqEPixGvSdeopyfzQACe2Tppb43OljoFfGUBdPTkgtpdvjvCEJO';
-        $res = password_get_info($hash);
+        $res = password_get_info($this->hashes['password_hash']);
         $this->assertPasswordInfoArray($res);
         $this->assertEquals(1, $res['algo']);
         $this->assertEquals('bcrypt', $res['algoName']);
 
         // these have type "0" aka unknown
-
-        // hash created with MD5-64
-        $hash = 'YSVYLZgOc2I46esatz1lFw==';
-        $res = password_get_info($hash);
+        $res = password_get_info($this->hashes['md5-64']);
         $this->assertPasswordInfoArray($res);
         $this->assertEquals(0, $res['algo']);
 
-        // hash created with md5
-        $hash = '6125582d980e736238e9eb1ab73d6517';
-        $res = password_get_info($hash);
+        $res = password_get_info($this->hashes['md5']);
         $this->assertPasswordInfoArray($res);
         $this->assertEquals(0, $res['algo']);
+    }
+
+    public function testPasswordNeedsRehash()
+    {
+        $res = password_needs_rehash($this->hashes['password_hash'], PASSWORD_DEFAULT);
+        $this->assertFalse($res);
+        $res = password_needs_rehash($this->hashes['md5-64'], PASSWORD_DEFAULT);
+        $this->assertTrue($res);
+        $res = password_needs_rehash($this->hashes['md5'], PASSWORD_DEFAULT);
+        $this->assertTrue($res);
     }
 
     private function assertPasswordInfoArray($res)

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -2,10 +2,48 @@
 
 class PasswordAuthTest extends PHPUnit_Framework_TestCase
 {
-    public function testPasswordHash() {
+    public function testPasswordHash()
+    {
         $password = "Tr0ub4dour&3";
         $hash = password_hash($password, PASSWORD_DEFAULT);
         $length = Misc::countBytes($hash);
         $this->assertEquals(60, $length);
+    }
+
+    public function testPasswordGetInfo()
+    {
+        // hash created with password_hash($password, PASSWORD_DEFAULT)
+        $hash = '$2y$10$xRKqEPixGvSdeopyfzQACe2Tppb43OljoFfGUBdPTkgtpdvjvCEJO';
+        $res = password_get_info($hash);
+        $this->assertPasswordInfoArray($res);
+        $this->assertEquals(1, $res['algo']);
+        $this->assertEquals('bcrypt', $res['algoName']);
+
+        // these have type "0" aka unknown
+
+        // hash created with MD5-64
+        $hash = 'YSVYLZgOc2I46esatz1lFw==';
+        $res = password_get_info($hash);
+        $this->assertPasswordInfoArray($res);
+        $this->assertEquals(0, $res['algo']);
+
+        // hash created with md5
+        $hash = '6125582d980e736238e9eb1ab73d6517';
+        $res = password_get_info($hash);
+        $this->assertPasswordInfoArray($res);
+        $this->assertEquals(0, $res['algo']);
+    }
+
+    private function assertPasswordInfoArray($res)
+    {
+        $this->assertInternalType('array', $res);
+        $this->assertArrayHasKey('algo', $res);
+        $this->assertInternalType('int', $res['algo']);
+
+        $this->assertArrayHasKey('algoName', $res);
+        $this->assertInternalType('string', $res['algoName']);
+
+        $this->assertArrayHasKey('options', $res);
+        $this->assertInternalType('array', $res['options']);
     }
 }

--- a/upgrade/patches/34_password_hash.sql
+++ b/upgrade/patches/34_password_hash.sql
@@ -1,0 +1,2 @@
+ALTER TABLE {{%user}}
+  MODIFY COLUMN usr_password varchar(60) NOT NULL DEFAULT '';

--- a/upgrade/patches/34_password_hash.sql
+++ b/upgrade/patches/34_password_hash.sql
@@ -1,5 +1,5 @@
 ALTER TABLE {{%user}}
-  MODIFY COLUMN usr_password varchar(60) NOT NULL DEFAULT '';
+  MODIFY COLUMN usr_password varchar(255) NOT NULL DEFAULT '';
 
 # reset account passwords who have empty passwords
 update {{%user}} set usr_password='' where usr_password=md5('');

--- a/upgrade/patches/34_password_hash.sql
+++ b/upgrade/patches/34_password_hash.sql
@@ -1,2 +1,5 @@
 ALTER TABLE {{%user}}
   MODIFY COLUMN usr_password varchar(60) NOT NULL DEFAULT '';
+
+# reset account passwords who have empty passwords
+update {{%user}} set usr_password='' where usr_password=md5('');


### PR DESCRIPTION
uses [password_hash](https://wiki.php.net/rfc/password_hash) family functions by default.
[compatibility library](https://github.com/ircmaxell/password_compat) for older php versions is included

new passwords are set using new algorithm, existing hashes will be verified using old methods.
auto migration of hash on successful login and hash upgrade can be added in later releases.
 
also added old password prompt when changing password and trivial check such as new and old passwords differ (auth backend said `false` anyway for such password change)

also includes sql patch to clear password for accounts where empty password was stored for whatever reason.