### PR TITLE
Ajax email test

### DIFF
--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -448,8 +448,26 @@ div#full_width_messages div#global_messages span {
     display: block;
 }
 
-div#global_messages div.error span {
+div#full_width_messages {
+    margin-bottom: 2px;
+}
+
+div#full_width_messages.error {
     background: #cc0029;
+    color: #000000;
+}
+
+div#full_width_messages.info {
+    background: #076486;
+    color: #ffffff;
+}
+
+div#full_width_messages.warning {
+    background: #ef6830;
+}
+
+div#global_messages div.error span {
+    background: rgba(204,00,41,0.5);
     color: #000000;
 }
 

--- a/htdocs/manage/check_email_settings.php
+++ b/htdocs/manage/check_email_settings.php
@@ -29,7 +29,7 @@
 require_once __DIR__ . '/../../init.php';
 
 $tpl = new Template_Helper();
-$tpl->setTemplate('get_emails.tpl.html');
+$tpl->setTemplate('get_emails_ajax.tpl.html');
 
 Auth::checkAuthentication(null, true);
 

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -58,11 +58,11 @@
 <div id="container">
     {block "header"}{/block}
 
-    {block "messages"}
     <div id="full_width_messages">
+    {block "messages"}
         {include "app_messages.tpl.html"}
-    </div>
     {/block}
+    </div>
 
     <div id="middle">
         <div id="content">

--- a/templates/base_full.tpl.html
+++ b/templates/base_full.tpl.html
@@ -78,10 +78,6 @@
     </div>
 {/block}
 
-{block "messages"}
-{include "app_messages.tpl.html"}
-{/block}
-
 {block "footer"}
   <div id="footer">
       {include "app_info.tpl.html"}

--- a/templates/get_emails_ajax.tpl.html
+++ b/templates/get_emails_ajax.tpl.html
@@ -1,0 +1,14 @@
+{* AJAX response message *}
+<span class="default">
+
+  {if $error == "imap_extension_missing"}
+    <b>Error: Eventum requires the IMAP extension in order to connect to IMAP/POP3 servers.<br /><br />
+    Please refer to the PHP manual for more details about how to enable the IMAP extension.</b>
+  {elseif $error == "hostname_resolv_error"}
+    <b>The provided hostname could not be resolved. Please check your information and try again.</b>
+  {elseif $error == "could_not_connect"}
+    <b>Could not connect to the server with the provided information.</b>
+  {else}
+    <b>Thank you, the connection to the email server was created successfully.</b>
+  {/if}
+</span>

--- a/templates/manage/email_accounts.tpl.html
+++ b/templates/manage/email_accounts.tpl.html
@@ -81,15 +81,15 @@
       $('.select_all').click(function() { Eventum.toggleCheckAll('items[]'); });
       $('#testSettings').click(function(event) {
            event.preventDefault();
-	   $('#full_width_messages').removeClass().html('Please wait.. testing connection.').addClass('info');
-    	   var serializedData = $('#email_account_form').serialize();
+           $('#full_width_messages').removeClass().html('Please wait.. testing connection.').addClass('info');
+           var serializedData = $('#email_account_form').serialize();
            $.ajax({
                type: "POST",
                url: "check_email_settings.php",
                data: serializedData
-	   }).done(function(response) {
+           }).done(function(response) {
                $('#full_width_messages').html(response);
-	   });
+           });
       });
   });
   //-->

--- a/templates/manage/email_accounts.tpl.html
+++ b/templates/manage/email_accounts.tpl.html
@@ -63,18 +63,6 @@
           folder[0].disabled = true;
       }
   }
-  function testSettings(f)
-  {
-      var features = 'width=320,height=200,top=30,left=30,resizable=yes,scrollbars=yes,toolbar=no,location=no,menubar=no,status=no';
-      var popupWin = window.open('', '_testEmailSettings', features);
-      popupWin.focus();
-      var old_action = f.action;
-      f.action = 'check_email_settings.php';
-      f.target = '_testEmailSettings';
-      f.submit();
-      f.action = old_action;
-      f.target = '';
-  }
   function checkDelete(f)
   {
       if (!Validation.hasOneChecked('items[]')) {
@@ -91,6 +79,18 @@
       toggleFolderField();
       $('#email_account_form').submit(validateForm);
       $('.select_all').click(function() { Eventum.toggleCheckAll('items[]'); });
+      $('#testSettings').click(function(event) {
+           event.preventDefault();
+	   $('#full_width_messages').removeClass().html('Please wait.. testing connection.').addClass('info');
+    	   var serializedData = $('#email_account_form').serialize();
+           $.ajax({
+               type: "POST",
+               url: "check_email_settings.php",
+               data: serializedData
+	   }).done(function(response) {
+               $('#full_width_messages').html(response);
+	   });
+      });
   });
   //-->
   </script>
@@ -209,7 +209,7 @@
   </tr>
   <tr class="buttons">
     <td colspan="2">
-      <input type="button" value="{t}Test Settings{/t}" onClick="testSettings(this.form);">
+      <input id="testSettings" type="button" value="{t}Test Settings{/t}">
       {if $smarty.get.cat|default:'' == 'edit'}
       <input type="submit" value="{t}Update Account{/t}">
       {else}


### PR DESCRIPTION
Display of result on page instead of popup.  Popup was not a form in this case.

Also changed base.tpl to move full_width_messages div outside block so it appears on every page.
This is in preparation for later enhancing other pages to use this div
for AJAX response messages. base_full.tpl was modified and the messages block was
removed so as not to override base.tpl (looked duplicative anyway)

I am proposing this as a template for making similar changes to other pages which use pop-ups only for results.  Any clean-up/enhancements (particularly css) are welcome.