### PR TITLE
show dates human friendly

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,7 @@
 		"jasig/phpcas":"~1.3.3",
 		"malsup/form" :"*",
 		"maximebf/debugbar": "1.*",
+		"rmm5t/jquery-timeago": "*",
 		"roave/security-advisories": "dev-master",
 		"symfony/var-dumper": "~2.7.3",
 		"zendframework/zend-mail": "2.4.*"

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
 		"maximebf/debugbar": "1.*",
 		"rmm5t/jquery-timeago": "*",
 		"roave/security-advisories": "dev-master",
+		"robloach/component-installer": "*",
 		"symfony/var-dumper": "~2.7.3",
 		"zendframework/zend-mail": "2.4.*"
 	},

--- a/htdocs/faq.php
+++ b/htdocs/faq.php
@@ -62,7 +62,6 @@ if (!empty($_GET['id'])) {
     if ((count($support_level_ids) > 0) && (count(array_intersect($support_level_ids, $t['support_levels'])) < 1)) {
         $tpl->assign('faq', -1);
     } else {
-        $t['faq_created_date'] = Date_Helper::getFormattedDate($t['faq_created_date']);
         $tpl->assign('faq', $t);
     }
 }

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -82,6 +82,9 @@ $(document).ready(function() {
 
     // autosize
     autosize($('textarea'));
+
+    // jquery timeago
+    $('abbr.timeago').timeago();
 });
 
 function Eventum()

--- a/htdocs/news.php
+++ b/htdocs/news.php
@@ -36,7 +36,6 @@ Auth::checkAuthentication('index.php?err=5', true);
 $prj_id = Auth::getCurrentProject();
 if (!empty($_GET['id'])) {
     $t = News::getDetails($_GET['id']);
-    $t['nws_created_date'] = Date_Helper::getFormattedDate($t['nws_created_date']);
     $tpl->assign('news', array($t));
 } else {
     $tpl->assign('news', News::getListByProject($prj_id, true));

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -864,7 +864,8 @@ Account Manager: ' . @$details['customer']['account_manager_name'];
         self::checkIssuePermissions($client, $auth, $issue_id);
 
         $note = self::getNote($client, $auth, $issue_id, $note_id);
-        echo sprintf("%15s: %s\n", 'Date', $note['not_created_date']);
+        $not_created_date = Date_Helper::getFormattedDate($note['not_created_date']);
+        echo sprintf("%15s: %s\n", 'Date', $not_created_date);
         echo sprintf("%15s: %s\n", 'From', $note['not_from']);
         echo sprintf("%15s: %s\n", 'Title', $note['not_title']);
         echo "------------------------------------------------------------------------\n";
@@ -1176,8 +1177,9 @@ Account Manager: ' . @$details['customer']['account_manager_name'];
             case 'convert-note':
             case 'cn':
                 $note_details = self::getNote($client, $auth, $issue_id, $args[3]);
+                $not_created_date = Date_Helper::getFormattedDate($note_details['not_created_date']);
                 $msg = "These are the current details for issue #$issue_id, note #" . $args[3] . ":\n" .
-                        '   Date: ' . $note_details['not_created_date'] . "\n" .
+                        '   Date: ' . $not_created_date . "\n" .
                         '   From: ' . $note_details['not_from'] . "\n" .
                         '  Title: ' . $note_details['not_title'] . "\n" .
                         'Are you sure you want to convert this note into a ' . $args[4] . '?';

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -1006,7 +1006,8 @@ Account Manager: ' . @$details['customer']['account_manager_name'];
         self::checkIssuePermissions($client, $auth, $issue_id);
 
         $draft = self::getDraft($client, $auth, $issue_id, $draft_id);
-        echo sprintf("%15s: %s\n", 'Date', $draft['emd_updated_date']);
+        $emd_updated_date = Date_Helper::getFormattedDate($draft['emd_updated_date']);
+        echo sprintf("%15s: %s\n", 'Date', $emd_updated_date);
         echo sprintf("%15s: %s\n", 'From', $draft['from']);
         echo sprintf("%15s: %s\n", 'To', $draft['to']);
         if (!empty($draft['cc'])) {

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -557,9 +557,10 @@ Support Options: ' . @$details['contract']['options_display'] . '
        Timezone: ' . $details['iss_contact_timezone'] . '
 Account Manager: ' . @$details['customer']['account_manager_name'];
         }
+        $iss_updated_date = Date_Helper::getFormattedDate($details['iss_updated_date']);
         $msg .= '
   Last Response: ' . $details['iss_last_response_date'] . '
-   Last Updated: ' . $details['iss_updated_date'] . "\n";
+   Last Updated: ' . $iss_updated_date . "\n";
         echo $msg;
 
         if ($full) {

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -791,7 +791,8 @@ Account Manager: ' . @$details['customer']['account_manager_name'];
         if ($display_full) {
             echo $email['seb_full_email'];
         } else {
-            echo sprintf("%15s: %s\n", 'Date', $email['sup_date']);
+            $sup_date = Date_Helper::getFormattedDate($email['sup_date']);
+            echo sprintf("%15s: %s\n", 'Date', $sup_date);
             echo sprintf("%15s: %s\n", 'From', $email['sup_from']);
             echo sprintf("%15s: %s\n", 'To', $email['sup_to']);
             echo sprintf("%15s: %s\n", 'CC', $email['sup_cc']);

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -558,8 +558,9 @@ Support Options: ' . @$details['contract']['options_display'] . '
 Account Manager: ' . @$details['customer']['account_manager_name'];
         }
         $iss_updated_date = Date_Helper::getFormattedDate($details['iss_updated_date']);
+        $iss_last_response_date = Date_Helper::getFormattedDate($details['iss_last_response_date']);
         $msg .= '
-  Last Response: ' . $details['iss_last_response_date'] . '
+  Last Response: ' . $iss_last_response_date . '
    Last Updated: ' . $iss_updated_date . "\n";
         echo $msg;
 

--- a/lib/eventum/class.date_helper.php
+++ b/lib/eventum/class.date_helper.php
@@ -407,6 +407,20 @@ class Date_Helper
     }
 
     /**
+     * Smarty helper formatting date value suitable for jquery-timeago
+     *
+     * @param string $date
+     * @return string
+     */
+    public static function formatTimeAgo($date)
+    {
+        $formatted_date = Date_Helper::getFormattedDate($date);
+        $gmt_date = self::getDateTime($date, 'GMT')->format('Y-m-d\TH:i:s\Z');
+
+        return sprintf('<abbr class="timeago" title="%s">%s</abbr>', $gmt_date, $formatted_date);
+    }
+
+    /**
      * Formats a given week start and week end to a format useable by getWeekOptions().
      *
      * @param   integer $start The start date of the week.

--- a/lib/eventum/class.draft.php
+++ b/lib/eventum/class.draft.php
@@ -267,7 +267,6 @@ class Draft
             throw new RuntimeException('email not found');
         }
 
-        $res['emd_updated_date'] = Date_Helper::getFormattedDate($res['emd_updated_date']);
         if (!empty($res['emd_unknown_user'])) {
             $res['from'] = $res['emd_unknown_user'];
         } else {
@@ -312,7 +311,6 @@ class Draft
         }
 
         foreach ($res as &$row) {
-            $row['emd_updated_date'] = Date_Helper::getFormattedDate($row['emd_updated_date']);
             if (!empty($row['emd_unknown_user'])) {
                 $row['from'] = $row['emd_unknown_user'];
             } else {

--- a/lib/eventum/class.faq.php
+++ b/lib/eventum/class.faq.php
@@ -79,7 +79,6 @@ class FAQ
             if (empty($row['faq_updated_date'])) {
                 $row['faq_updated_date'] = $row['faq_created_date'];
             }
-            $row['faq_updated_date'] = Date_Helper::getSimpleDate($row['faq_updated_date']);
         }
 
         return $res;
@@ -267,7 +266,6 @@ class FAQ
         if (empty($res['faq_updated_date'])) {
             $res['faq_updated_date'] = $res['faq_created_date'];
         }
-        $res['faq_updated_date'] = Date_Helper::getFormattedDate($res['faq_updated_date']);
         $res['message'] = Misc::activateLinks(nl2br(htmlspecialchars($res['faq_message'])));
 
         return $res;

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -119,7 +119,6 @@ class History
         }
 
         foreach ($res as &$row) {
-            $row['his_created_date'] = Date_Helper::getFormattedDate($row['his_created_date']);
             $row['his_summary'] = Misc::processTokens(ev_gettext($row['his_summary']), $row['his_context']);
         }
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -3049,9 +3049,8 @@ class Issue
         $res['associated_issues'] = self::getAssociatedIssues($res['iss_id']);
         $res['reporter'] = User::getFullName($res['iss_usr_id']);
         if (empty($res['iss_updated_date'])) {
+            // FIXME: translations, or just fill iss_created_date here?
             $res['iss_updated_date'] = 'not updated yet';
-        } else {
-            $res['iss_updated_date'] = Date_Helper::getFormattedDate($res['iss_updated_date']);
         }
         $res['estimated_formatted_time'] = Misc::getFormattedTime($res['iss_dev_time']);
         if (Release::isAssignable($res['iss_pre_id'])) {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -3049,8 +3049,7 @@ class Issue
         $res['associated_issues'] = self::getAssociatedIssues($res['iss_id']);
         $res['reporter'] = User::getFullName($res['iss_usr_id']);
         if (empty($res['iss_updated_date'])) {
-            // FIXME: translations, or just fill iss_created_date here?
-            $res['iss_updated_date'] = 'not updated yet';
+            $res['iss_updated_date'] = $res['iss_created_date'];
         }
         $res['estimated_formatted_time'] = Misc::getFormattedTime($res['iss_dev_time']);
         if (Release::isAssignable($res['iss_pre_id'])) {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -3025,7 +3025,6 @@ class Issue
         $res['iss_description'] = nl2br(htmlspecialchars($res['iss_description']));
         $res['iss_resolution'] = Resolution::getTitle($res['iss_res_id']);
         $res['iss_impact_analysis'] = nl2br(htmlspecialchars($res['iss_impact_analysis']));
-        $res['iss_created_date'] = Date_Helper::getFormattedDate($res['iss_created_date']);
         $res['iss_created_date_ts'] = $created_date_ts;
         $res['assignments'] = @implode(', ', array_values(self::getAssignedUsers($res['iss_id'])));
         list($res['authorized_names'], $res['authorized_repliers']) = Authorized_Replier::getAuthorizedRepliers($res['iss_id']);

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -543,7 +543,6 @@ class Mail_Queue
         if (count($res) > 0) {
             foreach ($res as &$row) {
                 $row['maq_recipient'] = Mime_Helper::decodeAddress($row['maq_recipient']);
-                $row['maq_queued_date'] = Date_Helper::getFormattedDate(Date_Helper::getUnixTimestamp($row['maq_queued_date'], 'GMT'));
                 $row['maq_subject'] = Mime_Helper::fixEncoding($row['maq_subject']);
             }
         }

--- a/lib/eventum/class.news.php
+++ b/lib/eventum/class.news.php
@@ -57,7 +57,6 @@ class News
         }
 
         foreach ($res as &$row) {
-            $row['nws_created_date'] = Date_Helper::getSimpleDate($row['nws_created_date']);
             if ((!$show_full_message) && (strlen($row['nws_message']) > 300)) {
                 $next_space = strpos($row['nws_message'], ' ', 254);
                 if (empty($next_space)) {

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -97,7 +97,7 @@ class Note
 
         if (count($res) > 0) {
             $res['timestamp'] = Date_Helper::getUnixTimestamp($res['not_created_date'], 'GMT');
-            $res['not_created_date'] = Date_Helper::getFormattedDate($res['not_created_date']);
+
             if ($res['not_is_blocked'] == 1) {
                 $res['has_blocked_message'] = true;
             } else {
@@ -555,7 +555,6 @@ class Note
                 $row['usr_full_name'] = $row['not_unknown_user'];
             }
 
-            $row['not_created_date'] = Date_Helper::getFormattedDate($row['not_created_date']);
             $t[] = $row;
             unset($row);
         }

--- a/lib/eventum/class.phone_support.php
+++ b/lib/eventum/class.phone_support.php
@@ -248,7 +248,6 @@ class Phone_Support
         foreach ($res as &$row) {
             $row['phs_description'] = Misc::activateLinks(nl2br(htmlspecialchars($row['phs_description'])));
             $row['phs_description'] = Link_Filter::processText($row['iss_prj_id'], $row['phs_description']);
-            $row['phs_created_date'] = Date_Helper::getFormattedDate($row['phs_created_date']);
         }
 
         return $res;

--- a/lib/eventum/class.reminder.php
+++ b/lib/eventum/class.reminder.php
@@ -1005,10 +1005,6 @@ class Reminder
             return array();
         }
 
-        foreach ($res as &$row) {
-            $row['rmh_created_date'] = Date_Helper::getFormattedDate($row['rmh_created_date']);
-        }
-
         return $res;
     }
 

--- a/lib/eventum/class.reminder.php
+++ b/lib/eventum/class.reminder.php
@@ -757,7 +757,6 @@ class Reminder
         }
 
         foreach ($res as &$row) {
-            $row['rem_created_date'] = Date_Helper::getFormattedDate($row['rem_created_date']);
             $actions = Reminder_Action::getList($row['rem_id']);
             $row['total_actions'] = count($actions);
             $priorities = self::getAssociatedPriorities($row['rem_id']);

--- a/lib/eventum/class.report.php
+++ b/lib/eventum/class.report.php
@@ -137,7 +137,7 @@ class Report
             $issues[$row['usr_full_name']][$row['iss_id']] = array(
                 'iss_summary'         => $row['iss_summary'],
                 'sta_title'           => $row['sta_title'],
-                'iss_created_date'    => Date_Helper::getFormattedDate($row['iss_created_date']),
+                'iss_created_date'    => $row['iss_created_date'],
                 'iss_last_response_date'    => Date_Helper::getFormattedDate($row['iss_last_response_date']),
                 'time_spent'          => Misc::getFormattedTime($row['time_spent']),
                 'status_color'        => $row['sta_color'],
@@ -230,7 +230,7 @@ class Report
             $issues[$name][$row['iss_id']] = array(
                 'iss_summary'         => $row['iss_summary'],
                 'sta_title'           => $row['sta_title'],
-                'iss_created_date'    => Date_Helper::getFormattedDate($row['iss_created_date']),
+                'iss_created_date'    => $row['iss_created_date'],
                 'time_spent'          => Misc::getFormattedTime($row['time_spent']),
                 'status_color'        => $row['sta_color'],
                 'last_update'         => Date_Helper::getFormattedDateDiff($ts, $update_date_ts),
@@ -286,7 +286,7 @@ class Report
             $issues[$row['usr_full_name']][$row['iss_id']] = array(
                 'iss_summary'      => $row['iss_summary'],
                 'sta_title'        => $row['sta_title'],
-                'iss_created_date' => Date_Helper::getFormattedDate($row['iss_created_date']),
+                'iss_created_date' => $row['iss_created_date'],
                 'time_spent'       => Misc::getFormattedTime($row['time_spent']),
                 'status_color'     => $row['sta_color'],
             );

--- a/lib/eventum/class.report.php
+++ b/lib/eventum/class.report.php
@@ -138,7 +138,6 @@ class Report
                 'iss_summary'         => $row['iss_summary'],
                 'sta_title'           => $row['sta_title'],
                 'iss_created_date'    => $row['iss_created_date'],
-                'iss_last_response_date'    => Date_Helper::getFormattedDate($row['iss_last_response_date']),
                 'time_spent'          => Misc::getFormattedTime($row['time_spent']),
                 'status_color'        => $row['sta_color'],
                 'last_update'         => Date_Helper::getFormattedDateDiff($ts, $updated_date_ts),

--- a/lib/eventum/class.scm.php
+++ b/lib/eventum/class.scm.php
@@ -131,7 +131,6 @@ class SCM
             $checkin['checkout_url'] = $scm->getCheckoutUrl($checkin);
             $checkin['diff_url'] = $scm->getDiffUrl($checkin);
             $checkin['scm_log_url'] = $scm->getLogUrl($checkin);
-            $checkin['isc_created_date'] = Date_Helper::getFormattedDate($checkin['isc_created_date']);
         }
 
         return $res;

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -458,7 +458,6 @@ class Search
         foreach ($res as &$row) {
             $issue_id = $row['iss_id'];
             $row['time_spent'] = Misc::getFormattedTime($row['time_spent']);
-            $row['iss_created_date'] = Date_Helper::getFormattedDate($row['iss_created_date']);
             $row['iss_expected_resolution_date'] = Date_Helper::getSimpleDate($row['iss_expected_resolution_date'], false);
             $row['excerpts'] = isset($excerpts[$issue_id]) ? $excerpts[$issue_id] : '';
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -335,7 +335,6 @@ class Support
         }
 
         foreach ($res as &$row) {
-            $row['sup_date'] = Date_Helper::getFormattedDate($row['sup_date']);
             $row['sup_subject'] = Mime_Helper::fixEncoding($row['sup_subject']);
             $row['sup_from'] = Mime_Helper::fixEncoding($row['sup_from']);
         }
@@ -1323,7 +1322,6 @@ class Support
         }
 
         foreach ($res as &$row) {
-            $row['sup_date'] = Date_Helper::getFormattedDate($row['sup_date']);
             $row['sup_subject'] = Mime_Helper::fixEncoding($row['sup_subject']);
             $row['sup_from'] = implode(', ', Mail_Helper::getName($row['sup_from'], true));
             if ((empty($row['sup_to'])) && (!empty($row['sup_iss_id']))) {
@@ -1626,7 +1624,6 @@ class Support
         $res['message'] = $res['seb_body'];
         $res['attachments'] = Mime_Helper::getAttachmentCIDs($res['seb_full_email']);
         $res['timestamp'] = Date_Helper::getUnixTimestamp($res['sup_date'], 'GMT');
-        $res['sup_date'] = Date_Helper::getFormattedDate($res['sup_date']);
         $res['sup_subject'] = Mime_Helper::fixEncoding($res['sup_subject']);
         // TRANSLATORS: %1 = email subject
         $res['reply_subject'] = Mail_Helper::removeExcessRe(ev_gettext('Re: %1$s', $res['sup_subject']), true);
@@ -1795,7 +1792,6 @@ class Support
         }
 
         foreach ($res as &$row) {
-            $row['sup_date'] = Date_Helper::getFormattedDate($row['sup_date']);
             $row['sup_subject'] = Mime_Helper::fixEncoding($row['sup_subject']);
             $row['sup_from'] = Mime_Helper::fixEncoding($row['sup_from']);
             $row['sup_to'] = Mime_Helper::fixEncoding($row['sup_to']);

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -58,6 +58,7 @@ class Template_Helper
         $smarty->registerPlugin('modifier', 'formatCustomValue', array('Custom_Field', 'formatValue'));
         $smarty->registerPlugin('modifier', 'bool', array('Misc', 'getBooleanDisplayValue'));
         $smarty->registerPlugin('modifier', 'format_date', array('Date_Helper', 'getFormattedDate'));
+        $smarty->registerPlugin('modifier', 'timeago', array('Date_Helper', 'formatTimeAgo'));
 
         // Fixes problem with CRM API and dynamic includes.
         // See https://code.google.com/p/smarty-php/source/browse/trunk/distribution/3.1.16_RELEASE_NOTES.txt?spec=svn4800&r=4800

--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -379,7 +379,6 @@ class Time_Tracking
         foreach ($res as &$row) {
             $row['ttr_summary'] = Link_Filter::processText(Issue::getProjectID($issue_id), nl2br(htmlspecialchars($row['ttr_summary'])));
             $row['formatted_time'] = Misc::getFormattedTime($row['ttr_time_spent']);
-            $row['ttr_created_date'] = Date_Helper::getFormattedDate($row['ttr_created_date']);
 
             if (isset($total_time_by_user[$row['ttr_usr_id']])) {
                 $total_time_by_user[$row['ttr_usr_id']]['time_spent'] += $row['ttr_time_spent'];

--- a/src/Controller/UpdateController.php
+++ b/src/Controller/UpdateController.php
@@ -356,10 +356,12 @@ class UpdateController extends BaseController
         $columns[1][] = array(
             'title' => ev_gettext('Submitted Date'),
             'data' => $details['iss_created_date'],
+            'field' => 'iss_created_date',
         );
         $columns[1][] = array(
             'title' => ev_gettext('Last Updated Date'),
             'data' => $details['iss_updated_date'],
+            'field' => 'iss_updated_date',
         );
         $columns[1][] = array(
             'title' => ev_gettext('Associated Issues'),

--- a/src/Controller/ViewController.php
+++ b/src/Controller/ViewController.php
@@ -354,6 +354,7 @@ class ViewController extends BaseController
         $columns[1][] = array(
             'title' => ev_gettext('Submitted Date'),
             'data' => $details['iss_created_date'],
+            'field' => 'iss_created_date',
         );
         $columns[1][] = array(
             'title' => ev_gettext('Last Updated Date'),

--- a/src/Controller/ViewController.php
+++ b/src/Controller/ViewController.php
@@ -359,6 +359,7 @@ class ViewController extends BaseController
         $columns[1][] = array(
             'title' => ev_gettext('Last Updated Date'),
             'data' => $details['iss_updated_date'],
+            'field' => 'iss_updated_date',
         );
         $columns[1][] = array(
             'title' => ev_gettext('Associated Issues'),

--- a/templates/attachments.tpl.html
+++ b/templates/attachments.tpl.html
@@ -44,7 +44,7 @@
               {/if}
             </td>
             {/if}
-            <td width="15%" nowrap>{$files[i].iat_created_date|format_date}</td>
+            <td width="15%" nowrap>{$files[i].iat_created_date|timeago}</td>
             <td width="45%">{$files[i].iat_description}</td>
           </tr>
           {sectionelse}

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -36,6 +36,7 @@
   <script type="text/javascript" src="{$core.rel_url}components/jquery-chosen/chosen.jquery.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/dropzone/dist/dropzone.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/autosize/dist/autosize.js"></script>
+  <script type="text/javascript" src="{$core.rel_url}components/jquery-timeago/jquery.timeago.js"></script>
 
   {* our css/js after remote assets to allow overrides *}
   <link rel="stylesheet" type="text/css" media="screen" href="{$core.rel_url}css/main.css">

--- a/templates/checkins.tpl.html
+++ b/templates/checkins.tpl.html
@@ -89,7 +89,7 @@ $(function() {
             <td valign="top">
               <input type="checkbox" name="item[]" value="{$checkins[i].isc_id}">
             </td>
-            <td valign="top" nowrap>{$checkins[i].isc_created_date}</td>
+            <td valign="top" nowrap>{$checkins[i].isc_created_date|timeago}</td>
             <td valign="top" >{$checkins[i].isc_username|escape:"html"}</td>
             <td valign="top">{$checkins[i].isc_module|escape:"html"}</td>
             <td valign="top" nowrap class="checkins">

--- a/templates/email_drafts.tpl.html
+++ b/templates/email_drafts.tpl.html
@@ -65,7 +65,7 @@ function showAllDrafts(thisBox)
             {/if}
             <td width="20%">{$drafts[i].from|escape:"html"}</td>
             <td width="20%">{$drafts[i].to|escape:"html"}</td>
-            <td width="20%" nowrap>{$drafts[i].emd_updated_date}</td>
+            <td width="20%" nowrap>{$drafts[i].emd_updated_date|timeago}</td>
             <td width="40%">
               <a title="{t}view email details{/t}" href="javascript:void(null);" onClick="viewDraft({$drafts[i].emd_id}, {$smarty.get.id|intval});">{$drafts[i].emd_subject|default:"<Empty Subject Header>"|escape:"html"}</a>
             </td>

--- a/templates/emails.tpl.html
+++ b/templates/emails.tpl.html
@@ -204,7 +204,7 @@
             {if $core.has_crm}
             <td nowrap>{$list[i].customer_title|escape:"html"}</td>
             {/if}
-            <td align="center" nowrap>{$list[i].sup_date}</td>
+            <td align="center" nowrap>{$list[i].sup_date|timeago}</td>
             <td>{$list[i].sup_to|escape:"html"|replace:",":" "}</td>
             <td align="center" nowrap>
                 {if $list[i].sup_iss_id != 0}

--- a/templates/faq.tpl.html
+++ b/templates/faq.tpl.html
@@ -34,7 +34,7 @@
         <th>{t}Last Updated Date{/t}</th>
     </tr>
     {section name="i" loop=$faqs}
-    <tr class="{cycle value='odd,even'}">
+    <tr class="{cycle values='odd,even'}">
         <td><b><a href="faq.php?id={$faqs[i].faq_id}" title="{t}read faq entry{/t}">{$faqs[i].faq_title}</a></b></td>
         <td>{$faqs[i].faq_updated_date}</td>
     </tr>

--- a/templates/faq.tpl.html
+++ b/templates/faq.tpl.html
@@ -14,7 +14,7 @@
     </tr>
     <tr>
         <td>
-            <p><i>{t}Last updated{/t}: {$faq.faq_updated_date}</i></p>
+            <p><i>{t}Last updated{/t}: {$faq.faq_updated_date|timeago}</i></p>
             {$faq.message}
         </td>
     </tr>
@@ -36,7 +36,7 @@
     {section name="i" loop=$faqs}
     <tr class="{cycle values='odd,even'}">
         <td><b><a href="faq.php?id={$faqs[i].faq_id}" title="{t}read faq entry{/t}">{$faqs[i].faq_title}</a></b></td>
-        <td>{$faqs[i].faq_updated_date}</td>
+        <td>{$faqs[i].faq_updated_date|timeago}</td>
     </tr>
     {/section}
     </tr>

--- a/templates/history.tpl.html
+++ b/templates/history.tpl.html
@@ -16,7 +16,7 @@
       {section name="i" loop=$changes}
       <tr class="{cycle values='odd,even'}">
         <th {if $changes[i].his_min_role > $core.roles.customer}class="internal"{/if} nowrap>
-          {$changes[i].his_created_date}
+          {$changes[i].his_created_date|timeago}
         </th>
         <td width="85%">
           {$changes[i].his_summary|activateLinks|replace:"no value set":"<i>no value set</i>"}

--- a/templates/history.tpl.html
+++ b/templates/history.tpl.html
@@ -50,7 +50,7 @@
       {section name="i" loop=$reminders}
       <tr class="{cycle values='odd,even'}">
         <td nowrap>
-          {$reminders[i].rmh_created_date}
+          {$reminders[i].rmh_created_date|timeago}
         </td>
         <td width="85%">
           {$reminders[i].rma_title|escape:"html"}

--- a/templates/latest_news.tpl.html
+++ b/templates/latest_news.tpl.html
@@ -9,7 +9,7 @@
               <tr>
                 <td>
                   {section name="i" loop=$news}
-                  <b>{$news[i].nws_created_date} - <a href="news.php?id={$news[i].nws_id}" title="{t}full news entry{/t}">{$news[i].nws_title}</a></b>
+                  <b>{$news[i].nws_created_date|timeago} - <a href="news.php?id={$news[i].nws_id}" title="{t}full news entry{/t}">{$news[i].nws_title}</a></b>
                   <br /><br />
                   {$news[i].nws_message|activateLinks:"links"}
                   <br /><br />

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -111,7 +111,7 @@
             {elseif $field_name == 'sta_rank'}
               {$list[i].sta_title|escape:"html"}
             {elseif $field_name == 'iss_created_date'}
-              {$list[i].iss_created_date|escape:"html"}
+              {$list[i].iss_created_date|timeago}
             {elseif $field_name == 'iss_dev_time'}
               {$list[i].iss_dev_time|escape:"html"}
             {elseif $field_name == 'sta_change_date'}

--- a/templates/mail_queue.tpl.html
+++ b/templates/mail_queue.tpl.html
@@ -25,7 +25,7 @@
         <tr class="{cycle values='odd,even'}">
             <td NOWRAP>{include file="expandable_cell/buttons.tpl.html" ec_id="mailqueue" list_id=$data[i].maq_id}</td>
             <td width="20%">{$data[i].maq_recipient|escape:"html"}</td>
-            <td width="20%" nowrap>{$data[i].maq_queued_date}</td>
+            <td width="20%" nowrap>{$data[i].maq_queued_date|timeago}</td>
             <td width="10%">{$data[i].maq_status}</td>
             <td width="50%">{$data[i].maq_subject|escape:"html"}</td>
         </tr>

--- a/templates/news.tpl.html
+++ b/templates/news.tpl.html
@@ -12,7 +12,7 @@
     <tr>
         <td>
             {section name="i" loop=$news}
-            <h3>{$news[i].nws_created_date} - {$news[i].nws_title}</h3>
+            <h3>{$news[i].nws_created_date|timeago} - {$news[i].nws_title}</h3>
             <p>{$news[i].nws_message|activateLinks:"links"}</p>
             {/section}
         </td>

--- a/templates/notes.tpl.html
+++ b/templates/notes.tpl.html
@@ -73,7 +73,7 @@ function replyNote(el)
             <td align="center">
               <a title="{t}reply to this note{/t}" href="post_note.php?cat=reply&id={$notes[i].not_id}&issue_id={$smarty.get.id|intval}" onClick="return replyNote(this);"><img src="{$core.rel_url}images/icons/reply.gif" border="0"></a>
             </td>
-            <td>{$notes[i].not_created_date}</td>
+            <td>{$notes[i].not_created_date|timeago}</td>
             <td>
               {$notes[i].usr_full_name|escape:"html"}
               {if $core.user.usr_id == $notes[i].not_usr_id OR $core.current_role >= $core.roles.manager}[ <a href="popup.php?cat=delete_note&id={$notes[i].not_id}" onClick="return deleteNote(this)">{t}delete{/t}</a> ]{/if}

--- a/templates/notifications/closed.tpl.text
+++ b/templates/notifications/closed.tpl.text
@@ -16,7 +16,7 @@
 ----------------------------------------------------------------------
                {t escape=no}ID{/t}: {$data.iss_id}
           {t escape=no}Summary{/t}: {$data.iss_summary}
-        {t escape=no}Submitted{/t}: {$data.iss_created_date}
+        {t escape=no}Submitted{/t}: {$data.iss_created_date|format_date}
            {t escape=no}Status{/t}: {$data.sta_title}
           {t escape=no}Project{/t}: {$data.prj_title}
       {t escape=no}Reported By{/t}: {$data.reporter}

--- a/templates/notifications/new_auto_created_issue.tpl.text
+++ b/templates/notifications/new_auto_created_issue.tpl.text
@@ -25,4 +25,4 @@ To view more details of this issue, or to update it, please visit the following 
      {t escape=no}Issue{/t} #: {$data.iss_id}
      {t escape=no}Summary{/t}: {$data.iss_summary}
     {t escape=no}Priority{/t}: {$data.pri_title}
-   {t escape=no}Submitted{/t}: {$data.iss_created_date}
+   {t escape=no}Submitted{/t}: {$data.iss_created_date|format_date}

--- a/templates/phone_support.tpl.html
+++ b/templates/phone_support.tpl.html
@@ -49,7 +49,7 @@ function addPhoneCall()
           <tr class="{$row_class}">
             <td nowrap>{include file="expandable_cell/buttons.tpl.html" ec_id="phone" list_id=$phone_entries[i].phs_id}</td>
             <td nowrap>{$smarty.section.i.iteration}</td>
-            <td nowrap>{$phone_entries[i].phs_created_date}</td>
+            <td nowrap>{$phone_entries[i].phs_created_date|timeago}</td>
             <td>
                 {$phone_entries[i].usr_full_name|escape:html}
                 {if $core.user.usr_id == $phone_entries[i].phs_usr_id}

--- a/templates/removed_emails.tpl.html
+++ b/templates/removed_emails.tpl.html
@@ -77,7 +77,7 @@
                 <input type="checkbox" name="item[]" value="{$list[i].sup_id}">
             </td>
             <td align="center" nowrap>
-                {$list[i].sup_date}
+                {$list[i].sup_date|timeago}
             </td>
             <td width="20%">
                 {$list[i].sup_from|escape:"html"}

--- a/templates/reports/issue_user.tpl.html
+++ b/templates/reports/issue_user.tpl.html
@@ -18,7 +18,7 @@
           <td bgcolor="{$issue.status_color}"><a target="_top" href="{$core.rel_url}view.php?id={$issue_id}" title="{t}view issue details{/t}">{$issue.iss_summary|escape:"html"}</a></td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.sta_title|escape:"html"}</td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.time_spent}</td>
-          <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date}</td>
+          <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date|timeago}</td>
         </tr>
         {/foreach}
       </table>

--- a/templates/reports/open_issues.tpl.html
+++ b/templates/reports/open_issues.tpl.html
@@ -46,7 +46,7 @@
           <td bgcolor="{$issue.status_color}"><a target="_top" href="{$core.rel_url}view.php?id={$issue_id}" title="{t}view issue details{/t}">{$issue.iss_summary|escape:"html"}</a></td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.sta_title|escape:"html"}</td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.time_spent}</td>
-          <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date}</td>
+          <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date|timeago}</td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.last_update}</td>
           <td bgcolor="{$issue.status_color}" align="center">{$issue.last_email_response}</td>
         </tr>

--- a/templates/reports/stalled_issues.tpl.html
+++ b/templates/reports/stalled_issues.tpl.html
@@ -82,7 +82,7 @@
         <td bgcolor="{$issue.status_color}"><a target="_top" href="{$core.rel_url}view.php?id={$issue_id}" title="{t}view issue details{/t}">{$issue.iss_summary|escape:"html"}</a></td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.sta_title|escape:"html"}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.time_spent}</td>
-        <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date}</td>
+        <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date|timeago}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_last_response_date}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.last_update}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.last_email_response}</td>

--- a/templates/reports/stalled_issues.tpl.html
+++ b/templates/reports/stalled_issues.tpl.html
@@ -83,7 +83,7 @@
         <td bgcolor="{$issue.status_color}" align="center">{$issue.sta_title|escape:"html"}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.time_spent}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_created_date|timeago}</td>
-        <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_last_response_date}</td>
+        <td bgcolor="{$issue.status_color}" align="center">{$issue.iss_last_response_date|timeago}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.last_update}</td>
         <td bgcolor="{$issue.status_color}" align="center">{$issue.last_email_response}</td>
     </tr>

--- a/templates/rss.tpl.xml
+++ b/templates/rss.tpl.xml
@@ -31,7 +31,7 @@
 			<?php echo Date_Helper::getRFC822Date($issue['iss_created_date'], "GMT");
 				{$issue.iss_created_date|Date_Helper::getRFC822Date:"GMT"}
 			*}
-			<pubDate>{$issue.iss_created_date}</pubDate>
+			<pubDate>{$issue.iss_created_date|format_date}</pubDate>
 		</item>
 		{/foreach}
 

--- a/templates/support_emails.tpl.html
+++ b/templates/support_emails.tpl.html
@@ -127,7 +127,7 @@
                     {$emails[i].sup_cc|escape:"html"}
                     {/if}
                 </td>
-                <td nowrap>{$emails[i].sup_date}</td>
+                <td nowrap>{$emails[i].sup_date|timeago}</td>
                 <td>
                     <a title="{t}view email details{/t}" href="javascript:void(null);" onClick="viewEmail({$emails[i].sup_ema_id}, {$emails[i].sup_id});">{$emails[i].sup_subject|default:"<Empty Subject Header>"|escape:"html"}</a>
                     {if $emails[i].sup_has_attachment}

--- a/templates/support_emails.tpl.html
+++ b/templates/support_emails.tpl.html
@@ -93,7 +93,7 @@
                 <td>
                     <em>{t}sent to notification list{/t}</em>
                 </td>
-                <td nowrap>{$issue.iss_created_date}</td>
+                <td nowrap>{$issue.iss_created_date|timeago}</td>
                 <td>
                     {$issue.iss_summary|escape:"html"}
                 </td>

--- a/templates/time_tracking.tpl.html
+++ b/templates/time_tracking.tpl.html
@@ -46,7 +46,7 @@ function addTimeEntry()
           {section name="i" loop=$time_entries}
           <tr class="{cycle values='odd,even'}">
             <td>{$smarty.section.i.iteration}</td>
-            <td nowrap>{$time_entries[i].ttr_created_date}</td>
+            <td nowrap>{$time_entries[i].ttr_created_date|timeago}</td>
             <td nowrap>
               {$time_entries[i].usr_full_name|escape:html}
               {if $core.user.usr_id == $time_entries[i].ttr_usr_id}[ <a href="javascript:void(null);" onClick="deleteTimeEntry({$time_entries[i].ttr_id});">{t}delete{/t}</a> ]{/if}

--- a/templates/update_form.tpl.html
+++ b/templates/update_form.tpl.html
@@ -107,14 +107,21 @@
             <tr>
                 <th {if isset($row.title_bgcolor)}style="background-color: {$row.title_bgcolor}"{/if}>{$row.title}</th>
                 <td {if isset($row.data_bgcolor)}style="background-color: {$row.data_bgcolor}"{/if}>
-                {if !isset($row.field)}
-                    {$row.data|escape:"html"}
+
+                {if in_array($row.field|default:'', array('iss_created_date', 'iss_updated_date'))}
+                  {$row.data|timeago}
+
+                {elseif !isset($row.field)}
+                  {$row.data|escape:"html"}
+
                 {elseif $row.field|default:'' == 'notification_list'}
                     {if $subscribers.staff != ''}{t}Staff{/t}: {$subscribers.staff|replace:"<":"&lt;"|replace:">":"&gt;"}{/if}
                     {if $subscribers.staff != '' and $subscribers.customers != ''}<br />{/if}
                     {if $subscribers.customers != ''}{t}Other{/t}: {$subscribers.customers|replace:"<":"&lt;"|replace:">":"&gt;"}{/if}
+
                 {elseif $row.field|default:'' == 'expected_resolution'}
                     <input type="text" name="expected_resolution_date" id="expected_resolution" value="{$issue.iss_expected_resolution_date}" class="date_picker">
+
                 {elseif $row.field|default:'' == 'duplicates'}
                     {if $issue.iss_duplicated_iss_id}
                     {t}Duplicate of{/t}: <a href="{$core.rel_url}view.php?id={$issue.iss_duplicated_iss_id}" title="{t}issue{/t} #{$issue.iss_duplicated_iss_id} ({$issue.duplicated_issue.current_status|escape:"html"}) - {$issue.duplicated_issue.title|escape:"html"}" class="{if $issue.duplicated_issue.is_closed}closed{/if}">#{$issue.iss_duplicated_iss_id}</a>
@@ -129,6 +136,7 @@
                     {/strip}
                     {/section}
                     {/if}
+
                 {elseif $row.field|default:'' == 'authorized_repliers'}
                     {if $issue.authorized_repliers.users|@count > 0}
                     {t}Staff{/t}:
@@ -149,6 +157,7 @@
                     {/strip}
                     {/section}
                     {/if}
+
                 {elseif $row.field|default:'' == 'customer_1'}
                     {t}Support Level{/t}: {$issue.contract.support_level}
                     {if $issue.contract.options_display|default:''}
@@ -168,11 +177,14 @@
                     {/strip}
                     {if $has_redeemed_incident != 1}<i>{t}None{/t}</i>{/if}
                     {/if}
+
                 {elseif $row.field == 'associated_issues'}
                     {include file="include/issue_field.tpl.html" field_name="associated_issues" form_name='update_form' value=", "|join:$issue.associated_issues}
+
                 {elseif $row.field == 'estimated_dev_time'}
                     <input type="text" name="estimated_dev_time" value="{$issue.iss_dev_time}" size="4">
                     <span>({t}in hours{/t})</span>
+
                 {elseif $row.field == 'group'}
                     <select name="group">
                         <option value=""></option>

--- a/templates/view_email.tpl.html
+++ b/templates/view_email.tpl.html
@@ -139,7 +139,7 @@ setTimeout('Eventum.close_and_refresh()', 2000);
             {t}Received{/t}:
           </th>
           <td>
-            {$email.sup_date}
+            {$email.sup_date|timeago}
           </td>
         </tr>
         <tr>

--- a/templates/view_form.tpl.html
+++ b/templates/view_form.tpl.html
@@ -88,7 +88,7 @@
                     <th {if isset($row.title_bgcolor)}style="background-color: {$row.title_bgcolor}"{/if}>{$row.title}</th>
                     <td {if isset($row.data_bgcolor)}style="background-color: {$row.data_bgcolor}"{/if}>
 
-                    {if $row.field|default:'' == 'iss_created_date'}
+                    {if in_array($row.field|default:'', array('iss_created_date', 'iss_updated_date'))}
                       {$row.data|timeago}
 
                     {elseif array_key_exists('data', $row)}

--- a/templates/view_form.tpl.html
+++ b/templates/view_form.tpl.html
@@ -87,12 +87,19 @@
                 <tr>
                     <th {if isset($row.title_bgcolor)}style="background-color: {$row.title_bgcolor}"{/if}>{$row.title}</th>
                     <td {if isset($row.data_bgcolor)}style="background-color: {$row.data_bgcolor}"{/if}>
-                    {if array_key_exists('data', $row)}
+
+                    {if $row.field|default:'' == 'iss_created_date'}
+                      {$row.data|timeago}
+
+                    {elseif array_key_exists('data', $row)}
                         {$row.data|escape:"html"}
+
                     {elseif $row.field|default:'' == 'notification_list'}
+
                     {if $subscribers.staff != ''}{t}Staff{/t}: {$subscribers.staff|replace:"<":"&lt;"|replace:">":"&gt;"}{/if}
                     {if $subscribers.staff != '' and $subscribers.customers != ''}<br />{/if}
                     {if $subscribers.customers != ''}{t}Other{/t}: {$subscribers.customers|replace:"<":"&lt;"|replace:">":"&gt;"}{/if}
+
                     {elseif $row.field|default:'' == 'associated_issues'}
                     {section name="i" loop=$issue.associated_issues_details}
                     {strip}
@@ -108,6 +115,7 @@
                         {else}
                             {$issue.iss_expected_resolution_date|escape:"html"}
                         {/if}
+
                     {elseif $row.field|default:'' == 'duplicates'}
                     {if $issue.iss_duplicated_iss_id}
                     {t}Duplicate of{/t}: <a href="{$core.rel_url}view.php?id={$issue.iss_duplicated_iss_id}" title="{t}issue{/t} #{$issue.iss_duplicated_iss_id} ({$issue.duplicated_issue.current_status|escape:"html"}) - {$issue.duplicated_issue.title|escape:"html"}" class="{if $issue.duplicated_issue.is_closed}closed{/if}">#{$issue.iss_duplicated_iss_id}</a>
@@ -122,6 +130,7 @@
                     {/strip}
                     {/section}
                     {/if}
+
                     {elseif $row.field|default:'' == 'authorized_repliers'}
                     {if $issue.authorized_repliers.users|@count > 0}
                     {t}Staff{/t}:
@@ -142,6 +151,7 @@
                     {/strip}
                     {/section}
                     {/if}
+
                     {elseif $row.field|default:'' == 'customer_1'}
                         {t}Support Level{/t}: {$issue.contract.support_level}
                         {if $issue.contract.options_display|default:''}

--- a/templates/view_note.tpl.html
+++ b/templates/view_note.tpl.html
@@ -67,7 +67,7 @@ function viewNote(id)
             {t}Posted Date{/t}:
           </th>
           <td>
-            {$note.not_created_date}
+            {$note.not_created_date|timeago}
           </td>
         </tr>
         <tr>


### PR DESCRIPTION
uses [jquery-timeago](http://timeago.yarp.com/) to print dates human readable.
to switch between human readable time ago and full timestamp, just click on the element.

could be done, but not (yet?):
- user preference to disable `timeago` formatting
- localized `timeago` messages. localized strings exist in [jquery-timeago](https://github.com/rmm5t/jquery-timeago/tree/v1.4.3/locales) project

how to check?
- code should not use `Date_Helper::getFormattedDate` method
- templates should use `{$var|format_date}` or `{$var|timeago}` modifier

----

before:
![before](https://cloud.githubusercontent.com/assets/199095/11452451/6d46d5e0-95f0-11e5-8352-0e75acdc9686.png)

after:
![after2](https://cloud.githubusercontent.com/assets/199095/11452454/761c70ee-95f0-11e5-912c-ce0398f7a4fd.png)
