### PR TITLE
File Attachments Corrupted when mbstring Overloading is Enabled

### DIFF
--- a/htdocs/csv.php
+++ b/htdocs/csv.php
@@ -45,5 +45,5 @@ header('Cache-Control: must-revalidate, post-check=0,pre-check=0');
 
 $filename = uniqid('csv') . '.xls';
 $mimetype = 'application/vnd.ms-excel';
-$filesize = strlen($csv);
+$filesize = Misc::countBytes($csv);
 Attachment::outputDownload($csv, $filename, $filesize, $mimetype);

--- a/htdocs/get_attachment.php
+++ b/htdocs/get_attachment.php
@@ -38,12 +38,12 @@ if (@$_GET['cat'] == 'blocked_email') {
     $email = Support::getFullEmail($_GET['sup_id']);
 }
 if (!empty($_GET['raw'])) {
-    Attachment::outputDownload($email, 'message.eml', strlen($email), 'message/rfc822');
+    Attachment::outputDownload($email, 'message.eml', Misc::countBytes($email), 'message/rfc822');
 } else {
     if (!empty($_GET['cid'])) {
         list($mimetype, $data) = Mime_Helper::getAttachment($email, $_GET['filename'], $_GET['cid']);
     } else {
         list($mimetype, $data) = Mime_Helper::getAttachment($email, $_GET['filename']);
     }
-    Attachment::outputDownload($data, $_GET['filename'], strlen($data), $mimetype);
+    Attachment::outputDownload($data, $_GET['filename'], Misc::countBytes($data), $mimetype);
 }

--- a/lib/eventum/class.attachment.php
+++ b/lib/eventum/class.attachment.php
@@ -504,7 +504,7 @@ class Attachment
             DB_Helper::getInstance()->query($stmt, array(
                 $attachment_id,
                 $filename,
-                strlen($blob),
+                Misc::countBytes($blob),
                 $filetype,
                 Date_Helper::getCurrentDateGMT(),
                 $blob,

--- a/upgrade/patches/36_iaf_filesize.sql
+++ b/upgrade/patches/36_iaf_filesize.sql
@@ -1,0 +1,7 @@
+# fix wrong iaf_filesize caused by mbstring overload
+# (or some other technical error)
+# https://github.com/eventum/eventum/pull/78
+
+update {{%issue_attachment_file}}
+    set iaf_filesize=length(iaf_file)
+    where iaf_filesize!=length(iaf_file);


### PR DESCRIPTION
fixes to file attachments corrupted when mbstring overloading is enabled. [LP#1494732](https://bugs.launchpad.net/eventum/+bug/1494732)