### PR TITLE
Improve select project page and increase project cookie lifespan.

### DIFF
--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -21,7 +21,7 @@ define('APP_COOKIE_DOMAIN', null);
 define('APP_COOKIE', 'eventum');
 define('APP_COOKIE_EXPIRE', time() + (60 * 60 * 8));
 define('APP_PROJECT_COOKIE', 'eventum_project');
-define('APP_PROJECT_COOKIE_EXPIRE', time() + (60 * 60 * 24));
+define('APP_PROJECT_COOKIE_EXPIRE', time() + (60 * 60 * 24 * 30)); // 30 days
 
 define('APP_DEFAULT_PAGER_SIZE', 5);
 define('APP_DEFAULT_REFRESH_RATE', 5); // in minutes

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -333,6 +333,10 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
     font-size: 2em;
 }
 
+#select_project .project_label {
+    display: block;
+}
+
 /* Begin Select Customer */
 #select_customer ul {
     list-style: none;

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -68,9 +68,6 @@ $(document).ready(function() {
 
     $("input.issue_field").blur(Validation.validateIssueNumberField);
 
-    $('#project_select_form').on('change', function() {
-	        $(this).closest("form").submit();
-    });
     // chosen config
     var config = {
         '.chosen-select'           : {},

--- a/htdocs/js/page.js
+++ b/htdocs/js/page.js
@@ -3,6 +3,21 @@
  */
 
 
+function select_project()
+{
+}
+
+select_project.ready = function()
+{
+    $('#project_select_form input[name=project]').on('change', function() {
+	        $(this).closest("form").submit();
+    });
+    $('#project_select_form .project_label').on('click', function() {
+	        $(this).closest("form").submit();
+    });
+}
+
+
 /*
  * List Issues Page
  */

--- a/templates/select_project.tpl.html
+++ b/templates/select_project.tpl.html
@@ -41,7 +41,7 @@
                     {if $project@first}checked="checked"{/if}>
                 </td>
                 <td>
-                    <label for="project_{$prj_id}">{$project}</label>
+                    <label class="project_label" for="project_{$prj_id}">{$project}</label>
                 </td>
             </tr>
             {/foreach}
@@ -49,7 +49,7 @@
                 <td colspan="2">
                     <input type="submit" name="Submit" value="{t}Continue{/t} &gt;&gt;">
                     <label for="remember" accesskey="r">
-                    <input type="checkbox" id="remember" name="remember" value="1">{t}Remember Selection{/t}</label>
+                    <input type="checkbox" id="remember" name="remember" value="1" checked="checked">{t}Remember Selection{/t}</label>
                 </td>
             </tr>
         </table>


### PR DESCRIPTION
Users can now one click anywhere on the project name cell to choose a project and submit.
Project cookie will last 30 days by default.
Project cookie will "remember" by default.

The only question I have is if we want to try to change the project lifetime that users already have set in their config.php. I don't think we have any mechanism to change that file. I suppose we could move it into the setup file though. Thoughts?