### PR TITLE
add DebugBar debug bar

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -92,6 +92,7 @@
 		"jackmoore/autosize":"*",
 		"jasig/phpcas":"~1.3.3",
 		"malsup/form" :"*",
+		"maximebf/debugbar": "1.*",
 		"roave/security-advisories": "dev-master",
 		"symfony/var-dumper": "~2.7.3"
 	},

--- a/init.php
+++ b/init.php
@@ -168,3 +168,8 @@ if (!defined('APP_DEFAULT_DB') || !defined('APP_TABLE_PREFIX')) {
     unset($dbconfig);
 }
 */
+
+use DebugBar\StandardDebugBar;
+
+$debugbar = new StandardDebugBar();
+$debugbar["messages"]->addMessage("hello world!");

--- a/init.php
+++ b/init.php
@@ -169,7 +169,7 @@ if (!defined('APP_DEFAULT_DB') || !defined('APP_TABLE_PREFIX')) {
 }
 */
 
-use DebugBar\StandardDebugBar;
-
-$debugbar = new StandardDebugBar();
-$debugbar["messages"]->addMessage("hello world!");
+// setup debugbar, if it can be autoloaded
+if (class_exists('DebugBar\StandardDebugBar')) {
+    $debugbar = new DebugBar\StandardDebugBar();
+}

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -281,11 +281,21 @@ class Template_Helper
         $debugbar->addCollector(
             new DebugBar\DataCollector\ConfigCollector($this->smarty->tpl_vars, 'Smarty')
         );
+        $debugbar->addCollector(
+            new DebugBar\DataCollector\ConfigCollector(Setup::get()->toArray(), 'Config')
+        );
         $debugbarRenderer = $debugbar->getJavascriptRenderer("{$rel_url}debugbar");
         $debugbarRenderer->addControl(
             'Smarty', array(
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'Smarty',
+                'default' => '[]'
+            )
+        );
+        $debugbarRenderer->addControl(
+            'Smarty', array(
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'Config',
                 'default' => '[]'
             )
         );

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -253,8 +253,12 @@ class Template_Helper
         }
         $this->assign('core', $core);
 
+        // setup debugbar:
+        // - if initialized
+        // - if role_id is set
+        // - if user is administrator
         global $debugbar;
-        if ($debugbar) {
+        if ($debugbar && $role_id && $role_id >= User::ROLE_ADMINISTRATOR) {
             $debugbar->addCollector(
                 new DebugBar\DataCollector\ConfigCollector($this->smarty->tpl_vars, 'Smarty')
             );

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -293,7 +293,7 @@ class Template_Helper
             )
         );
         $debugbarRenderer->addControl(
-            'Smarty', array(
+            'Config', array(
                 'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
                 'map' => 'Config',
                 'default' => '[]'

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -165,6 +165,7 @@ class Template_Helper
 
     /**
      * Processes the template and assign common variables automatically.
+     *
      * @return $this
      */
     private function processTemplate()
@@ -251,6 +252,24 @@ class Template_Helper
             $this->assign('roles', User::getAssocRoleIDs());
         }
         $this->assign('core', $core);
+
+        global $debugbar;
+        if ($debugbar) {
+            $debugbar->addCollector(
+                new DebugBar\DataCollector\ConfigCollector($this->smarty->tpl_vars, 'Smarty')
+            );
+            $debugbarRenderer = $debugbar->getJavascriptRenderer("{$core['rel_url']}debugbar");
+            $debugbarRenderer->addControl(
+                'Smarty', array(
+                    'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                    'map' => 'Smarty',
+                    'default' => '[]'
+                )
+            );
+
+            $this->assign('debugbar_head', $debugbarRenderer->renderHead());
+            $this->assign('debugbar_body', $debugbarRenderer->render());
+        }
 
         return $this;
     }

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -253,28 +253,44 @@ class Template_Helper
         }
         $this->assign('core', $core);
 
-        // setup debugbar:
-        // - if initialized
-        // - if role_id is set
-        // - if user is administrator
-        global $debugbar;
-        if ($debugbar && $role_id && $role_id >= User::ROLE_ADMINISTRATOR) {
-            $debugbar->addCollector(
-                new DebugBar\DataCollector\ConfigCollector($this->smarty->tpl_vars, 'Smarty')
-            );
-            $debugbarRenderer = $debugbar->getJavascriptRenderer("{$core['rel_url']}debugbar");
-            $debugbarRenderer->addControl(
-                'Smarty', array(
-                    'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
-                    'map' => 'Smarty',
-                    'default' => '[]'
-                )
-            );
-
-            $this->assign('debugbar_head', $debugbarRenderer->renderHead());
-            $this->assign('debugbar_body', $debugbarRenderer->render());
-        }
+        $this->addDebugbar(isset($role_id) ? $role_id : null);
 
         return $this;
+    }
+
+    /**
+     * Setup Debug Bar:
+     * - if initialized
+     * - if role_id is set
+     * - if user is administrator
+     *
+     * @throws \DebugBar\DebugBarException
+     */
+    private function addDebugbar($role_id)
+    {
+        if (!$role_id || $role_id < User::ROLE_ADMINISTRATOR) {
+            return;
+        }
+
+        global $debugbar;
+        if (!$debugbar) {
+            return;
+        }
+
+        $rel_url = APP_RELATIVE_URL;
+        $debugbar->addCollector(
+            new DebugBar\DataCollector\ConfigCollector($this->smarty->tpl_vars, 'Smarty')
+        );
+        $debugbarRenderer = $debugbar->getJavascriptRenderer("{$rel_url}debugbar");
+        $debugbarRenderer->addControl(
+            'Smarty', array(
+                'widget' => 'PhpDebugBar.Widgets.VariableListWidget',
+                'map' => 'Smarty',
+                'default' => '[]'
+            )
+        );
+
+        $this->assign('debugbar_head', $debugbarRenderer->renderHead());
+        $this->assign('debugbar_body', $debugbarRenderer->render());
     }
 }

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -46,7 +46,7 @@
   {* allow pages to inject to <head> block *}
   {block "stylesheets"}{/block}
   {block "javascripts"}{/block}
-  {$debugbar_head}
+  {$debugbar_head|default:''}
 
   {* local directory can add overrides *}
   {include file="extra_header.tpl.html"}
@@ -72,7 +72,7 @@
     </div>
 
     {block "footer"}{/block}
-    {$debugbar_body}
+    {$debugbar_body|default:''}
 </div>
 </body>
 </html>

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -46,6 +46,7 @@
   {* allow pages to inject to <head> block *}
   {block "stylesheets"}{/block}
   {block "javascripts"}{/block}
+  {$debugbar_head}
 
   {* local directory can add overrides *}
   {include file="extra_header.tpl.html"}
@@ -71,6 +72,7 @@
     </div>
 
     {block "footer"}{/block}
+    {$debugbar_body}
 </div>
 </body>
 </html>


### PR DESCRIPTION
adds add [DebugBar](http://phpdebugbar.com/) debug bar.

currently exposes:
- [x] Smarty variables
- [x] Setup config

the toolbar is enabled if:
- `DebugBar\StandardDebugBar` class can be loaded (`composer install --dev`)
- user level is administrator

the protection is made because debugbar can (and will) reveal sensitive information and should not be used in production nodes in regular basis.