### PR TITLE
fix wrapping the long lines

### DIFF
--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -153,6 +153,12 @@ body#issue_view div.issue_section {
 body#issue_view div.issue_section div.content table {
     width: 100%;
 }
+td#email_message,
+body#issue_view div.issue_section div.content table td {
+    -ms-word-break: break-all;
+    word-break: break-all;
+    word-break: break-word;
+}
 
 body#issue_view div#time_tracking tr.total_time td:first-child {
     background: #9c494b;


### PR DESCRIPTION
Prevent long lines make width very long, wrap them to the next line. Based on CSS provided by Risto Risti.

Inside issue view:
![issue](https://cloud.githubusercontent.com/assets/12842560/12643271/bfe8a10e-c5c3-11e5-82cd-55aa056e6afb.png)

Note view:
![note](https://cloud.githubusercontent.com/assets/12842560/12643324/1d632962-c5c4-11e5-95e2-7c362cf66a1d.png)
