### PR TITLE
add .htaccess to project root

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,21 @@
+#
+# You should not expose Eventum to web root.
+# Only htdocs directory should be exposed to webroot
+#
+# See installation documentation from wiki:
+# https://github.com/eventum/eventum/wiki/System-Admin%3A-Doing-a-fresh-install
+#
+
+# This is just workaround to redirect all requests outside /htdocs/ to /htdocs/.
+# Not perfect, but covers likely most of the cases.
+
+RewriteEngine On
+
+# Capture $BASE variable
+# http://stackoverflow.com/a/18589126/2314626
+RewriteCond %{REQUEST_URI}::$1 ^(/.+)/(.*)::\2$
+RewriteRule ^(.*)$ - [E=BASE:%1]
+
+# Redirect to htdocs/ if url already does not match 'htdocs'
+RewriteCond %{REQUEST_URI} !/htdocs/
+RewriteRule ^(.*)$ %{ENV:BASE}/htdocs/ [R=302,L]


### PR DESCRIPTION
this will at least redirect to htdocs subdir for poortly setup
installations.

originally i intended to add there `Require all denied` and `Require all granted` when directory is `htdocs`, but wasn't able to accomplish that without the same `.htaccess` matching in `htdocs/` dir.

so just kept rewrite rules. which also originally were conditional `<IfModule mod_rewrite.c>`, but removed condition, so that if you two of these:
  - expose directory outside htdocs to web
  - don't have mod_rewrite enabled either 

you will get 500 error about misconfiguration and it's good indication that you should really check your installation and read some docs.

making the web safer place!