### PR TITLE
Update custom fields from update issue page

### DIFF
--- a/htdocs/close.php
+++ b/htdocs/close.php
@@ -60,7 +60,7 @@ $tpl->assign('notification_list_internal', $notification_list_internal['all']);
 
 $cat = isset($_REQUEST['cat']) ? (string) $_REQUEST['cat'] : null;
 if ($cat == 'close') {
-    Custom_Field::updateValues();
+    Custom_Field::updateFromPost();
     $res = Issue::close(Auth::getUserID(), $issue_id, $_REQUEST['send_notification'], $_REQUEST['resolution'], $_REQUEST['status'], $_REQUEST['reason'], @$_REQUEST['notification_list']);
 
     if (!empty($_POST['time_spent'])) {

--- a/htdocs/custom_fields.php
+++ b/htdocs/custom_fields.php
@@ -44,7 +44,10 @@ if (!Issue::canUpdate($issue_id, Auth::getUserID())) {
 }
 
 if (@$_POST['cat'] == 'update_values') {
-    $res = Custom_Field::updateValues();
+    $res = Custom_Field::updateFromPost(true);
+    if (is_array($res)) {
+        $res = 1;
+    }
     $tpl->assign('update_result', $res);
 }
 

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -471,7 +471,7 @@ Validation.selectField = function(field)
 
 Validation.showErrorIcon = function(field, show)
 {
-    var icon = $('#error_icon_' + field.attr('name'));
+    var icon = $('#error_icon_' + Eventum.escapeSelector(field.attr('name')));
     if (icon.length == 0) {
         return false;
     }

--- a/htdocs/js/page.js
+++ b/htdocs/js/page.js
@@ -264,8 +264,6 @@ issue_view.ready = function(page_id)
     $('#upload_file').click(issue_view.upload_file);
     $('#attachments .delete_attachment').click(issue_view.delete_attachment);
     $('#attachments .delete_file').click(issue_view.delete_file);
-
-    $('#update_custom_fields').click(issue_view.updateCustomFields);
 };
 
 issue_view.toggle_issue_description = function()

--- a/htdocs/manage/custom_fields.php
+++ b/htdocs/manage/custom_fields.php
@@ -53,6 +53,7 @@ if (@$_POST['cat'] == 'new') {
             1   =>  array(ev_gettext('Thank you, the custom field was updated successfully.'), Misc::MSG_INFO),
             -1  =>  array(ev_gettext('An error occurred while trying to update the custom field information.'), Misc::MSG_ERROR),
     ));
+    Auth::redirect(APP_RELATIVE_URL . "manage/custom_fields.php");
 } elseif (@$_POST['cat'] == 'delete') {
     $res = Custom_Field::remove();
     Misc::mapMessages($res, array(

--- a/htdocs/update.php
+++ b/htdocs/update.php
@@ -311,6 +311,7 @@ $tpl->assign('issue_lock', $issue_lock);
         'current_year' =>   date('Y'),
         'products'     => Product::getList(false),
         'grid'         => $columns,
+        'custom_fields'=> Custom_Field::getListByIssue($prj_id, $issue_id, $usr_id)
     ));
 
 $tpl->assign('usr_role_id', User::getRoleByUser($usr_id, $prj_id));

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -34,6 +34,9 @@
 
 class Custom_Field
 {
+
+    public static $option_types = array('combo', 'multiple', 'checkbox');
+
     /**
      * Method used to remove a group of custom field options.
      *
@@ -130,21 +133,35 @@ class Custom_Field
         return true;
     }
 
+
+    /**
+     * Updates custom field values from the $_POST array.
+     */
+    public static function updateFromPost($send_notification = false)
+    {
+        if (isset($_POST['custom_fields'])) {
+            $updated_fields = self::updateValues($_POST['issue_id'], $_POST['custom_fields']);
+            if ($send_notification) {
+                Notification::notifyIssueUpdated($_POST['issue_id'], array(), array(), $updated_fields);
+            }
+            return $updated_fields;
+        }
+    }
+
     /**
      * Method used to update the values stored in the database.
      *
-     * @return  integer 1 if the update worked properly, any other value otherwise
+     * @param $issue_id
+     * @param $custom_fields
+     * @return array|int -1 if there is an error, otherwise an array of the updated fields
      */
-    public static function updateValues()
+    public static function updateValues($issue_id, $custom_fields)
     {
         $prj_id = Auth::getCurrentProject();
-        $issue_id = $_POST['issue_id'];
 
         $old_values = self::getValuesByIssue($prj_id, $issue_id);
 
-        if ((isset($_POST['custom_fields'])) && (count($_POST['custom_fields']) > 0)) {
-            $custom_fields = $_POST['custom_fields'];
-
+        if (count($custom_fields) > 0) {
             // get the types for all of the custom fields being submitted
             $cf = array_keys($custom_fields);
             $cf_list = DB_Helper::buildList($cf);
@@ -182,12 +199,15 @@ class Custom_Field
                     continue;
                 }
 
-                $option_types = array(
-                    'multiple',
-                    'combo',
-                    'checkbox',
+                $updated_fields[$fld_id] = array(
+                    'title' =>  $field_titles[$fld_id],
+                    'type'  =>  $field_types[$fld_id],
+                    'min_role'  =>  $min_role,
+                    'changes'   =>  '',
+                    'old_display'   =>  '',
+                    'new_display'   =>  '',
                 );
-                if (!in_array($field_types[$fld_id], $option_types)) {
+                if (!in_array($field_types[$fld_id], self::$option_types)) {
                     // check if this is a date field
                     $fld_db_name = self::getDBValueFieldNameByType($field_types[$fld_id]);
 
@@ -210,6 +230,7 @@ class Custom_Field
                     $old_value = $res['value'];
 
                     if ($old_value == $value) {
+                        unset($updated_fields[$fld_id]);
                         continue;
                     }
 
@@ -247,13 +268,20 @@ class Custom_Field
                             return -1;
                         }
                     }
+                    $updated_fields[$fld_id]['old_display'] = $old_value;
+                    $updated_fields[$fld_id]['new_display'] = $value;
                     if ($field_types[$fld_id] == 'textarea') {
-                        $updated_fields[$field_titles[$fld_id]] = '';
+                        $updated_fields[$fld_id]['changes'] = '';
                     } else {
-                        $updated_fields[$field_titles[$fld_id]] = History::formatChanges($old_value, $value);
+                        $updated_fields[$fld_id]['changes'] = History::formatChanges($old_value, $value);
                     }
                 } else {
                     $old_value = self::getDisplayValue($issue_id, $fld_id, true);
+
+                    // remove dummy value from checkboxes. This dummy value is required so all real values can be unchecked.
+                    if ($field_types[$fld_id] == 'checkbox') {
+                        $value = array_filter($value);
+                    }
 
                     if (!is_array($old_value)) {
                         $old_value = array($old_value);
@@ -270,7 +298,11 @@ class Custom_Field
                             self::associateIssue($issue_id, $fld_id, $value);
                         }
                         $new_display_value = self::getDisplayValue($issue_id, $fld_id);
-                        $updated_fields[$field_titles[$fld_id]] = History::formatChanges($old_display_value, $new_display_value);
+                        $updated_fields[$fld_id]['changes'] = History::formatChanges($old_display_value, $new_display_value);
+                        $updated_fields[$fld_id]['old_display'] = $old_display_value;
+                        $updated_fields[$fld_id]['new_display'] = $new_display_value;
+                    } else {
+                        unset($updated_fields[$fld_id]);
                     }
                 }
             }
@@ -278,33 +310,90 @@ class Custom_Field
             Workflow::handleCustomFieldsUpdated($prj_id, $issue_id, $old_values,
                 self::getValuesByIssue($prj_id, $issue_id), $updated_fields);
             Issue::markAsUpdated($issue_id);
-            // need to save a history entry for this
 
             if (count($updated_fields) > 0) {
                 // log the changes
-                $changes = '';
-                $i = 0;
-                foreach ($updated_fields as $key => $value) {
-                    if ($i > 0) {
-                        $changes .= '; ';
+                $changes = array();
+                foreach ($updated_fields as $fld_id => $updated_field) {
+                    if (!isset($changes[$updated_field['min_role']])) {
+                        $changes[$updated_field['min_role']] = array();
                     }
+                    $title = $updated_field['title'];
+                    $value = $updated_field['changes'];
+
                     if (!empty($value)) {
-                        $changes .= "$key: $value";
+                        $changes[$updated_field['min_role']][] = "$title: $value";
                     } else {
-                        $changes .= "$key";
+                        $changes[$updated_field['min_role']][] = $title;
                     }
-                    $i++;
                 }
 
                 $usr_id = Auth::getUserID();
-                History::add($issue_id, $usr_id, 'custom_field_updated', 'Custom field updated ({changes}) by {user}', array(
-                    'changes' => $changes,
-                    'user' => User::getFullName($usr_id)
-                ));
+                $usr_full_name = User::getFullName($usr_id);
+                foreach ($changes as $min_role => $role_changes) {
+                    History::add($issue_id, $usr_id, 'custom_field_updated', 'Custom field updated ({changes}) by {user}', array(
+                        'changes' => join('; ', $role_changes),
+                        'user' => $usr_full_name
+                    ), $min_role);
+                }
             }
+            return $updated_fields;
         }
 
-        return 1;
+        return array();
+    }
+
+    /**
+     * Returns custom field updates that are visible to the specified role
+     *
+     * @param   array $updated_fields
+     * @param   int $role
+     * @return  array
+     */
+    public static function getUpdatedFieldsForRole($updated_fields, $role)
+    {
+        $role_updates = array();
+        foreach ($updated_fields as $fld_id => $field) {
+            if ($role >= $field['min_role']) {
+                $role_updates[$fld_id] = $field;
+            }
+        }
+        return $role_updates;
+    }
+
+    /**
+     * Returns custom field updates in a diff format
+     *
+     * @param   array $updated_fields
+     * @param   bool $role If specified only fields that $role can see will be returned
+     * @return  array
+     */
+    public static function formatUpdatesToDiffs($updated_fields, $role=false)
+    {
+        if ($role) {
+            $updated_fields = self::getUpdatedFieldsForRole($updated_fields, $role);
+        }
+        $diffs = array();
+        foreach ($updated_fields as $fld_id => $field) {
+            if ($field['old_display'] != $field['new_display']) {
+                if ($field['type'] == 'textarea') {
+                    $old = explode("\n", $field['old_display']);
+                    $new = explode("\n", $field['new_display']);
+                    $diff = new Text_Diff($old, $new);
+                    $renderer = new Text_Diff_Renderer_unified();
+                    $desc_diff = explode("\n", trim($renderer->render($diff)));
+                    $diffs[] = $field['title'] . ':';
+                    foreach ($desc_diff as $diff) {
+                        $diffs[] = $diff;
+                    }
+                    $diffs[] = '';
+                } else {
+                    $diffs[] = '-' . $field['title'] . ': ' . $field['old_display'];
+                    $diffs[] = '+' . $field['title'] . ': ' . $field['new_display'];
+                }
+            }
+        }
+        return $diffs;
     }
 
     /**
@@ -327,7 +416,7 @@ class Custom_Field
             $params = array($iss_id, $fld_id);
             if ($fld_details['fld_type'] == 'integer') {
                 $params[] = $item;
-            } elseif ((in_array($fld_details['fld_type'], array('combo', 'multiple')) && ($item == -1))) {
+            } elseif ((in_array($fld_details['fld_type'], self::$option_types) && ($item == -1))) {
                 continue;
             } else {
                 $params[] = $item;
@@ -641,7 +730,7 @@ class Custom_Field
                 }
 
                 $fields[] = $row;
-            } elseif ($row['fld_type'] == 'multiple' || $row['fld_type'] == 'checkbox') {
+            } elseif (in_array($row['fld_type'], self::$option_types)) {
                 // check whether this field is already in the array
                 $found = 0;
                 foreach ($fields as $y => $field) {
@@ -714,7 +803,7 @@ class Custom_Field
                 $values[$field['fld_id']] = array(
                     $field['selected_cfo_id'] => $field['value'],
                 );
-            } elseif ($field['fld_type'] == 'multiple') {
+            } elseif ($field['fld_type'] == 'multiple' || $field['fld_type'] == 'checkbox') {
                 $selected = $field['selected_cfo_id'];
                 foreach ($selected as $cfo_id) {
                     $values[$field['fld_id']][$cfo_id] = @$field['field_options'][$cfo_id];
@@ -855,8 +944,7 @@ class Custom_Field
         }
 
         $new_id = DB_Helper::get_last_insert_id();
-        if (($_POST['field_type'] == 'combo') || ($_POST['field_type'] == 'multiple')
-             || ($_POST['field_type'] == 'checkbox')) {
+        if (in_array($_POST['field_type'], self::$option_types)) {
             foreach ($_POST['field_options'] as $option_value) {
                 $params = self::parseParameters($option_value);
                 self::addOptions($new_id, $params['value']);
@@ -918,7 +1006,7 @@ class Custom_Field
 
         foreach ($res as &$row) {
             $row['projects'] = @implode(', ', array_values(self::getAssociatedProjects($row['fld_id'])));
-            if (($row['fld_type'] == 'combo') || ($row['fld_type'] == 'multiple')) {
+            if (in_array($row['fld_type'], self::$option_types)) {
                 if (!empty($row['fld_backend'])) {
                     $row['field_options'] = implode(', ', array_values(self::getOptions($row['fld_id'])));
                 }
@@ -1162,7 +1250,7 @@ class Custom_Field
         }
 
         // if the current custom field is a combo box, get all of the current options
-        if (in_array($_POST['field_type'], array('combo', 'multiple'))) {
+        if (in_array($_POST['field_type'], self::$option_types)) {
             $stmt = 'SELECT
                         cfo_id
                      FROM
@@ -1175,7 +1263,7 @@ class Custom_Field
         if ($old_details['fld_type'] != $_POST['field_type']) {
             // gotta remove all custom field options if the field is being changed from a combo box to a text field
             if ((!in_array($old_details['fld_type'], array('text', 'textarea'))) &&
-                  (!in_array($_POST['field_type'], array('combo', 'multiple')))) {
+                  (!in_array($_POST['field_type'], self::$option_types))) {
                 self::removeOptionsByFields($_POST['id']);
             }
             if (in_array($_POST['field_type'], array('text', 'textarea', 'date', 'integer'))) {
@@ -1184,8 +1272,7 @@ class Custom_Field
             }
         }
         // update the custom field options, if any
-        if (($_POST['field_type'] == 'combo') || ($_POST['field_type'] == 'multiple') ||
-            ($_POST['field_type'] == 'checkbox')) {
+        if (in_array($_POST['field_type'], self::$option_types)) {
             $updated_options = array();
             foreach ($_POST['field_options'] as $option_value) {
                 $params = self::parseParameters($option_value);
@@ -1202,7 +1289,7 @@ class Custom_Field
         }
         // get the diff between the current options and the ones posted by the form
         // and then remove the options not found in the form submissions
-        if (in_array($_POST['field_type'], array('combo', 'multiple'))) {
+        if (in_array($_POST['field_type'], self::$option_types)) {
             $diff_ids = @array_diff($current_options, $updated_options);
             if (@count($diff_ids) > 0) {
                 self::removeOptions($_POST['id'], array_values($diff_ids));
@@ -1471,7 +1558,7 @@ class Custom_Field
 
         $values = array();
         foreach ($res as $row) {
-            if ($row['fld_type'] == 'combo' || $row['fld_type'] == 'multiple') {
+            if (in_array($row['fld_type'], self::$option_types)) {
                 if ($raw) {
                     $values[] = $row['value'];
                 } else {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1646,6 +1646,13 @@ class Issue
         if (isset($_POST['product']) && count($product_changes) > 0) {
             $updated_fields['Product'] = implode('; ', $product_changes);
         }
+
+        if (isset($_POST['custom_fields']) && count($_POST['custom_fields']) > 0) {
+            $updated_custom_fields = Custom_Field::updateValues($issue_id, $_POST['custom_fields']);
+        } else {
+            $updated_custom_fields = array();
+        }
+
         if (count($updated_fields) > 0) {
             // log the changes
             $changes = '';
@@ -1665,8 +1672,11 @@ class Issue
                 'changes' => $changes,
                 'user' => User::getFullName($usr_id)
             ));
+        }
+
+        if (count($updated_fields) > 0 || count($updated_custom_fields) > 0) {
             // send notifications for the issue being updated
-            Notification::notifyIssueUpdated($issue_id, $current, $_POST);
+            Notification::notifyIssueUpdated($issue_id, $current, $_POST, $updated_custom_fields);
         }
 
         // record group change as a separate change

--- a/lib/eventum/class.issue_field.php
+++ b/lib/eventum/class.issue_field.php
@@ -183,7 +183,7 @@ class Issue_Field
         $fields = self::getFieldsToDisplay($issue_id, $location);
         foreach ($fields as $field_name => $field_options) {
             if ($field_name == 'custom') {
-                Custom_Field::updateValues();
+                Custom_Field::updateFromPost();
             } else {
                 self::setValue($issue_id, $field_name, $values[$field_name]);
             }

--- a/templates/custom_fields.tpl.html
+++ b/templates/custom_fields.tpl.html
@@ -32,9 +32,10 @@
         </table>
     </div>
       {if $issue_access.update and $custom_fields != "" }
-      <form>
+      <form method="get" action="update.php">
+      <input type="hidden" name="id" value="{$issue.iss_id}">
       <div class="buttons">
-          <input type="button" value="{t}Update{/t}" id='update_custom_fields' data-issue-id="{$issue_id}">
+          <input type="submit" value="{t}Update Issue{/t}">
       </div>
       </form>
       {/if}

--- a/templates/edit_custom_fields.tpl.html
+++ b/templates/edit_custom_fields.tpl.html
@@ -19,7 +19,7 @@
     data-custom-title="{$custom_fields[i].fld_title}"
     data-custom-required="{$cf_required}"
     data-custom-validation-js="{$custom_fields[i].validation_js|default:''}">
-  <th>
+  <th class="{if $custom_fields[i].fld_min_role > $core.roles.customer}internal{/if}">
     {$custom_fields[i].fld_title}{if $cf_required} *{/if}
   </th>
   <td>
@@ -45,6 +45,7 @@
         {assign var="selected_cfo_ids" value=$custom_fields[i].selected_cfo_id|default:''}
       {/if}
       <ul class="custom_field_checkbox" id="custom_field_{$custom_fields[i].fld_id}">
+          <input type="hidden" name="custom_fields[{$custom_field_id}][]" value="" />
       {foreach $custom_fields[i].field_options as $key => $display}
           <li><label><input type="checkbox" name="custom_fields[{$custom_field_id}][]" value="{$key}"
                   {if in_array($key, $selected_cfo_ids)}checked{/if} />{$display}</label></li>

--- a/templates/history.tpl.html
+++ b/templates/history.tpl.html
@@ -15,7 +15,7 @@
       </tr>
       {section name="i" loop=$changes}
       <tr class="{cycle values='odd,even'}">
-        <th {if $changes[i].htt_role > $core.roles.customer}class="internal"{/if} nowrap>
+        <th {if $changes[i].his_min_role > $core.roles.customer}class="internal"{/if} nowrap>
           {$changes[i].his_created_date}
         </th>
         <td width="85%">

--- a/templates/notifications/updated.tpl.text
+++ b/templates/notifications/updated.tpl.text
@@ -12,7 +12,12 @@
           {t escape=no}Summary{/t}: {$data.iss_summary}
    {t escape=no}Changed Fields{/t}:
 ----------------------------------------------------------------------
+{if $data.diffs != ''}
 {$data.diffs}
+{/if}
+{if $data.custom_field_diffs != ''}
+{$data.custom_field_diffs}
+{/if}
 ----------------------------------------------------------------------
 
 {textformat style="email"}

--- a/templates/update_form.tpl.html
+++ b/templates/update_form.tpl.html
@@ -224,6 +224,8 @@
             <input type="hidden" name="trigger_reminders" value="{$issue.iss_trigger_reminders}">
             {/if}
 
+            {include file="edit_custom_fields.tpl.html" form_type='edit'}
+
             {if $core.has_crm}
             {include file="`$core.crm_template_path`/update_report_form_fields.tpl.html"}
             {/if}

--- a/upgrade/patches/40_history_role.php
+++ b/upgrade/patches/40_history_role.php
@@ -1,0 +1,13 @@
+<?php
+
+/**
+ * Add minimum role to history table and update old history entries
+ */
+$db->query('alter table {{%issue_history}} add `his_min_role` tinyint(1) NOT NULL DEFAULT 1');
+
+$res = $db->getAll("select htt_id, htt_role from {{%history_type}}");
+
+foreach ($res as $idx => $row) {
+    $params = array($row['htt_role'], $row['htt_id']);
+    $db->query('UPDATE {{%issue_history}} SET his_min_role=? WHERE his_htt_id=?', $params);
+}

--- a/upgrade/patches/40_history_role.php
+++ b/upgrade/patches/40_history_role.php
@@ -3,7 +3,7 @@
 /**
  * Add minimum role to history table and update old history entries
  */
-$db->query('alter table {{%issue_history}} add `his_min_role` tinyint(1) NOT NULL DEFAULT 1');
+$db->query('alter table {{%issue_history}} add `his_min_role` tinyint(1) NOT NULL DEFAULT ?', array(User::ROLE_VIEWER));
 
 $res = $db->getAll("select htt_id, htt_role from {{%history_type}}");
 


### PR DESCRIPTION
Custom fields are now included on the update issue page. During the implementation I fixed a bunch of little custom field related bugs.

* Include custom fields in update issue page.
* Fixed bug updating custom field definitions.
* Display admin only custom fields in 'internal' color.
* Fix bug unchecking checkbox custom fields.
* Include custom field changes in issue updated email.
* Fix data leakage problem with admin only custom fields by restricting history entries to correct role.
* Added minimum role to each history entry. If no role is specified it will default to role from history type.

Custom fields are displayed in a separate box, if we overhaul the UI we might want to include them with the rest of the issue details.