### PR TITLE
reuse existing Routing::route to route mails from support::getEmailInfo

### DIFF
--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -35,15 +35,11 @@ class Routing
 
         // we create addresses array so it can be reused
         $addresses = array();
-        if (isset($structure->to)) {
-            foreach ($structure->to as $address) {
-                $addresses[] = $address->mailbox . '@' . $address->host;
-            }
+        if (isset($structure->headers['to'])) {
+            $addresses[] = $structure->headers['to'];
         }
-        if (isset($structure->cc)) {
-            foreach ($structure->cc as $address) {
-                $addresses[] = $address->mailbox . '@' . $address->host;
-            }
+        if (isset($structure->headers['cc'])) {
+            $addresses[] = $structure->headers['cc'];
         }
         // free memory
         unset($structure);
@@ -59,6 +55,9 @@ class Routing
 
         $types = array('email', 'note', 'draft');
         foreach ($addresses as $address) {
+            // NOTE: $address is not individual recipients,
+            // but rather raw To or Cc header containing multiple addresses
+
             foreach ($types as $type) {
                 // route type needs to be enabled
                 if (!$routing[$type]) {

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -349,6 +349,13 @@ class Routing
         }
 
         $prj_id = Issue::getProjectID($issue_id);
+
+        if (!$prj_id) {
+            // if project id can't be fetched, the issue does not exist,
+            // no point check deeper
+            throw RoutingException::noIssuePermission($issue_id);
+        }
+
         // check if the sender is allowed in this issue' project and if it is an internal user
         $sender_email = strtolower(Mail_Helper::getEmailAddress($structure->headers['from']));
         $sender_usr_id = User::getUserIDByEmail($sender_email, true);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -514,14 +514,12 @@ class Support
             try {
                 $routed = Routing::route($message);
             } catch (RoutingException $e) {
-                self::bounceMessage($email, $e);
-
-                // if leave copy of emails on IMAP server is off we can
-                // bounce on note that user had no permission to write
-                // here.
+                // "if leave copy of emails on IMAP server" is "off",
+                // then we can bounce on the message
                 // otherwise proper would be to create table -
                 // eventum_bounce: bon_id, bon_message_id, bon_error
                 if (!$info['ema_leave_copy']) {
+                    self::bounceMessage($email, $e);
                     self::deleteMessage($info, $mbox, $num);
                 }
                 return;

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Mail\Exception\RoutingException;
+
 /**
  * Class to handle the business logic related to the email feature of
  * the application.
@@ -412,18 +414,17 @@ class Support
     /**
      * Bounce message to sender.
      *
-     * @param   object  $message parsed message structure.
-     * @param   array   array(ERROR_CODE, ERROR_STRING) of error to bounce
-     * @return  void
+     * @param object $message parsed message structure.
+     * @param Exception $error
      */
-    public function bounceMessage($message, $error)
+    private function bounceMessage($message, $error)
     {
         // open text template
         $tpl = new Template_Helper();
         $tpl->setTemplate('notifications/bounced_email.tpl.text');
         $tpl->assign(array(
-            'error_code'        => $error[0],
-            'error_message'     => $error[1],
+            'error_code'        => $error->getCode(),
+            'error_message'     => $error->getMessage(),
             'date'              => $message->date,
             'subject'           => Mime_Helper::fixEncoding($message->subject),
             'from'              => Mime_Helper::fixEncoding($message->fromaddress),
@@ -510,94 +511,33 @@ class Support
 
         // route emails if necessary
         if ($info['ema_use_routing'] == 1) {
-            $setup = Setup::get();
+            try {
+                $routed = Routing::route($message);
+            } catch (RoutingException $e) {
+                self::bounceMessage($email, $e);
 
-            // we create addresses array so it can be reused
-            $addresses = array();
-            if (isset($email->to)) {
-                foreach ($email->to as $address) {
-                    $addresses[] = $address->mailbox . '@' . $address->host;
+                // if leave copy of emails on IMAP server is off we can
+                // bounce on note that user had no permission to write
+                // here.
+                // otherwise proper would be to create table -
+                // eventum_bounce: bon_id, bon_message_id, bon_error
+                if (!$info['ema_leave_copy']) {
+                    self::deleteMessage($info, $mbox, $num);
                 }
-            }
-            if (isset($email->cc)) {
-                foreach ($email->cc as $address) {
-                    $addresses[] = $address->mailbox . '@' . $address->host;
-                }
+                return;
             }
 
-            if ($setup['email_routing']['status'] == 'enabled') {
-                $res = Routing::getMatchingIssueIDs($addresses, 'email');
-                if ($res != false) {
-                    $return = Routing::route_emails($message);
-                    if ($return === true) {
-                        self::deleteMessage($info, $mbox, $num);
-
-                        return;
-                    }
-                    // TODO: handle errors?
-                    return;
-                }
-            }
-            if ($setup['note_routing']['status'] == 'enabled') {
-                $res = Routing::getMatchingIssueIDs($addresses, 'note');
-                if ($res != false) {
-                    $return = Routing::route_notes($message);
-
-                    // if leave copy of emails on IMAP server is off we can
-                    // bounce on note that user had no permission to write
-                    // here.
-                    // otherwise proper would be to create table -
-                    // eventum_bounce: bon_id, bon_message_id, bon_error
-
-                    if ($info['ema_leave_copy']) {
-                        if ($return === true) {
-                            self::deleteMessage($info, $mbox, $num);
-                        }
-                    } else {
-                        if ($return !== true) {
-                            // in case of error, create bounce, but still
-                            // delete email not to send bounce in next process :)
-                            self::bounceMessage($email, $return);
-                        }
-                        self::deleteMessage($info, $mbox, $num);
-                    }
-
-                    return;
-                }
-            }
-            if ($setup['draft_routing']['status'] == 'enabled') {
-                $res = Routing::getMatchingIssueIDs($addresses, 'draft');
-                if ($res != false) {
-                    $return = Routing::route_drafts($message);
-
-                    // if leave copy of emails on IMAP server is off we can
-                    // bounce on note that user had no permission to write
-                    // here.
-                    // otherwise proper would be to create table -
-                    // eventum_bounce: bon_id, bon_message_id, bon_error
-
-                    if ($info['ema_leave_copy']) {
-                        if ($return === true) {
-                            self::deleteMessage($info, $mbox, $num);
-                        }
-                    } else {
-                        if ($return !== true) {
-                            // in case of error, create bounce, but still
-                            // delete email not to send bounce in next process :)
-                            self::bounceMessage($email, $return);
-                        }
-                        self::deleteMessage($info, $mbox, $num);
-                    }
-
-                    return;
+            // the mail was routed
+            if ($routed === true) {
+                if (!$info['ema_leave_copy']) {
+                    self::deleteMessage($info, $mbox, $num);
                 }
             }
 
-            // TODO:
-            // disabling return here allows routing and issue auto creating from same account
+            // no issue-, note-, draft- routing,
+            // continue to allow routing and issue auto creating from same account
             // but it will download email store it in database and do nothing
             // with it if it does not match support@ address.
-            //return;
         }
 
         $sender_email = Mail_Helper::getEmailAddress($email->fromaddress);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -533,10 +533,12 @@ class Support
                 return;
             }
 
-            // no issue-, note-, draft- routing,
-            // continue to allow routing and issue auto creating from same account
-            // but it will download email store it in database and do nothing
-            // with it if it does not match support@ address.
+            // no match for issue-, note-, draft- routing,
+            // continue to allow routing and issue auto creating from same account,
+            // but it will download email, store it in database and do nothing with it
+            // if it does not match support@ address.
+            // by "do nothing" it is meant that the mail will be downloaded each time
+            // the mails are processed from imap account.
         }
 
         $sender_email = Mail_Helper::getEmailAddress($email->fromaddress);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -530,6 +530,7 @@ class Support
                 if (!$info['ema_leave_copy']) {
                     self::deleteMessage($info, $mbox, $num);
                 }
+                return;
             }
 
             // no issue-, note-, draft- routing,


### PR DESCRIPTION
reuse existing Routing::route to route mails from support::getEmailInfo
some methods made private as they are no longer used elsewhere.

i have not tested the code yet, it's hard to test this in dev environment, but i compared the methods and they seem to do similar thing

there was some confusion with `ema_leave_copy` handling. i think it got in broken in initial commit dc0bf7185 (Eventum 2.2), which is probably now fixed with 137bd2b943a