### PR TITLE
add logging framework based on monolog

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,7 @@
 		"fonts/liberation":"*",
 		"ircmaxell/password-compat": "~1.0.4",
 		"ircmaxell/random-lib": "~1.1.0",
+		"monolog/monolog": "~1.17.2",
 		"pear-pear.php.net/mail_mimedecode": "*",
 		"pear-pear.php.net/math_stats": "*",
 		"pear-pear.php.net/net_ldap2": "~2.1",

--- a/htdocs/ajax/upload.php
+++ b/htdocs/ajax/upload.php
@@ -55,8 +55,7 @@ try {
         'error' => $code ? $code : -1,
         'message' => $e->getMessage(),
     );
-    error_log($e->getMessage());
-    error_log($e->getTraceAsString());
+    Logger::app()->error($e);
 }
 
 header('Content-Type: application/json; charset=UTF-8');

--- a/htdocs/file_upload.php
+++ b/htdocs/file_upload.php
@@ -58,8 +58,7 @@ if ($cat == 'upload_file') {
         Attachment::attachFiles($issue_id, $usr_id, $iaf_ids, $internal_only, $file_description);
         $res = 1;
     } catch (Exception $e) {
-        error_log($e->getMessage());
-        error_log($e->getTraceAsString());
+        Logger::app()->error($e);
         $res = -1;
     }
 

--- a/htdocs/offline.php
+++ b/htdocs/offline.php
@@ -26,7 +26,10 @@
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 
-require_once __DIR__ . '/../init.php';
+// this file may be called from db_helper, so init already called
+if (!defined('APP_PATH')) {
+    require_once __DIR__ . '/../init.php';
+}
 
 $tpl = new Template_Helper();
 if (php_sapi_name() == 'cli') {

--- a/htdocs/preferences.php
+++ b/htdocs/preferences.php
@@ -84,7 +84,7 @@ if ($cat == 'update_account') {
             User::updatePassword($usr_id, $_POST['new_password']);
             $res = 1;
         } catch (Exception $e) {
-            error_log($e->getMessage());
+            Logger::app()->error($e);
             $res = -1;
         }
     }

--- a/htdocs/scm_ping.php
+++ b/htdocs/scm_ping.php
@@ -42,8 +42,7 @@ try {
         'code' => $code ? $code : -1,
         'message' => $e->getMessage(),
     );
-    error_log($e->getMessage());
-    error_log($e->getTraceAsString());
+    Logger::app()->error($e);
 }
 
 if (!empty($_GET['json'])) {

--- a/init.php
+++ b/init.php
@@ -78,7 +78,6 @@ $define('APP_LOCKS_PATH', APP_VAR_PATH . '/lock');
 $define('APP_LOG_PATH', APP_VAR_PATH . '/log');
 $define('APP_ERROR_LOG', APP_LOG_PATH . '/errors.log');
 $define('APP_CLI_LOG', APP_LOG_PATH . '/cli.log');
-$define('APP_LOGIN_LOG', APP_LOG_PATH . '/login_attempts.log');
 
 // define the user_id of system user
 $define('APP_SYSTEM_USER_ID', 1);

--- a/init.php
+++ b/init.php
@@ -139,6 +139,7 @@ Misc::stripInput($_POST);
 // set default timezone
 date_default_timezone_set(APP_DEFAULT_TIMEZONE);
 
+Logger::initialize();
 Language::setup();
 
 // set charset

--- a/init.php
+++ b/init.php
@@ -77,7 +77,6 @@ $define('APP_TPL_COMPILE_PATH', APP_VAR_PATH . '/cache');
 $define('APP_LOCKS_PATH', APP_VAR_PATH . '/lock');
 $define('APP_LOG_PATH', APP_VAR_PATH . '/log');
 $define('APP_ERROR_LOG', APP_LOG_PATH . '/errors.log');
-$define('APP_CLI_LOG', APP_LOG_PATH . '/cli.log');
 
 // define the user_id of system user
 $define('APP_SYSTEM_USER_ID', 1);

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -1,0 +1,83 @@
+<?php
+/* vim: set expandtab tabstop=4 shiftwidth=4 encoding=utf-8: */
+// +----------------------------------------------------------------------+
+// | Eventum - Issue Tracking System                                      |
+// +----------------------------------------------------------------------+
+// | Copyright (c) 2015 Eventum Team.                                     |
+// |                                                                      |
+// | This program is free software; you can redistribute it and/or modify |
+// | it under the terms of the GNU General Public License as published by |
+// | the Free Software Foundation; either version 2 of the License, or    |
+// | (at your option) any later version.                                  |
+// |                                                                      |
+// | This program is distributed in the hope that it will be useful,      |
+// | but WITHOUT ANY WARRANTY; without even the implied warranty of       |
+// | MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the        |
+// | GNU General Public License for more details.                         |
+// |                                                                      |
+// | You should have received a copy of the GNU General Public License    |
+// | along with this program; if not, write to:                           |
+// |                                                                      |
+// | Free Software Foundation, Inc.                                       |
+// | 51 Franklin Street, Suite 330                                        |
+// | Boston, MA 02110-1301, USA.                                          |
+// +----------------------------------------------------------------------+
+
+use Monolog\Handler\StreamHandler;
+
+/**
+ * @method static Monolog\Logger app() Application log channel
+ * @method static Monolog\Logger db() Database log channel
+ */
+class Logger extends Monolog\Registry
+{
+    /**
+     * Configure logging for Eventum application.
+     *
+     * This can be used like:
+     *
+     * Logger::api()->addError('Sent to $api Logger instance');
+     * Logger::application()->addError('Sent to $application Logger instance');
+     */
+    public static function initialize()
+    {
+        // create 'app' instance, it will be used base of other loggers
+        $path = APP_LOG_PATH . '/eventum.log';
+        $logfile = new StreamHandler($path, Monolog\Logger::WARNING);
+
+        static::createLogger('app', array(), array())->pushHandler($logfile);
+
+        // add logger for database
+        static::createLogger('db');
+    }
+
+    /**
+     * Helper to create named logger and add it to registry.
+     * If handlers or processors not specified, they are taken from 'app' logger.
+     *
+     * This could be useful, say in LDAP Auth Adapter:
+     *
+     * $logger = Logger::createLogger('ldap');
+     * $logger->error('ldap error')
+     *
+     * @param string $name
+     * @param array $handlers
+     * @param array $processors
+     * @return \Monolog\Logger
+     */
+    public static function createLogger($name, $handlers = null, $processors = null)
+    {
+        if ($handlers === null) {
+            $handlers = self::getInstance('app')->getHandlers();
+        }
+        if ($processors === null) {
+            $processors = self::getInstance('app')->getProcessors();
+        }
+
+        $logger = new Monolog\Logger($name, $handlers, $processors);
+
+        Monolog\Registry::addLogger($logger);
+
+        return $logger;
+    }
+}

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -45,10 +45,13 @@ class Logger extends Monolog\Registry
         $path = APP_LOG_PATH . '/eventum.log';
         $logfile = new StreamHandler($path, Monolog\Logger::WARNING);
 
-        static::createLogger('app', array(), array())->pushHandler($logfile);
+        $app = static::createLogger('app', array(), array())->pushHandler($logfile);
 
         // add logger for database
         static::createLogger('db');
+
+        // attach php errorhandler to app logger
+        Monolog\ErrorHandler::register($app);
     }
 
     /**

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -41,6 +41,9 @@ class Logger extends Monolog\Registry
      */
     public static function initialize()
     {
+        // Configure it use Eventum timezone
+        Monolog\Logger::setTimezone(new DateTimeZone(APP_DEFAULT_TIMEZONE));
+
         // create 'app' instance, it will be used base of other loggers
         $path = APP_LOG_PATH . '/eventum.log';
         $logfile = new StreamHandler($path, Monolog\Logger::WARNING);

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -27,6 +27,7 @@
  * @method static Monolog\Logger app() Application log channel
  * @method static Monolog\Logger db() Database log channel
  * @method static Monolog\Logger auth() Auth log channel
+ * @method static Monolog\Logger cli() CLI log channel
  */
 class Logger extends Monolog\Registry
 {
@@ -67,6 +68,9 @@ class Logger extends Monolog\Registry
         // add logger for database and auth
         static::createLogger('db');
         static::createLogger('auth');
+
+        // add cli logger with different output file
+        static::createLogger('cli', array(self::createFileHandler('cli.log')));
 
         // attach php errorhandler to app logger
         Monolog\ErrorHandler::register($app);

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -65,9 +65,11 @@ class Logger extends Monolog\Registry
             }
         );
 
-        // add logger for database and auth
+        // add logger for database
         static::createLogger('db');
-        static::createLogger('auth');
+
+        // log auth channel to auth.log
+        static::createLogger('auth', array(self::createFileHandler('auth.log')));
 
         // add cli logger with different output file
         static::createLogger('cli', array(self::createFileHandler('cli.log')));

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -53,6 +53,17 @@ class Logger extends Monolog\Registry
             $app->pushHandler($mailer);
         }
 
+        $app->pushProcessor(new Monolog\Processor\WebProcessor());
+        $app->pushProcessor(new Monolog\Processor\MemoryUsageProcessor());
+        $app->pushProcessor(new Monolog\Processor\MemoryPeakUsageProcessor());
+        $app->pushProcessor(
+            function (array $record) {
+                $record['extra']['version'] = APP_VERSION;
+
+                return $record;
+            }
+        );
+
         // add logger for database
         static::createLogger('db');
 

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -23,8 +23,6 @@
 // | Boston, MA 02110-1301, USA.                                          |
 // +----------------------------------------------------------------------+
 
-use Monolog\Handler\StreamHandler;
-
 /**
  * @method static Monolog\Logger app() Application log channel
  * @method static Monolog\Logger db() Database log channel
@@ -46,13 +44,11 @@ class Logger extends Monolog\Registry
         Monolog\Logger::setTimezone(new DateTimeZone(APP_DEFAULT_TIMEZONE));
 
         // create 'app' instance, it will be used base of other loggers
-        $path = APP_LOG_PATH . '/eventum.log';
-        $logfile = new StreamHandler($path, Monolog\Logger::WARNING);
-
+        $logfile = self::createFileHandler('eventum.log');
         $app = static::createLogger('app', array(), array())->pushHandler($logfile);
 
         // setup mail logger if enabled
-        $mailer = self::getMailHandler();
+        $mailer = self::createMailHandler();
         if ($mailer) {
             $app->pushHandler($mailer);
         }
@@ -107,11 +103,25 @@ class Logger extends Monolog\Registry
     }
 
     /**
+     * Create Handler that logs to a file in APP_LOG_PATH directory
+     *
+     * @param string $filename
+     * @param integer $level The minimum logging level at which this handler will be triggered
+     * @return \Monolog\Handler\StreamHandler
+     */
+    private function createFileHandler($filename, $level = Monolog\Logger::INFO)
+    {
+        $path = APP_LOG_PATH . '/' . $filename;
+
+        return new Monolog\Handler\StreamHandler($path, $level);
+    }
+
+    /**
      * Get mail handler if configured
      *
      * @return \Monolog\Handler\MailHandler
      */
-    private static function getMailHandler()
+    private static function createMailHandler()
     {
         $setup = Setup::get();
         if ($setup['email_error']['status'] != 'enabled') {

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -113,7 +113,10 @@ class Logger extends Monolog\Registry
     {
         $path = APP_LOG_PATH . '/' . $filename;
 
-        return new Monolog\Handler\StreamHandler($path, $level);
+        // make files not world readable by default
+        $filePermission = 0640;
+
+        return new Monolog\Handler\StreamHandler($path, $level, true, $filePermission, false);
     }
 
     /**

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -28,6 +28,7 @@ use Monolog\Handler\StreamHandler;
 /**
  * @method static Monolog\Logger app() Application log channel
  * @method static Monolog\Logger db() Database log channel
+ * @method static Monolog\Logger auth() Auth log channel
  */
 class Logger extends Monolog\Registry
 {
@@ -67,8 +68,9 @@ class Logger extends Monolog\Registry
             }
         );
 
-        // add logger for database
+        // add logger for database and auth
         static::createLogger('db');
+        static::createLogger('auth');
 
         // attach php errorhandler to app logger
         Monolog\ErrorHandler::register($app);

--- a/lib/eventum/Logger.php
+++ b/lib/eventum/Logger.php
@@ -127,7 +127,8 @@ class Logger extends Monolog\Registry
         $handler = new Monolog\Handler\NativeMailerHandler(
             $to,
             $subject,
-            $setup['smtp']['from']
+            $setup['smtp']['from'],
+            Monolog\Logger::ERROR
         );
 
         return $handler;

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -76,13 +76,13 @@ class Auth
      */
     public static function saveLoginAttempt($email, $type, $extra = null)
     {
-        $msg = Date_Helper::getCurrentDateGMT() . " - Login attempt by '$email' was ";
+        $msg = "Login attempt by '$email' was ";
         if ($type == 'success') {
-            $msg .= "successful.\n";
+            $msg .= "successful.";
         } else {
-            $msg .= "not successful because of '$extra'.\n";
+            $msg .= "not successful because of '$extra'.";
         }
-        file_put_contents(APP_LOGIN_LOG, $msg, FILE_APPEND);
+        Logger::auth()->info($msg, array('user' => $email, 'type' => $type, 'extra' => $extra));
     }
 
     /**

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -512,9 +512,8 @@ class Auth
             try {
                 $instance = new $class();
             } catch (AuthException $e) {
-                $message = "Unable to use auth backend '$class': {$e->getMessage()}";
-                error_log($message);
-                Error_Handler::logError($message);
+                $message = "Unable to use auth backend '$class'";
+                Logger::app()->critical($message, array('exception' => $e));
 
                 if (APP_AUTH_BACKEND_ALLOW_FALLBACK != true) {
                     $tpl = new Template_Helper();

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -64,7 +64,7 @@ class DB_Helper
             }
             /** @global $error_type */
             $error_type = 'db';
-            require_once APP_PATH . '/htdocs/offline.php';
+            require APP_PATH . '/htdocs/offline.php';
             exit(2);
         }
 

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -287,14 +287,4 @@ class DB_Helper
 
         return str_replace("\n", ' ', $sql);
     }
-
-    public static function fatalDBError($e)
-    {
-        /** @var $e PEAR_Error */
-        Error_Handler::logError(array($e->getMessage(), $e->getDebugInfo()), __FILE__, __LINE__);
-        /** @global $error_type */
-        $error_type = 'db';
-        require_once APP_PATH . '/htdocs/offline.php';
-        exit(2);
-    }
 }

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -680,7 +680,7 @@ class Mail_Helper
         $mail = Mail::factory('smtp', $params);
         $res = $mail->send($address, $headers, $body);
         if (Misc::isError($res)) {
-            Error_Handler::logError(array($res->getMessage(), $res->getDebugInfo()), __FILE__, __LINE__);
+            Logger::app()->error($res->getMessage(), array('debug' => $res->getDebugInfo()));
         }
 
         $subjects[] = $subject;

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -127,7 +127,7 @@ class Mail_Queue
 
         $res = Mail_Helper::prepareHeaders($headers);
         if (Misc::isError($res)) {
-            Error_Handler::logError(array($res->getMessage(), $res->getDebugInfo()), __FILE__, __LINE__);
+            Logger::app()->error($res->getMessage(), array('debug' => $res->getDebugInfo()));
 
             return $res;
         }
@@ -196,7 +196,7 @@ class Mail_Queue
 
                 $res = Mail_Helper::prepareHeaders($headers);
                 if (Misc::isError($res)) {
-                    Error_Handler::logError(array($res->getMessage(), $res->getDebugInfo()), __FILE__, __LINE__);
+                    Logger::app()->error($res->getMessage(), array('debug' => $res->getDebugInfo()));
 
                     return;
                 }
@@ -302,10 +302,7 @@ class Mail_Queue
         $mail = Mail::factory('smtp', Mail_Helper::getSMTPSettings());
         $res = $mail->send($recipient, $headers, $body);
         if (Misc::isError($res)) {
-            // special handling of errors when the mail server is down
-            $msg = $res->getMessage();
-            $cant_notify = ($status == 'error' || strstr($msg, 'unable to connect to smtp server') || stristr($msg, 'Failed to connect to') !== false);
-            Error_Handler::logError(array($msg, $res->getDebugInfo()), __FILE__, __LINE__, !$cant_notify);
+            Logger::app()->error($res->getMessage(), array('debug' => $res->getDebugInfo()));
 
             return $res;
         }

--- a/lib/eventum/class.mime_helper.php
+++ b/lib/eventum/class.mime_helper.php
@@ -92,9 +92,10 @@ class Mime_Helper
         $parts = array();
         self::parse_output($output, $parts);
         if (empty($parts)) {
-            Error_Handler::logError(array('self::parse_output failed. Corrupted MIME in email?', $output), __FILE__, __LINE__);
+            Logger::app()->debug('parse_output failed. Corrupted MIME in email?', array('output' => $output));
             // we continue as if nothing happened until it's clear it's right check to do.
         }
+
         $str = '';
         $is_html = false;
         if (isset($parts['text'])) {

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -116,8 +116,7 @@ class Setup
             }
         } catch (Exception $e) {
             $code = $e->getCode();
-            error_log($e->getMessage());
-            error_log($e->getTraceAsString());
+            Logger::app()->error($e);
 
             return $code ?: -1;
         }

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -399,7 +399,7 @@ class Support
         $mbox = @imap_open(self::getServerURI($info), $info['ema_username'], $info['ema_password']);
         if ($mbox === false) {
             $error = @imap_last_error();
-            Error_Handler::logError('Error while connecting to the email server - ' . $error, __FILE__, __LINE__);
+            Logger::app()->error("Error while connecting to the email server - {$error}");
         }
 
         return $mbox;
@@ -761,7 +761,8 @@ class Support
                         $addr = Mail_Helper::getEmailAddress($structure->headers['from']);
                         if (Misc::isError($addr)) {
                             // XXX should we log or is this expected?
-                            Error_Handler::logError(array($addr->getMessage()." addr: $addr", $addr->getDebugInfo()), __FILE__, __LINE__);
+                            Logger::app()->error($addr->getMessage(), array('debug' => $res->getDebugInfo(), 'address' => $structure->headers['from']));
+
                             $usr_id = APP_SYSTEM_USER_ID;
                         } else {
                             $usr_id = User::getUserIDByEmail($addr);

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -325,7 +325,7 @@ class User
         try {
             User::updatePassword($usr_id, $_POST['passwd']);
         } catch (Exception $e) {
-            error_log($e->getMessage());
+            Logger::app()->error($e);
             return -1;
         }
 
@@ -1098,7 +1098,7 @@ class User
             try {
                 User::updatePassword($usr_id, $data['password']);
             } catch (Exception $e) {
-                error_log($e->getMessage());
+                Logger::app()->error($e);
                 return -1;
             }
         }

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -434,12 +434,12 @@ class User
 
         if (!is_string($email)) {
             if (Misc::isError($email)) {
-                Error_Handler::logError(array($email->getMessage(), $email->getDebugInfo()), __FILE__, __LINE__);
+                Logger::app()->error($email->getMessage(), array('debug' => $email->getDebugInfo()));
 
                 return null;
             }
 
-            Error_Handler::logError('$email parameter is not a string: '.gettype($email), __FILE__, __LINE__);
+            Logger::app()->error('$email parameter is not a string', array('type' => gettype($email)));
 
             return null;
         }

--- a/lib/eventum/db/DbPear.php
+++ b/lib/eventum/db/DbPear.php
@@ -61,7 +61,7 @@ class DbPear implements DbInterface
         }
 
         $db = DB::connect($dsn);
-        $this->assertError($db, 1);
+        $this->assertError($db);
 
         // DBTYPE specific session setup commands
         switch ($dsn['phptype']) {
@@ -218,7 +218,7 @@ class DbPear implements DbInterface
      *
      * @param $e PEAR_Error|array|object|int
      */
-    private function assertError($e, $depth = 2)
+    private function assertError($e)
     {
         if (!Misc::isError($e)) {
             return;

--- a/lib/eventum/db/DbPear.php
+++ b/lib/eventum/db/DbPear.php
@@ -228,19 +228,18 @@ class DbPear implements DbInterface
             'debuginfo' => $e->getDebugInfo(),
         );
 
-        // walk up in $e->backtrace until we find object DB_mysql/DB_mysqli
-        // and from it we can get 'last_query' and 'last_parameters'
+        // walk up in $e->backtrace until we find ourself
+        // and from it we can get method name and it's arguments
         foreach ($e->backtrace as $i => $stack) {
             if (!isset($stack['object'])) {
                 continue;
             }
-            $object = $stack['object'];
-            if (!$object instanceof DB_mysql && !$object instanceof DB_mysqli) {
+            if (!$stack['object'] instanceof self) {
                 continue;
             }
 
-            $context['query'] = $object->last_query;
-            $context['parameters'] = $object->last_parameters;
+            $context['method'] = $stack['function'];
+            $context['arguments'] = $stack['args'];
             break;
         }
 

--- a/lib/eventum/db/DbPear.php
+++ b/lib/eventum/db/DbPear.php
@@ -240,41 +240,22 @@ class DbPear implements DbInterface
 
             $context['method'] = $stack['function'];
             $context['arguments'] = $stack['args'];
+
+            // add these last, they are least interesting ones
+            $context['code'] = $e->getCode();
+            $context['file'] = $stack['file'];
+            $context['line'] = $stack['line'];
             break;
         }
-
-        list($file, $line) = self::getTrace($depth);
-        // add these last, they are least interesting ones
-        $context['code'] = $e->getCode();
-        $context['file'] = $file;
-        $context['line'] = $line;
 
         Logger::db()->error($e->getMessage(), $context);
 
         $de = new DbException($e->getMessage(), $e->getCode());
-        $de->setExceptionLocation($file, $line);
+        if (isset($context['file'])) {
+            $de->setExceptionLocation($context['file'], $context['line']);
+        }
 
         throw $de;
-    }
-
-    /**
-     * Get array of FILE and LOCATION from backtrace
-     *
-     * @param int $depth
-     * @return array
-     */
-    private static function getTrace($depth = 1)
-    {
-        $trace = debug_backtrace();
-        if (!isset($trace[$depth])) {
-            return null;
-        }
-        $caller = (object)$trace[$depth];
-        if (!isset($caller->file)) {
-            return null;
-        }
-
-        return array($caller->file, $caller->line);
     }
 
     /**

--- a/lib/eventum/rpc/RemoteApi.php
+++ b/lib/eventum/rpc/RemoteApi.php
@@ -1011,6 +1011,7 @@ class RemoteApi
         return $incidents;
     }
 
+    // FIXME: this method should be used by SERVER, not by CLIENT
     /**
      * @param string $command
      * @return string
@@ -1018,14 +1019,11 @@ class RemoteApi
      */
     public function logCommand($command)
     {
+
         $usr_id = Auth::getUserID();
         $email = User::getEmail($usr_id);
 
-        $msg = $email . "\t" . $command . "\n";
-
-        $fp = @fopen(APP_CLI_LOG, 'a');
-        @fwrite($fp, $msg);
-        @fclose($fp);
+        Logger::cli()->info($command, array('usr_id' => $usr_id, 'email' => $email));
 
         return 'OK';
     }

--- a/lib/eventum/search/class.sphinx_fulltext_search.php
+++ b/lib/eventum/search/class.sphinx_fulltext_search.php
@@ -74,14 +74,15 @@ class Sphinx_Fulltext_Search extends Abstract_Fulltext_Search
         $res = $this->sphinx->Query($options['keywords'], $indexes);
 
         // TODO: report these somehow back to the UI
+        // probably easy to do with Logger framework (add new handler?)
         if (method_exists($this->sphinx, 'IsConnectError') && $this->sphinx->IsConnectError()) {
-            error_log('sphinx_fulltext_search: Network Error');
+            Logger::app()->error('sphinx_fulltext_search: Network Error');
         }
         if ($this->sphinx->GetLastWarning()) {
-            error_log('sphinx_fulltext_search: WARNING: ' . $this->sphinx->GetLastWarning());
+            Logger::app()->warning('sphinx_fulltext_search: ' . $this->sphinx->GetLastWarning());
         }
         if ($this->sphinx->GetLastError()) {
-            error_log('sphinx_fulltext_search: ERROR: ' . $this->sphinx->GetLastError());
+            Logger::app()->error('sphinx_fulltext_search: ' . $this->sphinx->GetLastError());
         }
 
         $issue_ids = array();
@@ -146,7 +147,6 @@ class Sphinx_Fulltext_Search extends Abstract_Fulltext_Search
                     $res = $this->sphinx->BuildExcerpts($documents, 'issue_stemmed', $this->keywords, $excerpt_options);
                     if ($res[0] != $issue['iss_original_description']) {
                         $excerpt['issue']['description'] = self::cleanUpExcerpt($res[0]);
-                        error_log(print_r($excerpt['issue']['description'], 1));
                     }
                 } elseif ($match['index'] == 'email') {
                     $email = Support::getEmailDetails(null, $match['match_id']);

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -48,9 +48,19 @@ class LoggerTest extends PHPUnit_Framework_TestCase
     public function testLogException()
     {
         $e = new Exception('It happened');
+
+        Logger::app()->error($e);
+        Logger::app()->error($e->getMessage(), array('exception' => $e));
+    }
+
+    public function testLogPearException()
+    {
+        $e = new PEAR_Error('It happened');
+
+        // toString pear error object is not useful:
+        // "app.ERROR: It happened []"
         Logger::app()->error($e);
 
-        $e = new Exception('It happened');
-        Logger::app()->error($e->getMessage(), array('exception' => $e));
+        Logger::app()->error($e->getMessage(), array('debug' => $e->getDebugInfo()));
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -63,4 +63,9 @@ class LoggerTest extends PHPUnit_Framework_TestCase
 
         Logger::app()->error($e->getMessage(), array('debug' => $e->getDebugInfo()));
     }
+
+    public function testCliLog()
+    {
+        Logger::cli()->info('moo');
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -49,5 +49,8 @@ class LoggerTest extends PHPUnit_Framework_TestCase
     {
         $e = new Exception('It happened');
         Logger::app()->error($e);
+
+        $e = new Exception('It happened');
+        Logger::app()->error($e->getMessage(), array('exception' => $e));
     }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -33,4 +33,13 @@ class LoggerTest extends PHPUnit_Framework_TestCase
         $logger->error('ldap error 1');
         $logger->debug('ldap debug');
     }
+
+    public function testDbError()
+    {
+        try {
+            DB_Helper::getInstance()->query('here -->?<-- be dragons?', array('param1', 'param2'));
+        } catch (DbException $e) {
+        }
+    }
+
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -42,4 +42,12 @@ class LoggerTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    /**
+     * @test what happens if i just log exception object
+     */
+    public function testLogException()
+    {
+        $e = new Exception('It happened');
+        Logger::app()->error($e);
+    }
 }

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use Monolog\Handler\StreamHandler;
+
+class LoggerTest extends PHPUnit_Framework_TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Logger::initialize();
+    }
+
+    public function testLogger()
+    {
+        // create a log channel
+        $log = new Monolog\Logger('eventum');
+        $logfile = APP_LOG_PATH . '/test.log';
+        $log->pushHandler(new StreamHandler($logfile, Monolog\Logger::WARNING));
+
+        // add records to the log
+        $log->addWarning('Foo');
+        $log->addError('Bar');
+    }
+
+    public function testLoggerRegistry()
+    {
+        Logger::app()->addError('Sent to $app Logger instance');
+        Logger::db()->addError('Sent to $db Logger instance');
+    }
+
+    public function testLoggerCreateLogger()
+    {
+        $logger = Logger::createLogger('ldap');
+        $logger->error('ldap error 1');
+        $logger->debug('ldap debug');
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -52,6 +52,7 @@ define('APP_COOKIE_URL', APP_RELATIVE_URL);
 define('APP_PROJECT_COOKIE', 'eventum_project');
 define('APP_PROJECT_COOKIE_EXPIRE', time() + (60 * 60 * 24));
 define('APP_BASE_URL', 'http://localhost');
+define('APP_LOG_PATH', APP_CONFIG_PATH);
 
 require_once APP_PATH . '/autoload.php';
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -53,6 +53,12 @@ define('APP_PROJECT_COOKIE', 'eventum_project');
 define('APP_PROJECT_COOKIE_EXPIRE', time() + (60 * 60 * 24));
 define('APP_BASE_URL', 'http://localhost');
 define('APP_LOG_PATH', APP_CONFIG_PATH);
+define('APP_LOCAL_PATH', APP_CONFIG_PATH);
+define('APP_TPL_COMPILE_PATH', APP_CONFIG_PATH.'/tpl_c');
+define('APP_TPL_PATH', APP_PATH . '/templates');
+define('APP_NAME', 'Eventum Tests');
+define('APP_VERSION', '3.x.y-dev');
+define('APP_AUTH_BACKEND', 'mysql_auth_backend');
 
 require_once APP_PATH . '/autoload.php';
 


### PR DESCRIPTION
this adds framework to have common logging in code.
as we're in legacy-codebase situation, best fit was to use [Monolog\Registry](https://github.com/Seldaek/monolog/blob/1.17.2/doc/03-utilities.md)

overview is simple, call this in `init.php`:

```php
Logger::initialize();
```

and when want to log:
```php
Logger::db()->error('Sent to $db Logger instance');
Logger::app()->error('Sent to $app Logger instance');
```

Levels below `WARNING` are not logged anywhere, but it's pretty easy to setup something to do so. it's in single location (`Logger` class).

sub tasks:
- [x] replace db error logging
- [ ] add logging to auth actions
- [x] add `errors.log` logger, or just deprecate it in favour of general log?
- [x] add `login_attempts.log` logger, or add new channel 'auth'?
- [x] add mail output support
