### PR TITLE
use zf2 config for setup config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,8 @@
 		"phplot/phplot": "~6.1.0",
 		"smarty-gettext/smarty-gettext": "~1.0",
 		"smarty/smarty": "~3.1.12",
-		"sphinx/php-sphinxapi": "2.0.*"
+		"sphinx/php-sphinxapi": "2.0.*",
+		"zendframework/zend-config": "2.4.*"
 	},
 	"conflict": {
 		"pear/pear-core-minimal": ">=1.10"

--- a/htdocs/manage/general.php
+++ b/htdocs/manage/general.php
@@ -44,27 +44,28 @@ if ($role_id < User::ROLE_REPORTER) {
 $tpl->assign('project_list', Project::getAll());
 
 if (@$_POST['cat'] == 'update') {
-    $setup = Setup::load();
-    $setup['tool_caption'] = $_POST['tool_caption'];
-    $setup['support_email'] = $_POST['support_email'];
-    $setup['description_email_0'] = $_POST['description_email_0'];
-    $setup['spell_checker'] = $_POST['spell_checker'];
-    $setup['irc_notification'] = $_POST['irc_notification'];
-    $setup['update'] = $_POST['update'];
-    $setup['closed'] = $_POST['closed'];
-    $setup['emails'] = $_POST['emails'];
-    $setup['files'] = $_POST['files'];
-    $setup['smtp'] = $_POST['smtp'];
-    $setup['open_signup'] = $_POST['open_signup'];
-    $setup['accounts_projects'] = isset($_POST['accounts_projects']) ? $_POST['accounts_projects'] : null;
-    $setup['accounts_role'] = isset($_POST['accounts_role']) ? $_POST['accounts_role'] : null;
-    $setup['subject_based_routing'] = $_POST['subject_based_routing'];
-    $setup['email_routing'] = $_POST['email_routing'];
-    $setup['note_routing'] = $_POST['note_routing'];
-    $setup['draft_routing'] = $_POST['draft_routing'];
-    $setup['email_error'] = $_POST['email_error'];
-    $setup['email_reminder'] = $_POST['email_reminder'];
-    $setup['handle_clock_in'] = $_POST['handle_clock_in'];
+    $setup = array(
+        'tool_caption' => $_POST['tool_caption'],
+        'support_email' => $_POST['support_email'],
+        'description_email_0' => $_POST['description_email_0'],
+        'spell_checker' => $_POST['spell_checker'],
+        'irc_notification' => $_POST['irc_notification'],
+        'update' => $_POST['update'],
+        'closed' => $_POST['closed'],
+        'emails' => $_POST['emails'],
+        'files' => $_POST['files'],
+        'smtp' => $_POST['smtp'],
+        'open_signup' => $_POST['open_signup'],
+        'accounts_projects' => isset($_POST['accounts_projects']) ? $_POST['accounts_projects'] : null,
+        'accounts_role' => isset($_POST['accounts_role']) ? $_POST['accounts_role'] : null,
+        'subject_based_routing' => $_POST['subject_based_routing'],
+        'email_routing' => $_POST['email_routing'],
+        'note_routing' => $_POST['note_routing'],
+        'draft_routing' => $_POST['draft_routing'],
+        'email_error' => $_POST['email_error'],
+        'email_reminder' => $_POST['email_reminder'],
+        'handle_clock_in' => $_POST['handle_clock_in'],
+    );
     $res = Setup::save($setup);
     $tpl->assign('result', $res);
 

--- a/htdocs/manage/general.php
+++ b/htdocs/manage/general.php
@@ -81,8 +81,10 @@ if (@$_POST['cat'] == 'update') {
                 Misc::MSG_NOTE_BOX),
     ));
 }
-$options = Setup::load(true);
-$tpl->assign('setup', $options);
-$tpl->assign('user_roles', User::getRoles(array('Customer')));
+
+$tpl->assign(array(
+    'setup' => Setup::load(),
+    'user_roles' => User::getRoles(array('Customer')),
+));
 
 $tpl->displayTemplate();

--- a/htdocs/manage/general.php
+++ b/htdocs/manage/general.php
@@ -44,6 +44,8 @@ if ($role_id < User::ROLE_REPORTER) {
 $tpl->assign('project_list', Project::getAll());
 
 if (@$_POST['cat'] == 'update') {
+    $smtp = $_POST['smtp'];
+    $smtp['auth'] = (bool)$smtp['auth'];
     $setup = array(
         'tool_caption' => $_POST['tool_caption'],
         'support_email' => $_POST['support_email'],
@@ -54,7 +56,7 @@ if (@$_POST['cat'] == 'update') {
         'closed' => $_POST['closed'],
         'emails' => $_POST['emails'],
         'files' => $_POST['files'],
-        'smtp' => $_POST['smtp'],
+        'smtp' => $smtp,
         'open_signup' => $_POST['open_signup'],
         'accounts_projects' => isset($_POST['accounts_projects']) ? $_POST['accounts_projects'] : null,
         'accounts_role' => isset($_POST['accounts_role']) ? $_POST['accounts_role'] : null,

--- a/htdocs/manage/monitor.php
+++ b/htdocs/manage/monitor.php
@@ -63,9 +63,11 @@ if (!empty($_POST['cat']) && $_POST['cat'] == 'update') {
     ));
 }
 
-$tpl->assign('enable_disable', array(
-    'enabled' => ev_gettext('Enabled'),
-    'disabled' => ev_gettext('Disabled'),
+$tpl->assign(array(
+    'enable_disable', array(
+        'enabled' => ev_gettext('Enabled'),
+        'disabled' => ev_gettext('Disabled'),
+    ),
     'setup' => Setup::load(),
 ));
 

--- a/htdocs/manage/monitor.php
+++ b/htdocs/manage/monitor.php
@@ -66,9 +66,7 @@ if (!empty($_POST['cat']) && $_POST['cat'] == 'update') {
 $tpl->assign('enable_disable', array(
     'enabled' => ev_gettext('Enabled'),
     'disabled' => ev_gettext('Disabled'),
+    'setup' => Setup::load(),
 ));
-
-$options = Setup::load(true);
-$tpl->assign('setup', $options);
 
 $tpl->displayTemplate();

--- a/htdocs/manage/monitor.php
+++ b/htdocs/manage/monitor.php
@@ -44,11 +44,12 @@ if ($role_id < User::ROLE_REPORTER) {
 $tpl->assign('project_list', Project::getAll());
 
 if (!empty($_POST['cat']) && $_POST['cat'] == 'update') {
-    $setup = Setup::load();
-    $setup['monitor']['diskcheck'] = $_POST['diskcheck'];
-    $setup['monitor']['paths'] = $_POST['paths'];
-    $setup['monitor']['ircbot'] = $_POST['ircbot'];
-    $res = Setup::save($setup);
+    $setup = array(
+        'diskcheck' => $_POST['diskcheck'],
+        'paths' => $_POST['paths'],
+        'ircbot' => $_POST['ircbot'],
+    );
+    $res = Setup::save(array('monitor' => $setup));
     Misc::mapMessages($res, array(
             1   =>  array(ev_gettext('Thank you, the setup information was saved successfully.'), Misc::MSG_INFO),
             -1  =>  array(ev_gettext(

--- a/htdocs/manage/scm.php
+++ b/htdocs/manage/scm.php
@@ -56,7 +56,7 @@ if (@$_POST['cat'] == 'update') {
                 Misc::MSG_NOTE_BOX),
     ));
 }
-$options = Setup::load(true);
-$tpl->assign('setup', $options);
+
+$tpl->assign('setup', Setup::load());
 
 $tpl->displayTemplate();

--- a/htdocs/manage/scm.php
+++ b/htdocs/manage/scm.php
@@ -41,11 +41,7 @@ if ($role_id < User::ROLE_REPORTER) {
 }
 
 if (@$_POST['cat'] == 'update') {
-    $setup = Setup::load();
-
-    $setup['scm_integration'] = $_POST['scm_integration'];
-
-    $res = Setup::save($setup);
+    $res = Setup::save(array('scm_integration' => $_POST['scm_integration']));
     $tpl->assign('result', $res);
 
     Misc::mapMessages($res, array(

--- a/htdocs/rss.php
+++ b/htdocs/rss.php
@@ -30,17 +30,10 @@
 
 require_once __DIR__ . '/../init.php';
 
-$setup = Setup::load();
-if (empty($setup['tool_caption'])) {
-    $setup['tool_caption'] = APP_NAME;
-}
-
 function sendAuthenticateHeader()
 {
-    global $setup;
-
     // FIXME: escape tool_caption properly
-    header('WWW-Authenticate: Basic realm="' . $setup['tool_caption'] . '"');
+    header('WWW-Authenticate: Basic realm="' . Misc::getToolCaption() . '"');
     header('HTTP/1.0 401 Unauthorized');
 }
 
@@ -180,7 +173,7 @@ Issue::getDescriptionByIssues($issues);
 $tpl->assign(array(
     'charset' => APP_CHARSET,
     'project_title' => Project::getName($filter['cst_prj_id']),
-    'setup' => $setup,
+    'setup' => Setup::load(),
     'filter' => $filter,
     'issues' => $issues,
 ));

--- a/htdocs/rss.php
+++ b/htdocs/rss.php
@@ -166,7 +166,8 @@ $options = array(
     'custom_field'  => $filter['cst_custom_field'],
     'search_type'   => $filter['cst_search_type'],
 );
-$issues = Search::getListing($filter['cst_prj_id'], $options, 0, 'ALL', true);
+
+$issues = Search::getListing($filter['cst_prj_id'], $options, 0, 'ALL');
 $issues = $issues['list'];
 Issue::getDescriptionByIssues($issues);
 

--- a/htdocs/setup/index.php
+++ b/htdocs/setup/index.php
@@ -537,17 +537,17 @@ function setup_database()
         throw new RuntimeException("Database setup failed on upgrade:<br/><tt>{$e->getMessage()}</tt><br/><br/>You may want run update script <tt>$upgrade_script</tt> manually");
     }
 
-    $setup = Setup::load();
     // write db name now that it has been created
-    $setup['database']['database'] = $_POST['db_name'];
+    $setup = array();
+    $setup['database'] = $_POST['db_name'];
 
     // substitute the appropriate values in config.php!!!
     if (@$_POST['alternate_user'] == 'yes') {
-        $setup['database']['username'] = $_POST['eventum_user'];
-        $setup['database']['password'] = $_POST['eventum_password'];
+        $setup['username'] = $_POST['eventum_user'];
+        $setup['password'] = $_POST['eventum_password'];
     }
 
-    Setup::save($setup);
+    Setup::save(array('database' => $setup));
 }
 
 function write_file($file, $contents)

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -79,10 +79,10 @@ class DB_Helper
      */
     public static function getConfig()
     {
-        $setup = &Setup::load();
+        $setup = Setup::load();
 
         if (isset($setup['database'])) {
-            $config = $setup['database'];
+            $config = $setup['database']->toArray();
         } else {
             // legacy: import from constants
             $config = array(
@@ -106,8 +106,7 @@ class DB_Helper
             );
 
             // save it back. this will effectively do the migration
-            $setup['database'] = $config;
-            Setup::save($setup);
+            Setup::save(array('database' => $config));
         }
 
         return $config;

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -6,7 +6,7 @@
 // +----------------------------------------------------------------------+
 // | Copyright (c) 2003 - 2008 MySQL AB                                   |
 // | Copyright (c) 2008 - 2010 Sun Microsystem Inc.                       |
-// | Copyright (c) 2011 - 2014 Eventum Team.                              |
+// | Copyright (c) 2011 - 2015 Eventum Team.                              |
 // |                                                                      |
 // | This program is free software; you can redistribute it and/or modify |
 // | it under the terms of the GNU General Public License as published by |
@@ -22,7 +22,7 @@
 // | along with this program; if not, write to:                           |
 // |                                                                      |
 // | Free Software Foundation, Inc.                                       |
-// | 51 Franklin Street, Suite 330                                          |
+// | 51 Franklin Street, Suite 330                                        |
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 // | Authors: João Prado Maia <jpm@mysql.com>                             |
@@ -33,7 +33,6 @@
  * Class to manage all tasks related to the DB abstraction module. This is only
  * useful to maintain a data dictionary of the current database schema tables.
  */
-
 class DB_Helper
 {
     /**
@@ -76,6 +75,8 @@ class DB_Helper
     /**
      * Get database config.
      * load it from setup, fall back to legacy config.php constants
+     *
+     * @return array
      */
     public static function getConfig()
     {
@@ -125,7 +126,7 @@ class DB_Helper
         try {
             $stmt = "show variables like 'max_allowed_packet'";
             $res = DB_Helper::getInstance(false)->getPair($stmt);
-            $max_allowed_packet = (int) $res['max_allowed_packet'];
+            $max_allowed_packet = (int)$res['max_allowed_packet'];
         } catch (DbException $e) {
         }
 
@@ -147,7 +148,7 @@ class DB_Helper
     public static function get_last_insert_id()
     {
         $stmt = 'SELECT last_insert_id()';
-        $res = (integer) DB_Helper::getInstance()->getOne($stmt);
+        $res = (integer)DB_Helper::getInstance()->getOne($stmt);
 
         return $res;
     }
@@ -171,7 +172,7 @@ class DB_Helper
         }
 
         if ($add_quotes) {
-            $res = "'". $res . "'";
+            $res = "'" . $res . "'";
         }
 
         return $res;
@@ -236,7 +237,8 @@ class DB_Helper
         }
 
         // this is crazy, but it does work. Anyone with a better solution email balsdorf@gmail.com
-        $sql = "((UNIX_TIMESTAMP($end_date_field) - UNIX_TIMESTAMP($start_date_field)) - (CASE
+        $sql
+            = "((UNIX_TIMESTAMP($end_date_field) - UNIX_TIMESTAMP($start_date_field)) - (CASE
             WHEN DAYOFWEEK($start_date_field) = 1 THEN (floor(((TO_DAYS($end_date_field) - TO_DAYS($start_date_field))-1)/7) * 86400 * 2)
             WHEN DAYOFWEEK($start_date_field) = 2 THEN (floor(((TO_DAYS($end_date_field) - TO_DAYS($start_date_field)))/7) * 86400 *2)
             WHEN DAYOFWEEK($start_date_field) = 3 THEN (floor(((TO_DAYS($end_date_field) - TO_DAYS($start_date_field))+1)/7) * 86400 *2)
@@ -261,7 +263,7 @@ class DB_Helper
     {
         /** @var $e PEAR_Error */
         Error_Handler::logError(array($e->getMessage(), $e->getDebugInfo()), __FILE__, __LINE__);
-        /** @global $error_type  */
+        /** @global $error_type */
         $error_type = 'db';
         require_once APP_PATH . '/htdocs/offline.php';
         exit(2);

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -322,9 +322,6 @@ class Mail_Helper
     {
         $settings = Setup::load();
 
-        // TODO: fix places that require this instead
-        $settings['smtp']['auth'] = (bool)$settings['smtp']['auth'];
-
         if (file_exists('/etc/mailname')) {
             $settings['smtp']['localhost'] = trim(file_get_contents('/etc/mailname'));
         }

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -321,7 +321,10 @@ class Mail_Helper
     public static function getSMTPSettings()
     {
         $settings = Setup::load();
-        settype($settings['smtp']['auth'], 'boolean');
+
+        // TODO: fix places that require this instead
+        $settings['smtp']['auth'] = (bool)$settings['smtp']['auth'];
+
         if (file_exists('/etc/mailname')) {
             $settings['smtp']['localhost'] = trim(file_get_contents('/etc/mailname'));
         }
@@ -619,6 +622,7 @@ class Mail_Helper
      * Method used to save a copy of the given email to a configurable address.
      *
      * @param   array $email The email to save.
+     * @return bool
      */
     public static function saveOutgoingEmailCopy(&$email)
     {

--- a/lib/eventum/class.scm.php
+++ b/lib/eventum/class.scm.php
@@ -246,17 +246,6 @@ class SCM
 
         $setup = Setup::load();
 
-        // handle legacy setup, convert existing config to be known under name 'default'
-        if (!isset($setup['scm'])) {
-            $scm = array(
-                'name' => 'default',
-                'checkout_url' => $setup['checkout_url'],
-                'diff_url' => $setup['diff_url'],
-                'log_url' => $setup['scm_log_url'],
-            );
-            Setup::save(array('scm' => array($scm['name'] => $scm)));
-        }
-
         if (!isset($setup['scm'][$scm_name])) {
             throw new Exception("SCM '$scm_name' not defined");
         }

--- a/lib/eventum/class.scm.php
+++ b/lib/eventum/class.scm.php
@@ -244,7 +244,7 @@ class SCM
             return $instances[$scm_name];
         }
 
-        $setup = &Setup::load();
+        $setup = Setup::load();
 
         // handle legacy setup, convert existing config to be known under name 'default'
         if (!isset($setup['scm'])) {
@@ -254,8 +254,7 @@ class SCM
                 'diff_url' => $setup['diff_url'],
                 'log_url' => $setup['scm_log_url'],
             );
-            $setup['scm'][$scm['name']] = $scm;
-            Setup::save($setup);
+            Setup::save(array('scm' => array($scm['name'] => $scm)));
         }
 
         if (!isset($setup['scm'][$scm_name])) {

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -40,13 +40,12 @@ class Setup
     /**
      * Method used to load the setup options for the application.
      *
-     * @param bool $reload If the data should be forced to be loaded again.
      * @return Config The system-wide preferences
      */
-    public static function load($reload = false)
+    public static function load()
     {
         static $config;
-        if (!$config || $reload == true) {
+        if (!$config) {
             $config = self::initialize();
         }
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -29,6 +29,8 @@
 // | Authors: Elan Ruusamäe <glen@delfi.ee>                               |
 // +----------------------------------------------------------------------+
 
+use Zend\Config\Config;
+
 /**
  * Class to handle the business logic related to setting and updating
  * the setup information of the system.
@@ -38,29 +40,46 @@ class Setup
     /**
      * Method used to load the setup options for the application.
      *
-     * @param   boolean $force If the data should be forced to be loaded again.
-     * @return  array The system-wide preferences
+     * @param bool $reload If the data should be forced to be loaded again.
+     * @return Config The system-wide preferences
      */
-    public static function &load($force = false)
+    public static function load($reload = false)
     {
-        static $setup;
-        if (!$setup || $force == true) {
-            $setup = self::loadConfig(APP_SETUP_FILE, self::getDefaults());
+        static $config;
+        if (!$config || $reload == true) {
+            $config = self::initialize();
         }
 
-        return $setup;
+        return $config;
+    }
+
+    /**
+     * Set options to system config.
+     * The changes are not stored to disk.
+     *
+     * @param array $options
+     * @return Config returns the root config object
+     */
+    public static function set($options)
+    {
+        $config = self::load();
+        $config->merge(new Config($options));
+
+        return $config;
     }
 
     /**
      * Method used to save the setup options for the application.
+     * The $options are merged with existing config and then saved.
      *
-     * @param   array $options The system-wide preferences
-     * @return  integer 1 if the update worked, -1 or -2 otherwise
+     * @param array $options Options to modify (does not need to be full setup)
+     * @return integer 1 if the update worked, -1 or -2 otherwise
      */
-    public static function save($options)
+    public static function save($options = array())
     {
+        $config = self::set($options);
         try {
-            self::saveConfig(APP_SETUP_FILE, $options);
+            self::saveConfig(APP_SETUP_FILE, $config);
         } catch (Exception $e) {
             $code = $e->getCode();
             error_log($e->getMessage());
@@ -73,16 +92,32 @@ class Setup
     }
 
     /**
-     * Load config from $path and merge with $defaults.
+     * Initialize config object, load it from setup file, merge defaults.
+     *
+     * @return Config
+     */
+    private static function initialize()
+    {
+        $config = new Config(self::getDefaults(), true);
+        $config->merge(new Config(self::loadConfigFile(APP_SETUP_FILE, $migrate)));
+
+        if ($migrate) {
+            // save config in new format
+            self::saveConfig(APP_SETUP_FILE, $config);
+        }
+
+        return $config;
+    }
+
+    /**
+     * Load config from $path.
      * Config file should return configuration array.
      *
      * @param string $path
-     * @param array $defaults
      * @return array
      */
-    private static function loadConfig($path, $defaults)
+    private static function loadConfigFile($path, &$migrate)
     {
-        $migrate = false;
         $eventum_setup_string = $eventum_setup = null;
 
         // config array is supposed to be returned from that path
@@ -91,23 +126,12 @@ class Setup
         // fall back to old modes:
         // 1. $eventum_setup string
         // 2. base64 encoded $eventum_setup_string
-        // TODO: save it over so the support could be removed soon
         if (isset($eventum_setup)) {
             $config = $eventum_setup;
             $migrate = true;
         } elseif (isset($eventum_setup_string)) {
             $config = unserialize(base64_decode($eventum_setup_string));
             $migrate = true;
-        }
-
-        if ($migrate) {
-            // save config in new format
-            Setup::save($config);
-        }
-
-        // merge with defaults
-        if ($defaults) {
-            $config = Misc::array_extend($defaults, $config);
         }
 
         return $config;
@@ -117,9 +141,9 @@ class Setup
      * Save config to filesystem
      *
      * @param string $path
-     * @param array $config
+     * @param Config $config
      */
-    private static function saveConfig($path, $config)
+    private static function saveConfig($path, Config $config)
     {
         // if file exists, the file must be writable
         if (file_exists($path)) {
@@ -145,12 +169,12 @@ class Setup
     /**
      * Export config in a format to be stored to config file
      *
-     * @param array $config
+     * @param Config $config
      * @return string
      */
-    private static function dumpConfig($config)
+    private static function dumpConfig(Config $config)
     {
-        return '<' . "?php\nreturn " . var_export($config, 1) . ";\n";
+        return '<' . "?php\nreturn " . var_export($config->toArray(), 1) . ";\n";
     }
 
     /**
@@ -158,7 +182,7 @@ class Setup
      *
      * @return  string array of the default preferences
      */
-    public static function getDefaults()
+    private static function getDefaults()
     {
         $defaults = array(
             'monitor' => array(

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -85,7 +85,7 @@ class Abstract_Workflow_Backend
         $name = $this->getWorkflowName();
         $setup = Setup::load();
 
-        if (isset($setup['workflow'])) {
+        if (!isset($setup['workflow'])) {
             $setup['workflow'] = array();
         }
 

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -55,20 +55,9 @@ class Abstract_Workflow_Backend
      */
 
     /**
-     * array to hold workflow settings, best accessed via ->getConfig()
+     * hold workflow settings, best accessed via ->getConfig()
      */
-    protected $config = array();
-
-    /**
-     * Copy of whole loaded setup, needed if you need to save Setup data within workflow
-     * TODO: this would not be probably needed if Setup is not static.
-     */
-    private $config_setup_copy;
-
-    /**
-     * set to true by loadConfig() after loading workflow configuration variables
-     */
-    private $configLoaded = false;
+    protected $config = null;
 
     /**
      * use this function to access workflow configuration variables
@@ -78,7 +67,7 @@ class Abstract_Workflow_Backend
      */
     protected function getConfig($option)
     {
-        if (!$this->configLoaded) {
+        if (!isset($this->config)) {
             $this->loadConfig();
         }
 
@@ -95,17 +84,23 @@ class Abstract_Workflow_Backend
         $defaults = $this->getConfigDefaults();
         $name = $this->getWorkflowName();
         $setup = Setup::load();
-        $this->config_setup_copy = &$setup;
 
-        foreach ($defaults as $key => $value) {
-            if (isset($setup['workflow'][$name][$key])) {
-                continue;
-            }
-            $setup['workflow'][$name][$key] = $value;
+        if (isset($setup['workflow'])) {
+            $setup['workflow'] = array();
         }
 
-        $this->configLoaded = true;
-        $this->config = &$setup['workflow'][$name];
+        // create copy, this avoids the "indirect" error
+        $config = $setup['workflow'][$name];
+        // merge defaults
+        foreach ($defaults as $key => $value) {
+            if (isset($config[$key])) {
+                continue;
+            }
+            $config[$key] = $value;
+        }
+
+        // save back to config tree
+        $this->config = $setup['workflow'][$name] = $config;
     }
 
     /**
@@ -114,11 +109,11 @@ class Abstract_Workflow_Backend
      */
     protected function saveConfig()
     {
-        if (!$this->configLoaded || !$this->config_setup_copy) {
+        if (!isset($this->config)) {
             return;
         }
 
-        Setup::save($this->config_setup_copy);
+        Setup::save();
     }
 
     /**

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -42,8 +42,28 @@ class ConfigTest extends PHPUnit_Framework_TestCase
 
         $config = Setup::load();
         $this->assertEquals('one', $config->item1, "config change is present");
+    }
 
-        $config = Setup::load(true);
-        $this->assertNull($config->item1, "config is now lost");
+    /**
+     * @see Mail_Helper::getSMTPSettings does this weird settype:
+     * settype($config['smtp']['auth'], 'boolean');
+     * that does not work (Indirect modification error),
+     * so test version that works
+     */
+    public function testSetType()
+    {
+        $config = Setup::load();
+
+        $config['smtp'] = array(
+            'from' => 'admin@example.org',
+            'host' => 'localhost',
+            'port' => '25',
+            'auth' => '0',
+        );
+
+        $this->assertSame('0', $config['smtp']['auth']);
+
+        $config['smtp']['auth']= (bool)$config['smtp']['auth'];
+        $this->assertFalse($config['smtp']['auth']);
     }
 }

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -1,0 +1,49 @@
+<?php
+
+class ConfigTest extends PHPUnit_Framework_TestCase
+{
+    public function testConfig()
+    {
+        $config = Setup::load();
+
+        $config['item1'] = 'one';
+        $this->assertEquals('one', $config['item1'], "config as array set works");
+        $config->item2 = 'two';
+        $this->assertEquals('two', $config['item2'], "config as object set works");
+
+        $this->assertNull($config->nokey, "accessing keys that don't exist is fine");
+        $this->assertNull($config['nokey'], "accessing keys that don't exist is fine with arrays too");
+
+        // these will fail if 'smtp' key is missing
+        // "Indirect modification of overloaded property" is the error
+        //$config->smtp->host = 'localhost';
+        //$config['smtp']['host'] = 'localhost';
+
+        $this->assertNull($config['noentry']['host'], 'Can access inaccessible parent as array');
+        //$this->assertNull($config->noentry->host, 'Can not access inaccessible parent as object');
+
+        $this->assertTrue(empty($config->noentry->host), "can do empty checks on inaccessible parents");
+        $this->assertFalse(isset($config->noentry->host), "can do isset checks on inaccessible parents");
+        $this->assertTrue(empty($config['noentry']['host']), "can do empty checks on inaccessible parents");
+        $this->assertFalse(isset($config['noentry']['host']), "can do isset checks on inaccessible parents");
+
+        // this avoids the "indirect" error
+        $tmp = $config->group;
+        $tmp['param3'] = 'value';
+        $config->group = $tmp;
+        $this->assertEquals('value', $config->group->param3);
+
+        // but this is better:
+        // set multilevel entries works
+        $array['smtp']['host'] = 'localhost';
+        Setup::set($array);
+        $this->assertEquals(300, $config->issue_lock, "the other entries are not lost");
+        $this->assertEquals('localhost', $config->smtp->host, "config change is present");
+
+        $config = Setup::load();
+        $this->assertEquals('one', $config->item1, "config change is present");
+
+        $config = Setup::load(true);
+        $this->assertNull($config->item1, "config is now lost");
+    }
+}

--- a/tests/IssueLockTest.php
+++ b/tests/IssueLockTest.php
@@ -10,7 +10,7 @@ class IssueLockTest extends PHPUnit_Framework_TestCase {
         $locker = 'admin';
         $locker2 = 'user';
 
-        $setup = &Setup::load();
+        $setup = Setup::load();
         $setup['issue_lock'] = 2;
 
         $res = Issue_Lock::acquire($issue_id, $locker);

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -78,7 +78,7 @@ if (!file_exists(APP_SETUP_FILE)) {
 
 if (!getenv('TRAVIS')) {
     // init these from setup file
-    $setup = &Setup::load(true);
+    $setup = Setup::load();
 
     // used for tests
     define('APP_ADMIN_USER_ID', $setup['admin_user']);

--- a/upgrade/patches/33_set_required_fields.php
+++ b/upgrade/patches/33_set_required_fields.php
@@ -1,8 +1,9 @@
 <?php
-
 /**
  * Set required fields to match old default configuration
  */
+
+/** @var DbInterface $db */
 
 $setup = Setup::load();
 

--- a/upgrade/patches/38_config.php
+++ b/upgrade/patches/38_config.php
@@ -21,3 +21,6 @@ if (!isset($setup['scm'])) {
 
 // 2. fix smtp.auth boolean cast
 $setup['smtp']['auth'] = (bool)$setup['smtp']['auth'];
+
+// save it back
+Setup::save();

--- a/upgrade/patches/38_config.php
+++ b/upgrade/patches/38_config.php
@@ -1,0 +1,20 @@
+<?php
+/*
+ * Migrate config to new schema
+ */
+
+$setup = Setup::load();
+
+// scm config
+// handle legacy setup, convert existing config to be known under name 'default'
+if (!isset($setup['scm'])) {
+    $scm = array(
+        'name' => 'default',
+        'checkout_url' => $setup['checkout_url'],
+        'diff_url' => $setup['diff_url'],
+        'log_url' => $setup['scm_log_url'],
+    );
+    Setup::save(array('scm' => array($scm['name'] => $scm)));
+}
+
+// note: db config migration can't be done due simple chicken-egg problem ;)

--- a/upgrade/patches/38_config.php
+++ b/upgrade/patches/38_config.php
@@ -5,7 +5,9 @@
 
 $setup = Setup::load();
 
-// scm config
+// NOTE: db config migration can't be done due simple chicken-egg problem ;)
+
+// 1. scm config
 // handle legacy setup, convert existing config to be known under name 'default'
 if (!isset($setup['scm'])) {
     $scm = array(
@@ -17,4 +19,5 @@ if (!isset($setup['scm'])) {
     Setup::save(array('scm' => array($scm['name'] => $scm)));
 }
 
-// note: db config migration can't be done due simple chicken-egg problem ;)
+// 2. fix smtp.auth boolean cast
+$setup['smtp']['auth'] = (bool)$setup['smtp']['auth'];


### PR DESCRIPTION
besides dual usage (via object and array),
the Setup::save takes only keys you want to modify, no need for Setup::load
and if you modify the retrieved setup, the in-memory version is modified too.

using zf2 lts version (2.4)