### PR TITLE
Issue 91 notice and IMAP missing error change

### DIFF
--- a/bin/download_emails.php
+++ b/bin/download_emails.php
@@ -131,8 +131,8 @@ function getParams()
 if (!function_exists('imap_open')) {
     fatal(
         'Eventum requires the IMAP extension in order to download messages saved on a IMAP/POP3 mailbox.',
-        'It is installed by default on some systems but must also be enabled. See INSTALL.md',
-        'Please refer to the PHP manual for more details about how to enable the IMAP extension.'
+        'See Prerequisites on the Wiki https://github.com/eventum/eventum/wiki/Prerequisites',
+        'Please refer to the PHP manual for more details about how to install and enable the IMAP extension.'
     );
 }
 

--- a/bin/download_emails.php
+++ b/bin/download_emails.php
@@ -131,6 +131,7 @@ function getParams()
 if (!function_exists('imap_open')) {
     fatal(
         'Eventum requires the IMAP extension in order to download messages saved on a IMAP/POP3 mailbox.',
+        'It is installed by default on some systems but must also be enabled. See INSTALL.md',
         'Please refer to the PHP manual for more details about how to enable the IMAP extension.'
     );
 }

--- a/htdocs/manage/check_email_settings.php
+++ b/htdocs/manage/check_email_settings.php
@@ -46,7 +46,7 @@ if (!function_exists('imap_open')) {
             'ema_hostname' => $_POST['hostname'],
             'ema_port'     => $_POST['port'],
             'ema_type'     => $_POST['type'],
-            'ema_folder'   => isset($_POST['folder']) ? $_POST['folder'] : null,
+            'ema_folder'   => Misc::ifSet($_POST, 'folder'),
             'ema_username' => $_POST['username'],
             'ema_password' => $_POST['password'],
         );

--- a/templates/get_emails.tpl.html
+++ b/templates/get_emails.tpl.html
@@ -10,8 +10,9 @@
 
   {if $error == "imap_extension_missing"}
     <b>Error: Eventum requires the IMAP extension in order to connect to IMAP/POP3 servers.<br /><br />
-    It is installed by default on some systems but must also be enabled. See INSTALL.md <br /><br />
-    Please refer to the PHP manual for more details about how to enable the IMAP extension.</b>
+    It is installed by default on some systems but must also be enabled. <br />
+    See <a href="https://github.com/eventum/eventum/wiki/Prerequisites">Prerequisites (Wiki)</a><br /><br />
+    Please refer to the PHP manual for more details about how to install and enable the IMAP extension.</b>
   {elseif $error == "hostname_resolv_error"}
     <b>The provided hostname could not be resolved. Please check your information and try again.</b>
   {elseif $error == "could_not_connect"}

--- a/templates/get_emails.tpl.html
+++ b/templates/get_emails.tpl.html
@@ -10,6 +10,7 @@
 
   {if $error == "imap_extension_missing"}
     <b>Error: Eventum requires the IMAP extension in order to connect to IMAP/POP3 servers.<br /><br />
+    It is installed by default on some systems but must also be enabled. See INSTALL.md <br /><br />
     Please refer to the PHP manual for more details about how to enable the IMAP extension.</b>
   {elseif $error == "hostname_resolv_error"}
     <b>The provided hostname could not be resolved. Please check your information and try again.</b>


### PR DESCRIPTION
@glensc I didn't see that you also fixed this until after.. this pull also fixes the notice.  I used Misc::ifSet that you referenced in the notes.

I also added a new line to the error text when imap_open is missing:
"It is installed by default on some systems but must also be enabled. See INSTALL.md"

The error previously only referenced checking the PHP docs.. the PHP site is silent on enabling.

INSTALL.md isn't there any more (so i didn't edit) - we need a note that imap needs to be installed **and** enabled.  `php5enmod -s ALL imap` should do it on most linux machines.  Works on Ubuntu.