### PR TITLE
move Db classes under Eventum\Db namespace

### DIFF
--- a/bin/upgrade.php
+++ b/bin/upgrade.php
@@ -7,6 +7,8 @@
  * https://github.com/eventum/eventum/wiki/Upgrading
  */
 
+use Eventum\Db\Migrate;
+
 define('INSTALL_PATH', __DIR__ . '/..');
 define('CONFIG_PATH', INSTALL_PATH . '/config');
 
@@ -24,7 +26,7 @@ require_once INSTALL_PATH . '/init.php';
 $patch = isset($argv[1]) ? (int)$argv[1] : null;
 
 try {
-    $dbmigrate = new DbMigrate(INSTALL_PATH . '/upgrade');
+    $dbmigrate = new Migrate(INSTALL_PATH . '/upgrade');
     $dbmigrate->patch_database($patch);
 } catch (Exception $e) {
     echo $e->getMessage(), "\n";

--- a/docs/examples/htdocs/customer/example/create_customers.php
+++ b/docs/examples/htdocs/customer/example/create_customers.php
@@ -10,6 +10,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 require_once __DIR__ . '/../../../init.php';
 
 // creates user accounts for all the customers
@@ -47,7 +49,7 @@ foreach ($customers as $customer_id => $customer_name) {
             );
             try {
                 DB_Helper::getInstance()->query($sql, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 echo 'Error inserting user<br />';
             }
             $new_usr_id = DB_Helper::get_last_insert_id();

--- a/docs/examples/workflow/class.example.php
+++ b/docs/examples/workflow/class.example.php
@@ -9,6 +9,7 @@
  * please see the COPYING and AUTHORS files
  * that were distributed with this source code.
  */
+use Eventum\Db\DatabaseException;
 
 /**
  * Example workflow backend class. For example purposes it will print what
@@ -226,7 +227,7 @@ class Example_Workflow_Backend extends Abstract_Workflow_Backend
                     iss_id = ?";
         try {
             DB_Helper::getInstance()->query($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 

--- a/htdocs/reports/category_statuses.php
+++ b/htdocs/reports/category_statuses.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 require_once __DIR__ . '/../../init.php';
 
 $tpl = new Template_Helper();
@@ -46,7 +48,7 @@ foreach ($categories as $cat_id => $cat_title) {
                     iss_prc_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($prj_id, $sta_id, $cat_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             break 2;
         }
         $data[$cat_id]['statuses'][$sta_id] = array(

--- a/htdocs/reports/estimated_dev_time.php
+++ b/htdocs/reports/estimated_dev_time.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 require_once __DIR__ . '/../../init.php';
 
 $tpl = new Template_Helper();
@@ -41,7 +43,7 @@ $sql = 'SELECT
         	iss_prc_id';
 try {
     $res = DB_Helper::getInstance()->getAll($sql, array(Auth::getCurrentProject()));
-} catch (DbException $e) {
+} catch (DatabaseException $e) {
     return false;
 }
 $total = 0;

--- a/lib/eventum/auth/APIAuthToken.php
+++ b/lib/eventum/auth/APIAuthToken.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class APIAuthToken
 {
     private static $default_alg = 'HS256';
@@ -40,7 +42,7 @@ class APIAuthToken
                 Date_Helper::getCurrentDateGMT(),
                 $token,
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
     }
@@ -73,7 +75,7 @@ class APIAuthToken
                     apt_status = 'active'";
         try {
             $usr_id = DB_Helper::getInstance()->getOne($sql, array($token));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             throw new AuthException('Error fetching user token');
         }
         if (empty($usr_id)) {
@@ -103,7 +105,7 @@ class APIAuthToken
                     apt_created DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
         if (empty($res)) {
@@ -129,7 +131,7 @@ class APIAuthToken
                     apt_usr_id = ?";
         try {
             DB_Helper::getInstance()->query($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/auth/class.mysql_auth_backend.php
+++ b/lib/eventum/auth/class.mysql_auth_backend.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * MySQL (builtin) auth backend
  */
@@ -65,7 +67,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
         $params = array(AuthPassword::hash($password), $usr_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -101,7 +103,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -126,7 +128,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -153,7 +155,7 @@ class Mysql_Auth_Backend implements Auth_Backend_Interface
         $params = array(APP_FAILED_LOGIN_BACKOFF_COUNT, $usr_id);
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return true;
         }
 

--- a/lib/eventum/class.attachment.php
+++ b/lib/eventum/class.attachment.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class designed to handle all business logic related to attachments being
  * uploaded to issues in the application.
@@ -109,7 +111,7 @@ class Attachment
         }
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -156,7 +158,7 @@ class Attachment
                     iaf_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($file_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -187,7 +189,7 @@ class Attachment
 
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -223,7 +225,7 @@ class Attachment
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -240,7 +242,7 @@ class Attachment
                     iat_iss_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($iat_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -274,7 +276,7 @@ class Attachment
                     iaf_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($iaf_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -299,7 +301,7 @@ class Attachment
                     iaf_iat_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($attachment_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -345,7 +347,7 @@ class Attachment
         $params = array($issue_id);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -440,7 +442,7 @@ class Attachment
     {
         try {
             $iaf_ids = self::addFiles($_FILES['attachment']);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -452,7 +454,7 @@ class Attachment
 
         try {
             self::attachFiles($_POST['issue_id'], $usr_id, $iaf_ids, $internal_only, $_POST['file_description']);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -489,7 +491,7 @@ class Attachment
                 Date_Helper::getCurrentDateGMT(),
                 $blob,
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -597,7 +599,7 @@ class Attachment
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.authorized_replier.php
+++ b/lib/eventum/class.authorized_replier.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class designed to handle adding, removing and viewing authorized repliers for an issue.
  */
@@ -47,7 +49,7 @@ class Authorized_Replier
         $params = array(APP_SYSTEM_USER_ID, APP_SYSTEM_USER_ID, $issue_id);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array(
                 array(),
                 $repliers,
@@ -93,7 +95,7 @@ class Authorized_Replier
                     iur_id IN ($iur_list)";
         try {
             $issue_id = DB_Helper::getInstance()->getOne($stmt, $iur_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -105,7 +107,7 @@ class Authorized_Replier
                         iur_id IN ($iur_list)";
             try {
                 DB_Helper::getInstance()->query($stmt, $iur_ids);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -162,7 +164,7 @@ class Authorized_Replier
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, APP_SYSTEM_USER_ID, $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -202,7 +204,7 @@ class Authorized_Replier
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -251,7 +253,7 @@ class Authorized_Replier
                     iur_email=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id, $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -280,7 +282,7 @@ class Authorized_Replier
                     iur_usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -310,7 +312,7 @@ class Authorized_Replier
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($iur_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -340,7 +342,7 @@ class Authorized_Replier
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id, $email, $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 

--- a/lib/eventum/class.category.php
+++ b/lib/eventum/class.category.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle project category related issues.
  */
@@ -32,7 +34,7 @@ class Category
                     prc_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($prc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -54,7 +56,7 @@ class Category
                     prc_prj_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -76,7 +78,7 @@ class Category
                     prc_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -104,7 +106,7 @@ class Category
                     prc_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['prj_id'], $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -132,7 +134,7 @@ class Category
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['prj_id'], $_POST['title']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -159,7 +161,7 @@ class Category
                     prc_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -192,7 +194,7 @@ class Category
                     prc_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -217,7 +219,7 @@ class Category
                     prc_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 define('CRM_EXCLUDE_EXPIRED', 'exclude_expired');
 
 abstract class CRM
@@ -328,7 +331,7 @@ abstract class CRM
                  WHERE prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             $res = false;
         }
 
@@ -404,7 +407,7 @@ abstract class CRM
                     cam_usr_id=usr_id';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -443,7 +446,7 @@ abstract class CRM
             DB_Helper::getInstance()->query(
                 $stmt, array($_POST['project'], $_POST['customer'], $_POST['manager'], $_POST['type'])
             );
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -466,7 +469,7 @@ abstract class CRM
                     cam_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($cam_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -493,7 +496,7 @@ abstract class CRM
             DB_Helper::getInstance()->query(
                 $stmt, array($_POST['project'], $_POST['customer'], $_POST['manager'], $_POST['type'], $_POST['id'])
             );
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -515,7 +518,7 @@ abstract class CRM
                     cam_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -544,8 +547,8 @@ abstract class CRM
                     cam_prj_id=? AND
                     cam_customer_id=?';
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $customer_id), DbInterface::DB_FETCHMODE_ASSOC);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $customer_id), AdapterInterface::DB_FETCHMODE_ASSOC);
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -575,7 +578,7 @@ abstract class CRM
                     cno_customer_id = ?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($customer_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -600,7 +603,7 @@ abstract class CRM
                     cno_id = ?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($cno_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -625,7 +628,7 @@ abstract class CRM
                     cno_customer_id ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -664,7 +667,7 @@ abstract class CRM
             DB_Helper::getInstance()->query(
                 $stmt, array($note, $prj_id, $customer_id, Date_Helper::getCurrentDateGMT(), $cno_id)
             );
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -697,7 +700,7 @@ abstract class CRM
                 $stmt,
                 array($prj_id, $customer_id, Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $note)
             );
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -718,7 +721,7 @@ abstract class CRM
                     cno_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of custom fields in the system.
@@ -40,7 +42,7 @@ class Custom_Field
                     cfo_id IN (' . DB_Helper::buildList($cfo_id) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $cfo_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -83,7 +85,7 @@ class Custom_Field
             $params = array_merge(array($fld_id, $option));
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -108,7 +110,7 @@ class Custom_Field
                     cfo_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($cfo_value, $cfo_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -205,7 +207,7 @@ class Custom_Field
 
                     try {
                         $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id, $fld_id));
-                    } catch (DbException $e) {
+                    } catch (DatabaseException $e) {
                         return -1;
                     }
                     $icf_id = $res['icf_id'];
@@ -232,7 +234,7 @@ class Custom_Field
                         );
                         try {
                             DB_Helper::getInstance()->query($stmt, $params);
-                        } catch (DbException $e) {
+                        } catch (DatabaseException $e) {
                             return -1;
                         }
                     } else {
@@ -246,7 +248,7 @@ class Custom_Field
                         $params = array($value, $icf_id);
                         try {
                             DB_Helper::getInstance()->query($stmt, $params);
-                        } catch (DbException $e) {
+                        } catch (DatabaseException $e) {
                             return -1;
                         }
                     }
@@ -418,7 +420,7 @@ class Custom_Field
                      )";
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return false;
             }
         }
@@ -474,7 +476,7 @@ class Custom_Field
                     fld_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -559,7 +561,7 @@ class Custom_Field
                     cfo_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($fld_id, $value));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -611,7 +613,7 @@ class Custom_Field
                     cfo_value=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($fld_id, $value));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -694,7 +696,7 @@ class Custom_Field
                     fld_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -818,7 +820,7 @@ class Custom_Field
                     fld_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -828,7 +830,7 @@ class Custom_Field
                     pcf_fld_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -838,7 +840,7 @@ class Custom_Field
                     icf_fld_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -848,7 +850,7 @@ class Custom_Field
                     cfo_fld_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -931,7 +933,7 @@ class Custom_Field
                 $_POST['rank'],
                 @$_POST['custom_field_backend'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -969,7 +971,7 @@ class Custom_Field
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id, $fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -992,7 +994,7 @@ class Custom_Field
                     fld_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1034,7 +1036,7 @@ class Custom_Field
                     prj_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1064,7 +1066,7 @@ class Custom_Field
                     fld_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1130,7 +1132,7 @@ class Custom_Field
                     cfo_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1242,7 +1244,7 @@ class Custom_Field
                 @$_POST['custom_field_backend'],
                 $_POST['id'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1310,7 +1312,7 @@ class Custom_Field
                     pcf_fld_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1338,7 +1340,7 @@ class Custom_Field
                     pcf_prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1372,7 +1374,7 @@ class Custom_Field
                         iss_prj_id = ?';
             try {
                 $res = DB_Helper::getInstance()->getColumn($sql, array($prj_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return false;
             }
 
@@ -1390,7 +1392,7 @@ class Custom_Field
         }
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1415,7 +1417,7 @@ class Custom_Field
                     cfo_fld_id IN ($items)";
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1440,7 +1442,7 @@ class Custom_Field
                     icf_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1462,7 +1464,7 @@ class Custom_Field
                     pcf_prj_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1492,7 +1494,7 @@ class Custom_Field
                     fld_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($prj_id, Auth::getCurrentRole()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1515,7 +1517,7 @@ class Custom_Field
                     fld_title = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -1549,7 +1551,7 @@ class Custom_Field
                     fld_id = ?';
         try {
             $res = DB_Helper::getInstance()->getAll($sql, array($iss_id, $fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1649,7 +1651,7 @@ class Custom_Field
                     fld_id = ?';
         try {
             DB_Helper::getInstance()->query($sql, array($rank, $fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1715,7 +1717,7 @@ class Custom_Field
                     fld_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($fld_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1777,7 +1779,7 @@ class Custom_Field
                 "%$search%",
             );
             $res = DB_Helper::getInstance()->getColumn($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1882,7 +1884,7 @@ class Custom_Field
         $params = array($fld_id);
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -11,18 +11,22 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\Adapter\NullAdapter;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to manage all tasks related to the DB abstraction module. This is only
  * useful to maintain a data dictionary of the current database schema tables.
  */
 class DB_Helper
 {
-    const DEFAULT_ADAPTER = 'DbPear';
+    const DEFAULT_ADAPTER = 'Pear';
 
     /**
      * @param bool $fallback
-     * @return DbInterface
-     * @throws DbException
+     * @return AdapterInterface
+     * @throws DatabaseException
      * @throws Exception
      */
     public static function getInstance($fallback = true)
@@ -36,13 +40,13 @@ class DB_Helper
         $instance = false;
 
         $config = self::getConfig();
-        $className = isset($config['classname']) ? $config['classname'] : self::DEFAULT_ADAPTER;
+        $className = self::getAdapterClass($config);
 
         try {
             $instance = new $className($config);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             // set dummy provider in as offline.php uses db methods
-            $instance = new DbNull($config);
+            $instance = new NullAdapter($config);
 
             if (!$fallback) {
                 throw $e;
@@ -54,6 +58,23 @@ class DB_Helper
         }
 
         return $instance;
+    }
+
+    private static function getAdapterClass($config)
+    {
+        $classname = isset($config['classname']) ? $config['classname'] : self::DEFAULT_ADAPTER;
+
+        // legacy class name started with 'Db'
+        if (substr($classname, 0, 2) == 'Db') {
+            $classname = substr($classname, 2);
+        }
+
+        // append Adapter to classname
+        if (substr($classname, -7) != 'Adapter') {
+            $classname .= 'Adapter';
+        }
+
+        return 'Eventum\\Db\\Adapter\\' . $classname;
     }
 
     /**
@@ -111,7 +132,7 @@ class DB_Helper
             $stmt = "show variables like 'max_allowed_packet'";
             $res = self::getInstance(false)->getPair($stmt);
             $max_allowed_packet = (int) $res['max_allowed_packet'];
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
         }
 
         if (empty($max_allowed_packet)) {
@@ -128,14 +149,14 @@ class DB_Helper
      * Also, the percentage character "%" at the beginning or ending of a table name will be replaced
      * with [[tablePrefix]].
      *
-     * @param DbInterface $db
+     * @param AdapterInterface $db
      * @param string $tablePrefix
      * @param string $sql
      * @return string
      * @see https://github.com/yiisoft/yii2/blob/2.0.0/framework/db/Connection.php#L761-L783
      * @internal
      */
-    public static function quoteTableName(DbInterface $db, $tablePrefix, $sql)
+    public static function quoteTableName(AdapterInterface $db, $tablePrefix, $sql)
     {
         $sql = preg_replace_callback(
             '/(\\{\\{(%?[\w\-\. ]+%?)\\}\\}|\\[\\[([\w\-\. ]+)\\]\\])/',

--- a/lib/eventum/class.display_column.php
+++ b/lib/eventum/class.display_column.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle determining which columns should be displayed and in what order
  * on a page (e.g. Issue Listing page).
@@ -108,8 +111,8 @@ class Display_Column
                 ORDER BY
                     ctd_rank';
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $page), DbInterface::DB_FETCHMODE_ASSOC);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id, $page), AdapterInterface::DB_FETCHMODE_ASSOC);
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -238,7 +241,7 @@ class Display_Column
                     ctd_page = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id, $page));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -255,7 +258,7 @@ class Display_Column
             $params = array($prj_id, $page, $field_name, $_REQUEST['min_role'][$field_name], $rank);
             try {
                 DB_Helper::getInstance()->query($sql, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
             $rank++;
@@ -292,7 +295,7 @@ class Display_Column
             $params = array($prj_id, $page, $field_name, $min_role, $rank);
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
             $rank++;

--- a/lib/eventum/class.draft.php
+++ b/lib/eventum/class.draft.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Draft
 {
     /**
@@ -86,7 +88,7 @@ class Draft
         $stmt .= ')';
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -137,7 +139,7 @@ class Draft
         $params = array(Date_Helper::getCurrentDateGMT(), $emd_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -166,7 +168,7 @@ class Draft
                     emd_id=?";
         try {
             DB_Helper::getInstance()->query($stmt, array($emd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -188,7 +190,7 @@ class Draft
                     edr_emd_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($emd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -224,7 +226,7 @@ class Draft
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -248,7 +250,7 @@ class Draft
 
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($emd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             throw new RuntimeException('email not found');
         }
 
@@ -291,7 +293,7 @@ class Draft
                     emd_id';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -328,7 +330,7 @@ class Draft
                     edr_emd_id=?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($emd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array('', '');
         }
 
@@ -373,7 +375,7 @@ class Draft
                 LIMIT 1 OFFSET " . ($sequence - 1);
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -429,7 +431,7 @@ class Draft
                     emd_usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($start, $end, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.edit_reporter.php
+++ b/lib/eventum/class.edit_reporter.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class designed to handle adding, removing and viewing authorized repliers for an issue.
  */
@@ -43,7 +45,7 @@ class Edit_Reporter
 
         try {
             DB_Helper::getInstance()->query($sql, array($usr_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Email_Account
 {
     /**
@@ -30,7 +32,7 @@ class Email_Account
                     ema_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($ema_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -58,7 +60,7 @@ class Email_Account
                     ema_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($auto_creation, @serialize($options), $ema_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -82,7 +84,7 @@ class Email_Account
                     sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -113,7 +115,7 @@ class Email_Account
                 $params[] = $mailbox;
             }
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -156,7 +158,7 @@ class Email_Account
         // IMPORTANT: do not print out $emai_id without sanitizing, it may contain XSS
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($ema_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             throw new RuntimeException('email account not found');
         }
 
@@ -187,7 +189,7 @@ class Email_Account
                     ema_prj_id IN ($id_list)";
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -199,7 +201,7 @@ class Email_Account
                     ema_prj_id IN ($id_list)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -220,7 +222,7 @@ class Email_Account
                     ema_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -280,7 +282,7 @@ class Email_Account
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -337,7 +339,7 @@ class Email_Account
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -360,7 +362,7 @@ class Email_Account
                     ema_hostname';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -401,7 +403,7 @@ class Email_Account
                     ema_title';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $projects);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -430,7 +432,7 @@ class Email_Account
                     1 OFFSET 0';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -456,7 +458,7 @@ class Email_Account
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.email_response.php
+++ b/lib/eventum/class.email_response.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of canned email responses in the system.
@@ -58,7 +60,7 @@ class Email_Response
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['response_body']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -85,7 +87,7 @@ class Email_Response
                     ere_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -119,7 +121,7 @@ class Email_Response
         }
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -145,7 +147,7 @@ class Email_Response
                     ere_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['response_body'], $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -175,7 +177,7 @@ class Email_Response
                     ere_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($ere_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -205,7 +207,7 @@ class Email_Response
                     per_ere_id=?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($ere_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -229,7 +231,7 @@ class Email_Response
                     ere_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -263,7 +265,7 @@ class Email_Response
                     ere_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -290,7 +292,7 @@ class Email_Response
                     per_prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.faq.php
+++ b/lib/eventum/class.faq.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class FAQ
 {
     /**
@@ -56,7 +58,7 @@ class FAQ
 
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -83,7 +85,7 @@ class FAQ
                     faq_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -111,7 +113,7 @@ class FAQ
                     fsl_faq_id IN (' . DB_Helper::buildList($faq_id) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $faq_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -146,7 +148,7 @@ class FAQ
         $params = array($_POST['project'], Date_Helper::getCurrentDateGMT(), $_POST['title'], $_POST['message'], $_POST['rank'], $faq_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -189,7 +191,7 @@ class FAQ
         $params = array($_POST['project'], Auth::getUserID(), Date_Helper::getCurrentDateGMT(), $_POST['title'], $_POST['message'], $_POST['rank']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -240,7 +242,7 @@ class FAQ
                     faq_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($faq_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -274,7 +276,7 @@ class FAQ
                     faq_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -388,7 +390,7 @@ class FAQ
                     faq_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the custom filters.
  */
@@ -34,7 +36,7 @@ class Filter
                     cst_is_global=1';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($cst_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -65,7 +67,7 @@ class Filter
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($cst_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -336,7 +338,7 @@ class Filter
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -363,7 +365,7 @@ class Filter
         $params = array(Auth::getUserID(), Auth::getCurrentProject(), $cst_title);
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -395,7 +397,7 @@ class Filter
         $params = array(Auth::getCurrentProject(), Auth::getUserID());
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -427,7 +429,7 @@ class Filter
         $params = array(Auth::getCurrentProject(), Auth::getUserID());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -537,7 +539,7 @@ class Filter
 
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -582,7 +584,7 @@ class Filter
 
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -605,7 +607,7 @@ class Filter
                     cst_prj_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.group.php
+++ b/lib/eventum/class.group.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of groups.
@@ -39,7 +41,7 @@ class Group
         $params = array($_POST['group_name'], $_POST['description'], $_POST['manager']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -72,7 +74,7 @@ class Group
         $params = array($_POST['group_name'], $_POST['description'], $_POST['manager'], $_POST['id']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -112,7 +114,7 @@ class Group
                         grp_id = ?';
             try {
                 DB_Helper::getInstance()->query($stmt, array($grp_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -151,7 +153,7 @@ class Group
                      )';
             try {
                 DB_Helper::getInstance()->query($stmt, array($prj_id, $grp_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -174,7 +176,7 @@ class Group
                     pgr_grp_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($grp_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -197,7 +199,7 @@ class Group
                     pgr_prj_id IN (' . DB_Helper::buildList($projects) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $projects);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -229,7 +231,7 @@ class Group
 
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($grp_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -283,7 +285,7 @@ class Group
                     grp_name';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -323,7 +325,7 @@ class Group
                     grp_name';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -349,7 +351,7 @@ class Group
                     grp_name';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -372,7 +374,7 @@ class Group
                     ugr_grp_id = ?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($grp_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -398,7 +400,7 @@ class Group
                     pgr_grp_id = ?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($grp_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -423,7 +425,7 @@ class Group
                     grp_name = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($name));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -451,7 +453,7 @@ class Group
                   ugr_created = ?';
         try {
             $res = DB_Helper::getInstance()->query($sql, array($usr_id, $grp_id, Date_Helper::getCurrentDateGMT()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -474,7 +476,7 @@ class Group
                   ugr_grp_id = ?';
         try {
             $res = DB_Helper::getInstance()->query($sql, array($usr_id, $grp_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the history information for
  * the issues entered in the system.
@@ -69,7 +71,7 @@ class History
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
         }
     }
 
@@ -98,7 +100,7 @@ class History
         $params = array($iss_id, Auth::getCurrentRole());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -125,7 +127,7 @@ class History
                     his_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -159,7 +161,7 @@ class History
                     htt_name IN('" . implode("','", $name) . "')";
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 'unknown';
         }
 
@@ -193,7 +195,7 @@ class History
                     htt_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
         $returns[$id] = $res;
@@ -258,7 +260,7 @@ class History
         $params = array($usr_id, $start, $end, $prj_id);
         try {
             return DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
     }
@@ -303,7 +305,7 @@ class History
         $params = array($prj_id, $usr_id, $start, $end);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -330,7 +332,7 @@ class History
                 LIMIT 1';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id, self::getTypeID('issue_closed')));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 

--- a/lib/eventum/class.impact_analysis.php
+++ b/lib/eventum/class.impact_analysis.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the impact analysis section
  * of the view issue page. This section allows the developer to give feedback
@@ -41,7 +43,7 @@ class Impact_Analysis
         $params = array($issue_id, $usr_id, Date_Helper::getCurrentDateGMT(), $_POST['new_requirement']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -84,7 +86,7 @@ class Impact_Analysis
                     isr_usr_id=A.usr_id';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -134,7 +136,7 @@ class Impact_Analysis
         $params = array($usr_id, Date_Helper::getCurrentDateGMT(), $dev_time, $_POST['impact_analysis'], $isr_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -171,7 +173,7 @@ class Impact_Analysis
                     isr_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -201,7 +203,7 @@ class Impact_Analysis
                     isr_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class designed to handle all business logic related to the issues in the
  * system, such as adding or updating them or listing them in the grid mode.
@@ -40,7 +42,7 @@ class Issue
         }
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -91,7 +93,7 @@ class Issue
                     iss_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -120,7 +122,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -148,7 +150,7 @@ class Issue
         $params = array(Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $issue_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -177,7 +179,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -208,7 +210,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -236,7 +238,7 @@ class Issue
                     iss_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($contract_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -272,7 +274,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -304,7 +306,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -377,7 +379,7 @@ class Issue
         $params = array($status_id, Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $issue_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -441,7 +443,7 @@ class Issue
                         iss_id = ?';
             try {
                 DB_Helper::getInstance()->query($sql, array($pre_id, $issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -465,7 +467,7 @@ class Issue
                     iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -490,7 +492,7 @@ class Issue
                         iss_id = ?';
             try {
                 DB_Helper::getInstance()->query($sql, array($pri_id, $issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -514,7 +516,7 @@ class Issue
                     iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -539,7 +541,7 @@ class Issue
                         iss_id = ?';
             try {
                 DB_Helper::getInstance()->query($sql, array($sev_id, $issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -563,7 +565,7 @@ class Issue
                     iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -590,7 +592,7 @@ class Issue
                         iss_id = ?';
             try {
                 DB_Helper::getInstance()->query($sql, array($expected_resolution_date, $issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -623,7 +625,7 @@ class Issue
                     iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -648,7 +650,7 @@ class Issue
                         iss_id = ?';
             try {
                 DB_Helper::getInstance()->query($sql, array($prc_id, $issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -672,7 +674,7 @@ class Issue
                     iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -731,7 +733,7 @@ class Issue
                         iss_id";
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -766,7 +768,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -813,7 +815,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -857,7 +859,7 @@ class Issue
                     iss_duplicated_iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -907,7 +909,7 @@ class Issue
         $params = array_merge($params, $ids);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -976,7 +978,7 @@ class Issue
                     iss_duplicated_iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1005,7 +1007,7 @@ class Issue
         $params = array(Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $issue_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1043,7 +1045,7 @@ class Issue
         $params = array(Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $dup_iss_id, $issue_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1075,7 +1077,7 @@ class Issue
                     iss_duplicated_iss_id IS NULL';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1102,7 +1104,7 @@ class Issue
                     isu_usr_id=usr_id';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1125,7 +1127,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1148,7 +1150,7 @@ class Issue
                     iss_summary=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($summary));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -1189,7 +1191,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1251,7 +1253,7 @@ class Issue
                     iss_prj_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1316,7 +1318,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1563,7 +1565,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1732,7 +1734,7 @@ class Issue
               iss_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($new_prj_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1887,7 +1889,7 @@ class Issue
         $params = array($issue_id, $assignee_usr_id, Date_Helper::getCurrentDateGMT());
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1919,7 +1921,7 @@ class Issue
                     isu_iss_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $issues);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1949,7 +1951,7 @@ class Issue
                     isu_usr_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2445,7 +2447,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2675,7 +2677,7 @@ class Issue
                     iss_id DESC';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2712,7 +2714,7 @@ class Issue
                     isu_usr_id=usr_id';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -2762,7 +2764,7 @@ class Issue
 
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 
@@ -2801,7 +2803,7 @@ class Issue
                     isu_iss_id IN ($ids)";
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 
@@ -2847,7 +2849,7 @@ class Issue
                     iss_id in ($ids)";
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 
@@ -2875,7 +2877,7 @@ class Issue
                     isu_usr_id=usr_id';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -2902,7 +2904,7 @@ class Issue
                     isu_usr_id=usr_id";
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -2969,7 +2971,7 @@ class Issue
                     iss_prj_id=prj_id';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -3085,7 +3087,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -3139,7 +3141,7 @@ class Issue
                             isu_iss_id = ?';
                 try {
                     $current_assignees = DB_Helper::getInstance()->getPair($stmt, array($issue_id));
-                } catch (DbException $e) {
+                } catch (DatabaseException $e) {
                     return -1;
                 }
 
@@ -3264,7 +3266,7 @@ class Issue
         $params = array(Date_Helper::getCurrentDateGMT(), Date_Helper::getCurrentDateGMT(), $_POST['dev_time'], $_POST['impact_analysis'], $issue_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3300,7 +3302,7 @@ class Issue
                     iss_id DESC';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -3331,7 +3333,7 @@ class Issue
                     iss_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -3385,7 +3387,7 @@ class Issue
                     isa_issue_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -3413,7 +3415,7 @@ class Issue
                     sta_is_closed=1';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -3442,7 +3444,7 @@ class Issue
         $params = array(Date_Helper::getCurrentDateGMT());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -3470,7 +3472,7 @@ class Issue
                         iqu_expiration IS NULL)';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id, Date_Helper::getCurrentDateGMT()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -3505,7 +3507,7 @@ class Issue
                     iqu_iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3525,7 +3527,7 @@ class Issue
             $params[] = $issue_id;
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -3552,7 +3554,7 @@ class Issue
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3583,7 +3585,7 @@ class Issue
                     iss_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($group_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3616,7 +3618,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3666,7 +3668,7 @@ class Issue
                         iss_id=?';
             try {
                 $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return true;
             }
 
@@ -3697,7 +3699,7 @@ class Issue
                     iss_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -3720,7 +3722,7 @@ class Issue
                     iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -3748,7 +3750,7 @@ class Issue
                     iss_root_message_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($msg_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle parsing content for links.
  */
@@ -36,7 +39,7 @@ class Link_Filter
                     lfi_id = ?';
         try {
             $res = DB_Helper::getInstance()->getRow($sql, array($lfi_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -49,7 +52,7 @@ class Link_Filter
                         plf_lfi_id = ?';
             try {
                 $projects = DB_Helper::getInstance()->getColumn($sql, array($res['lfi_id']));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 $projects = array();
             }
 
@@ -81,7 +84,7 @@ class Link_Filter
                     lfi_id';
         try {
             $res = DB_Helper::getInstance()->getAll($sql);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -97,7 +100,7 @@ class Link_Filter
                         plf_lfi_id = ?';
             try {
                 $projects = DB_Helper::getInstance()->getPair($sql, array($row['lfi_id']));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 $projects = array();
             }
             if ($projects === null) {
@@ -131,7 +134,7 @@ class Link_Filter
         $params = array($_REQUEST['pattern'], $_REQUEST['replacement'], $_REQUEST['usr_role'], $_REQUEST['description']);
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -147,7 +150,7 @@ class Link_Filter
                     )';
             try {
                 DB_Helper::getInstance()->query($sql, array($prj_id, $lfi_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -171,7 +174,7 @@ class Link_Filter
                     lfi_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($sql, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -181,7 +184,7 @@ class Link_Filter
                     plf_lfi_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($sql, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -212,7 +215,7 @@ class Link_Filter
                 $_REQUEST['description'],
                 $_REQUEST['id'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -222,7 +225,7 @@ class Link_Filter
                     plf_lfi_id = ?';
         try {
             DB_Helper::getInstance()->query($sql, array($_REQUEST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -237,7 +240,7 @@ class Link_Filter
                     )';
             try {
                 DB_Helper::getInstance()->query($sql, array($prj_id, $_REQUEST['id']));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -363,8 +366,8 @@ class Link_Filter
                     lfi_id";
         $params = array(Auth::getCurrentRole(), $prj_id);
         try {
-            $res = DB_Helper::getInstance()->getAll($stmt, $params, DbInterface::DB_FETCHMODE_DEFAULT);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->getAll($stmt, $params, AdapterInterface::DB_FETCHMODE_DEFAULT);
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Mail_Queue
 {
     /**
@@ -115,7 +117,7 @@ class Mail_Queue
         $stmt = 'INSERT INTO {{%mail_queue}} SET ' . DB_Helper::buildSet($params);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -306,7 +308,7 @@ class Mail_Queue
                     $limit OFFSET 0";
         try {
             $res = DB_Helper::getInstance()->getColumn($sql, array($status));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -342,7 +344,7 @@ class Mail_Queue
 
         try {
             $res = DB_Helper::getInstance()->getAll($sql, array($status));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -376,7 +378,7 @@ class Mail_Queue
                     maq_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($maq_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -406,7 +408,7 @@ class Mail_Queue
                     maq_id IN (' . implode(',', $maq_ids) . ')';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -456,7 +458,7 @@ class Mail_Queue
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -494,7 +496,7 @@ class Mail_Queue
                     maq_queued_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -531,7 +533,7 @@ class Mail_Queue
                     maq_id = ?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($maq_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -556,7 +558,7 @@ class Mail_Queue
         $params[] = $type_id;
         try {
             $res = DB_Helper::getInstance()->getColumn($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -585,7 +587,7 @@ class Mail_Queue
                     maq_queued_date <= DATE_SUB(NOW(), INTERVAL 1 MONTH)";
         try {
             DB_Helper::getInstance()->query($sql);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.monitor.php
+++ b/lib/eventum/class.monitor.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Monitor
 {
     /**
@@ -32,7 +34,7 @@ class Monitor
                     maq_id";
         try {
             $queue_ids = DB_Helper::getInstance()->getColumn($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             echo ev_gettext('ERROR: There was a DB error checking the mail queue status'), "\n";
 
             return;
@@ -70,7 +72,7 @@ class Monitor
         ';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.news.php
+++ b/lib/eventum/class.news.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class News
 {
     /**
@@ -37,7 +39,7 @@ class News
                     3 OFFSET 0";
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -113,7 +115,7 @@ class News
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -141,7 +143,7 @@ class News
                     nws_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -176,7 +178,7 @@ class News
         }
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -207,7 +209,7 @@ class News
         $params = array($_POST['title'], $_POST['message'], $_POST['status'], $_POST['id']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -236,7 +238,7 @@ class News
                     nws_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($nws_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -263,7 +265,7 @@ class News
                     nws_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($nws_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -290,7 +292,7 @@ class News
                     nws_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -322,7 +324,7 @@ class News
                     prn_nws_id=?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($nws_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to adding, updating or
  * deleting notes from the application.
@@ -38,7 +40,7 @@ class Note
                     not_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -76,7 +78,7 @@ class Note
                     not_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -129,7 +131,7 @@ class Note
                     not_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -162,7 +164,7 @@ class Note
                     not_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             throw new RuntimeException("Can't find note");
         }
 
@@ -185,7 +187,7 @@ class Note
                     not_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -214,7 +216,7 @@ class Note
                 LIMIT 1 OFFSET $offset";
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -237,7 +239,7 @@ class Note
                     not_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -390,7 +392,7 @@ class Note
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -429,7 +431,7 @@ class Note
                     not_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -467,7 +469,7 @@ class Note
                     not_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -521,7 +523,7 @@ class Note
                     not_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -682,7 +684,7 @@ class Note
         $params = array(Auth::getCurrentProject(), $start, $end, $usr_id);
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -705,7 +707,7 @@ class Note
                     not_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -729,7 +731,7 @@ class Note
                     not_removed = 0';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -756,7 +758,7 @@ class Note
                     not_message_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -784,7 +786,7 @@ class Note
                     child.not_message_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -815,7 +817,7 @@ class Note
                     not_message_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -843,7 +845,7 @@ class Note
                     not_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -870,7 +872,7 @@ class Note
                     not_message_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle all of the business logic related to sending email
  * notifications on actions regarding the issues.
@@ -80,7 +82,7 @@ class Notification
 
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -127,7 +129,7 @@ class Notification
 
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
         $data = array();
@@ -427,7 +429,7 @@ class Notification
                     not_usr_id=usr_id';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($note_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -471,7 +473,7 @@ class Notification
                     sup_id IN ($items)";
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $sup_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -508,7 +510,7 @@ class Notification
                     iat_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id, $attachment_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -567,7 +569,7 @@ class Notification
         }
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1401,7 +1403,7 @@ class Notification
         $stmt = 'INSERT INTO {{%irc_notice}} SET '. DB_Helper::buildSet($params);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1480,7 +1482,6 @@ class Notification
             'app_title'    => Misc::getToolCaption(),
             'user'         => $info,
         ));
-
 
         // TRANSLATORS: %s - APP_SHORT_NAME
         $subject = ev_gettext('%s: New User information', APP_SHORT_NAME);
@@ -1667,7 +1668,7 @@ class Notification
         }
         try {
             $users = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1708,7 +1709,7 @@ class Notification
             }
             try {
                 $emails = DB_Helper::getInstance()->getAll($stmt, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return array();
             }
 
@@ -1748,7 +1749,7 @@ class Notification
                     sub_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1778,7 +1779,7 @@ class Notification
                     sbt_sub_id=?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1804,7 +1805,7 @@ class Notification
                     sub_iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1839,7 +1840,7 @@ class Notification
                     sub_usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 
@@ -1864,7 +1865,7 @@ class Notification
                     sub_iss_id IN ($items)";
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1940,7 +1941,7 @@ class Notification
         }
         try {
             $sub_id = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1950,7 +1951,7 @@ class Notification
                     sub_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1960,7 +1961,7 @@ class Notification
                     sbt_sub_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1994,7 +1995,7 @@ class Notification
                     sub_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2032,7 +2033,7 @@ class Notification
         }
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 
@@ -2139,7 +2140,7 @@ class Notification
                  )";
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, $subscriber_usr_id, Date_Helper::getCurrentDateGMT()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2225,7 +2226,7 @@ class Notification
                  )";
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, Date_Helper::getCurrentDateGMT(), $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2304,7 +2305,7 @@ class Notification
                     sub_id=?";
         try {
             DB_Helper::getInstance()->query($stmt, array($email, $usr_id, $sub_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2337,7 +2338,8 @@ class Notification
      * @param string $subject
      * @param string $text_message
      */
-    private static function notifyUserByMail($usr_id, $subject, $text_message) {
+    private static function notifyUserByMail($usr_id, $subject, $text_message)
+    {
         $info = User::getDetails($usr_id);
 
         // change the current locale

--- a/lib/eventum/class.pager.php
+++ b/lib/eventum/class.pager.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to manage paginated links on the frontend pages.
  */
@@ -40,7 +42,7 @@ class Pager
         $stmt = preg_replace("/(.*)(ORDER BY\s+\w+\s+\w+)(?:,\s+\w+\s+\w+)*(.*)/si", '\\1\\3', $stmt);
         try {
             $rows = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Handles the interactions between Eventum and partner backends.
  */
@@ -93,7 +95,7 @@ class Partner
                         ipa_created_date = ?';
             try {
                 DB_Helper::getInstance()->query($sql, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return false;
             }
             $backend = self::getBackend($par_code);
@@ -119,7 +121,7 @@ class Partner
                     ipa_par_code = ?';
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
         $backend = self::getBackend($par_code);
@@ -145,7 +147,7 @@ class Partner
 
         try {
             $res = DB_Helper::getInstance()->getColumn($sql, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -173,7 +175,7 @@ class Partner
                     ipa_iss_id = ?';
         try {
             $partners = DB_Helper::getInstance()->getColumn($sql, array($prj_id, $iss_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -255,7 +257,7 @@ class Partner
                     pap_par_code = ?';
         try {
             DB_Helper::getInstance()->query($sql, array($par_code));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -268,7 +270,7 @@ class Partner
                             pap_prj_id = ?';
                 try {
                     DB_Helper::getInstance()->query($sql, array($par_code, $prj_id));
-                } catch (DbException $e) {
+                } catch (DatabaseException $e) {
                     return -1;
                 }
             }
@@ -290,7 +292,7 @@ class Partner
                     pap_par_code = ?';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($par_code));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/class.phone_support.php
+++ b/lib/eventum/class.phone_support.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the phone support
  * feature of the application.
@@ -37,7 +39,7 @@ class Phone_Support
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['prj_id'], $_POST['title']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -65,7 +67,7 @@ class Phone_Support
                     phc_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['prj_id'], $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -89,7 +91,7 @@ class Phone_Support
                     phc_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -112,7 +114,7 @@ class Phone_Support
                     phc_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($phc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -139,7 +141,7 @@ class Phone_Support
                     phc_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -166,7 +168,7 @@ class Phone_Support
                     phc_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -189,7 +191,7 @@ class Phone_Support
                     phs_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($phs_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -225,7 +227,7 @@ class Phone_Support
                     phs_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -293,7 +295,7 @@ class Phone_Support
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -330,7 +332,7 @@ class Phone_Support
                         phs_id = ?';
             try {
                 DB_Helper::getInstance()->query($stmt, array($ttr_id, $phs_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -366,7 +368,7 @@ class Phone_Support
                     phs_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($phone_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -405,7 +407,7 @@ class Phone_Support
                     phs_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -435,7 +437,7 @@ class Phone_Support
         $params = array(Auth::getCurrentProject(), $start, $end, $usr_id);
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.prefs.php
+++ b/lib/eventum/class.prefs.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the user preferences
  * available in the application.
@@ -82,7 +85,7 @@ class Prefs
                     upr_usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return self::getDefaults(array_keys(Project::getAssocList($usr_id, false, true)));
         }
         if ($res === null) {
@@ -113,8 +116,8 @@ class Prefs
                 WHERE
                     upp_usr_id = $usr_id";
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($sql, array(), DbInterface::DB_FETCHMODE_ASSOC);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->fetchAssoc($sql, array(), AdapterInterface::DB_FETCHMODE_ASSOC);
+        } catch (DatabaseException $e) {
             return $returns[$usr_id];
         }
 
@@ -163,7 +166,7 @@ class Prefs
                 @$preferences['close_popup_windows'],
                 @$preferences['relative_date'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -187,7 +190,7 @@ class Prefs
                     $preferences['receive_new_issue_email'][$prj_id],
                     $preferences['receive_copy_of_own_action'][$prj_id],
                 ));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }

--- a/lib/eventum/class.priority.php
+++ b/lib/eventum/class.priority.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle project priority related issues.
  */
@@ -88,7 +90,7 @@ class Priority
                     pri_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -111,7 +113,7 @@ class Priority
                     pri_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($pri_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -134,7 +136,7 @@ class Priority
                     pri_prj_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -157,7 +159,7 @@ class Priority
                     pri_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -186,7 +188,7 @@ class Priority
                     pri_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['rank'], $_POST['prj_id'], $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -214,7 +216,7 @@ class Priority
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['prj_id'], $_POST['title'], $_POST['rank']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -242,7 +244,7 @@ class Priority
                     pri_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -265,7 +267,7 @@ class Priority
                     pri_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($pri_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -298,7 +300,7 @@ class Priority
                     pri_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -327,7 +329,7 @@ class Priority
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id, $pri_title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 

--- a/lib/eventum/class.product.php
+++ b/lib/eventum/class.product.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Product
 {
     public static function getList($include_removed = null)
@@ -36,7 +38,7 @@ class Product
                     pro_rank';
         try {
             $res = DB_Helper::getInstance()->getAll($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -70,7 +72,7 @@ class Product
                     pro_email = ?';
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -95,7 +97,7 @@ class Product
                     pro_id = ?';
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -111,7 +113,7 @@ class Product
 
         try {
             DB_Helper::getInstance()->query($sql, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -134,7 +136,7 @@ class Product
 
         try {
             $res = DB_Helper::getInstance()->getRow($sql, array($pro_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -163,7 +165,7 @@ class Product
         $params = array($issue_id, $pro_id, $version);
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -186,7 +188,7 @@ class Product
                     ipv_iss_id = ?';
         try {
             $res = DB_Helper::getInstance()->getAll($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -239,7 +241,7 @@ class Product
         }
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of projects in the system.
@@ -39,7 +42,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return $default;
         }
 
@@ -70,7 +73,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -94,7 +97,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -119,7 +122,7 @@ class Project
         $params = array($_POST['anonymous_post'], @serialize($_POST['options']), $prj_id);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -145,7 +148,7 @@ class Project
                     prj_title";
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -168,7 +171,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -195,7 +198,7 @@ class Project
                     prj_title=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -224,7 +227,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -255,7 +258,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             // FIXME: why return true?
             return true;
         }
@@ -287,7 +290,7 @@ class Project
                     prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
         }
 
         if (empty($res)) {
@@ -314,7 +317,7 @@ class Project
                     prj_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -357,7 +360,7 @@ class Project
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -406,7 +409,7 @@ class Project
                 $_POST['workflow_backend'],
                 $_POST['id'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -452,7 +455,7 @@ class Project
                     pru_usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($prj_id, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -468,7 +471,7 @@ class Project
                      )';
             try {
                 DB_Helper::getInstance()->query($stmt, array($usr_id, $prj_id, $role));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return false;
             }
 
@@ -520,7 +523,7 @@ class Project
                 $_POST['customer_backend'],
                 $_POST['workflow_backend'],
             ));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -566,7 +569,7 @@ class Project
                     prj_title';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -618,11 +621,11 @@ class Project
                 User::ROLE_MANAGER,
             );
             if ($include_extra) {
-                $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, DbInterface::DB_FETCHMODE_ASSOC);
+                $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, AdapterInterface::DB_FETCHMODE_ASSOC);
             } else {
                 $res = DB_Helper::getInstance()->getPair($stmt, $params);
             }
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -669,7 +672,7 @@ class Project
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -697,7 +700,7 @@ class Project
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -726,7 +729,7 @@ class Project
                     prj_title';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -821,7 +824,7 @@ class Project
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -847,7 +850,7 @@ class Project
                     prj_title";
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -889,7 +892,7 @@ class Project
                     prj_title';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($usr_id, User::ROLE_CUSTOMER));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -938,7 +941,7 @@ class Project
                     usr_email ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -972,7 +975,7 @@ class Project
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id, $prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -995,7 +998,7 @@ class Project
                     pfd_prj_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1014,7 +1017,7 @@ class Project
             try {
                 DB_Helper::getInstance()->query($stmt, array($prj_id, $field, $details['min_role'],
                     (isset($details['required']) ? $details['required'] : 0)));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
         }
@@ -1039,8 +1042,8 @@ class Project
                  WHERE
                     pfd_prj_id = ?';
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id), DbInterface::DB_FETCHMODE_ASSOC);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, array($prj_id), AdapterInterface::DB_FETCHMODE_ASSOC);
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.release.php
+++ b/lib/eventum/class.release.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of releases in the system.
@@ -35,7 +37,7 @@ class Release
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($pre_id, 'available'));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -64,7 +66,7 @@ class Release
                     pre_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($pre_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -87,7 +89,7 @@ class Release
                     pre_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($pre_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -109,7 +111,7 @@ class Release
                     pre_prj_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -136,7 +138,7 @@ class Release
                     iss_pre_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -146,7 +148,7 @@ class Release
                     pre_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -177,7 +179,7 @@ class Release
         $params = array($_POST['title'], $scheduled_date, $_POST['status'], $_POST['prj_id'], $_POST['id']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -214,7 +216,7 @@ class Release
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -243,7 +245,7 @@ class Release
                     pre_scheduled_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -281,7 +283,7 @@ class Release
                     pre_scheduled_date ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.reminder.php
+++ b/lib/eventum/class.reminder.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the reminder emails
  * that the system sends out.
@@ -98,7 +100,7 @@ class Reminder
                     rem_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -138,7 +140,7 @@ class Reminder
                     rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -161,7 +163,7 @@ class Reminder
                     rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -184,7 +186,7 @@ class Reminder
                     rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -235,7 +237,7 @@ class Reminder
                     rep_rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -252,7 +254,7 @@ class Reminder
                     rpr_rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -276,7 +278,7 @@ class Reminder
                     rms_rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -303,7 +305,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $support_level_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -329,7 +331,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -356,7 +358,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $customer_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -381,7 +383,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, 1));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -407,7 +409,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $priority_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -426,7 +428,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $pro_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -452,7 +454,7 @@ class Reminder
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($rem_id, $severity_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -524,7 +526,7 @@ class Reminder
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -591,7 +593,7 @@ class Reminder
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -648,7 +650,7 @@ class Reminder
                     rem_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -687,7 +689,7 @@ class Reminder
                     rer_rem_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -736,7 +738,7 @@ class Reminder
                     rem_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -775,7 +777,7 @@ class Reminder
                     rem_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -826,7 +828,7 @@ class Reminder
         $stmt = str_replace('UNIX_TIMESTAMP()', "UNIX_TIMESTAMP('" . Date_Helper::getCurrentDateGMT() . "')", $stmt);
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -985,7 +987,7 @@ class Reminder
                     rmh_created_date DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($iss_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/class.reminder_action.php
+++ b/lib/eventum/class.reminder_action.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the reminder emails
  * that the system sends out.
@@ -88,7 +90,7 @@ class Reminder_Action
                     rma_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -111,7 +113,7 @@ class Reminder_Action
                     rma_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($rma_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -134,7 +136,7 @@ class Reminder_Action
                     rma_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($rma_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -180,7 +182,7 @@ class Reminder_Action
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -211,7 +213,7 @@ class Reminder_Action
                     ral_rma_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($rma_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -289,7 +291,7 @@ class Reminder_Action
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -320,7 +322,7 @@ class Reminder_Action
                     rmt_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($rmt_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -403,7 +405,7 @@ class Reminder_Action
                     rmt_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -437,7 +439,7 @@ class Reminder_Action
                     rma_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($rem_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -473,7 +475,7 @@ class Reminder_Action
                     rma_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($reminder_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -500,7 +502,7 @@ class Reminder_Action
                     rmt_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($rmt_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -528,7 +530,7 @@ class Reminder_Action
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id, $rma_id, Date_Helper::getCurrentDateGMT()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -797,7 +799,7 @@ class Reminder_Action
                     rta_iss_id IN ($idlist)";
         try {
             $triggered_actions = DB_Helper::getInstance()->getPair($stmt, $issues);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return $issues;
         }
 
@@ -853,7 +855,7 @@ class Reminder_Action
         }
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -874,7 +876,7 @@ class Reminder_Action
                     rta_iss_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.reminder_condition.php
+++ b/lib/eventum/class.reminder_condition.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the reminder emails
  * that the system sends out.
@@ -33,7 +35,7 @@ class Reminder_Condition
                     rlc_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($rlc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -69,7 +71,7 @@ class Reminder_Condition
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -104,7 +106,7 @@ class Reminder_Condition
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -148,7 +150,7 @@ class Reminder_Condition
                     rlc_rmo_id=rmo_id';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($action_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -186,7 +188,7 @@ class Reminder_Condition
                     rlc_id ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($rma_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -223,7 +225,7 @@ class Reminder_Condition
                     rmf_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($field_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -246,7 +248,7 @@ class Reminder_Condition
                     rmf_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($field_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -274,7 +276,7 @@ class Reminder_Condition
                     rmf_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -298,7 +300,7 @@ class Reminder_Condition
                     rmo_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -321,7 +323,7 @@ class Reminder_Condition
                     rmf_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($field_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.report.php
+++ b/lib/eventum/class.report.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to all aspects of the
  * reporting system.
@@ -106,7 +108,7 @@ class Report
                     iss_last_response_date ' . $sort_order;
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -189,7 +191,7 @@ class Report
         }
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id, $ts_diff));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -264,7 +266,7 @@ class Report
                     usr_full_name';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -341,7 +343,7 @@ class Report
         $params = array($usr_id, Auth::getCurrentProject(), $start_ts, $end_ts);
         try {
             $newly_assigned = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             $newly_assigned = null;
         }
 
@@ -440,7 +442,7 @@ class Report
         $params = array(Auth::getCurrentProject());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -519,7 +521,7 @@ class Report
                     time_period';
         try {
             $total = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -543,7 +545,7 @@ class Report
                     time_period";
         try {
             $dev_stats = DB_Helper::getInstance()->getPair($stmt, $emails);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -736,7 +738,7 @@ class Report
                         row_count DESC';
             try {
                 $res = DB_Helper::getInstance()->getAll($sql, $params);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return array();
             }
 
@@ -807,13 +809,13 @@ class Report
                     } else {
                         $res = DB_Helper::getInstance()->getPair($stmt, $params);
                     }
-                } catch (DbException $e) {
+                } catch (DatabaseException $e) {
                     return array();
                 }
             } else {
                 try {
                     $res = DB_Helper::getInstance()->getOne($stmt, $params);
-                } catch (DbException $e) {
+                } catch (DatabaseException $e) {
                     return array();
                 }
             }
@@ -838,7 +840,7 @@ class Report
         $params[] = $fld_id;
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
         $data['All Others'] = $res;
@@ -927,7 +929,7 @@ class Report
 
         try {
             $res = DB_Helper::getInstance()->getAll($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1012,7 +1014,7 @@ class Report
         }
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
         $data['issues']['points'] = $res;
@@ -1073,7 +1075,7 @@ class Report
 
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
         $data['emails']['points'] = $res;

--- a/lib/eventum/class.resolution.php
+++ b/lib/eventum/class.resolution.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of resolutions in the system.
@@ -33,7 +35,7 @@ class Resolution
                     res_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($res_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -56,7 +58,7 @@ class Resolution
                     res_title=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -82,7 +84,7 @@ class Resolution
                     iss_res_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -92,7 +94,7 @@ class Resolution
                     res_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -119,7 +121,7 @@ class Resolution
                     res_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['title'], $_POST['rank'], $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -142,7 +144,7 @@ class Resolution
                     res_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($res_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -167,7 +169,7 @@ class Resolution
                     res_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -192,7 +194,7 @@ class Resolution
                     res_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -222,7 +224,7 @@ class Resolution
         $params = array($_POST['title'], $_POST['rank'], Date_Helper::getCurrentDateGMT());
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.round_robin.php
+++ b/lib/eventum/class.round_robin.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Round_Robin
 {
     /**
@@ -176,7 +178,7 @@ class Round_Robin
                     rru_prr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($prr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -189,7 +191,7 @@ class Round_Robin
                     rru_prr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id, $prr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -212,7 +214,7 @@ class Round_Robin
                     prr_prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -245,7 +247,7 @@ class Round_Robin
                     usr_id ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -289,7 +291,7 @@ class Round_Robin
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['project'], $blackout_start, $blackout_end));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -322,7 +324,7 @@ class Round_Robin
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($prr_id, $usr_id, 0));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -349,7 +351,7 @@ class Round_Robin
                     prj_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -383,7 +385,7 @@ class Round_Robin
                     usr_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -406,7 +408,7 @@ class Round_Robin
                     prr_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($prr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -435,7 +437,7 @@ class Round_Robin
                     prr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['project'], $blackout_start, $blackout_end, $_POST['id']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -467,7 +469,7 @@ class Round_Robin
                     rru_prr_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $prr_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -490,7 +492,7 @@ class Round_Robin
                     prr_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.scm.php
+++ b/lib/eventum/class.scm.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the source control management
  * integration features of the application.
@@ -32,7 +34,7 @@ class SCM
                     isc_iss_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -63,7 +65,7 @@ class SCM
                     isc_id IN ($itemlist)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -95,7 +97,7 @@ class SCM
                     isc_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -203,7 +205,7 @@ class SCM
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Holding all search relevant methods
  */
@@ -399,7 +401,7 @@ class Search
                     ' . Misc::escapeInteger($max) . ' OFFSET ' . Misc::escapeInteger($start);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array(
                 'list' => null,
                 'info' => null,

--- a/lib/eventum/class.search_profile.php
+++ b/lib/eventum/class.search_profile.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Search_Profile
 {
     /**
@@ -32,7 +34,7 @@ class Search_Profile
                     sep_type=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id, $prj_id, $type));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -66,7 +68,7 @@ class Search_Profile
                     sep_type=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id, $prj_id, $type));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -100,7 +102,7 @@ class Search_Profile
                     sep_type=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id, $prj_id, $type));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -154,7 +156,7 @@ class Search_Profile
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id, $prj_id, $type, serialize($profile)));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -184,7 +186,7 @@ class Search_Profile
 
         try {
             DB_Helper::getInstance()->query($stmt, array(serialize($profile), $usr_id, $prj_id, $type));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.severity.php
+++ b/lib/eventum/class.severity.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle issue severity
  */
@@ -57,7 +59,7 @@ class Severity
                         sev_id=?';
             try {
                 DB_Helper::getInstance()->query($sql, array($ranking[$sev_id], $prj_id, $replaced_sev_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return array();
             }
         }
@@ -70,7 +72,7 @@ class Severity
                     sev_id=?';
         try {
             DB_Helper::getInstance()->query($sql, array($new_rank, $prj_id, $sev_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -97,7 +99,7 @@ class Severity
                     sev_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -120,7 +122,7 @@ class Severity
                     sev_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($sql, array($sev_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -143,7 +145,7 @@ class Severity
                     sev_prj_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($sql, $prj_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -170,7 +172,7 @@ class Severity
                     sev_id IN ($items)";
         try {
             DB_Helper::getInstance()->query($sql, $sev_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -197,7 +199,7 @@ class Severity
                     sev_id=?';
         try {
             DB_Helper::getInstance()->query($sql, array($title, $description, $rank, $sev_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -223,7 +225,7 @@ class Severity
                     sev_rank=?';
         try {
             DB_Helper::getInstance()->query($sql, array($prj_id, $title, $description, $rank));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -253,7 +255,7 @@ class Severity
 
         try {
             $res = DB_Helper::getInstance()->getAll($sql, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -276,7 +278,7 @@ class Severity
                     sev_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($sev_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -309,7 +311,7 @@ class Severity
                     sev_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -337,7 +339,7 @@ class Severity
 					AND sev_title = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($prj_id, $sev_title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.stats.php
+++ b/lib/eventum/class.stats.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the generation of the
  * issue statistics displayed in the main screen of the application.
@@ -186,7 +188,7 @@ class Stats
                     total_items DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -227,7 +229,7 @@ class Stats
                     total_open_items';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -268,7 +270,7 @@ class Stats
                     total_open_items DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -345,7 +347,7 @@ class Stats
                     total_open_items DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -427,7 +429,7 @@ class Stats
                     total_open_items DESC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -457,7 +459,7 @@ class Stats
                     type";
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -478,7 +480,7 @@ class Stats
                     sup_removed=1';
         try {
             $res3 = DB_Helper::getInstance()->getOne($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle all business logic related to the way statuses
  * are represented in the system.
@@ -42,7 +44,7 @@ class Status
 
         try {
             $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -65,7 +67,7 @@ class Status
                     psd_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($psd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -86,7 +88,7 @@ class Status
                     psd_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -116,7 +118,7 @@ class Status
                     psd_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id, $sta_id, $date_field, $label, $psd_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -146,7 +148,7 @@ class Status
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id, $sta_id, $date_field, $label));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -179,7 +181,7 @@ class Status
                     prj_title ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -207,7 +209,7 @@ class Status
                     sta_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sta_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -242,7 +244,7 @@ class Status
         $params = array($_POST['title'], $_POST['abbreviation'], $_POST['rank'], $_POST['color'], $_POST['is_closed']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -285,7 +287,7 @@ class Status
         $params = array($_POST['title'], $_POST['abbreviation'], $_POST['rank'], $color, $_POST['is_closed'], $_POST['id']);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -314,7 +316,7 @@ class Status
                         iss_prj_id IN (' . implode(', ', $removed_projects) . ')';
             try {
                 DB_Helper::getInstance()->query($stmt, array($_POST['id']));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 // FIXME: why no error handling?
             }
         }
@@ -338,7 +340,7 @@ class Status
                     sta_id IN ($item_list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -401,7 +403,7 @@ class Status
         }
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -424,7 +426,7 @@ class Status
                     sta_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($sta_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -450,7 +452,7 @@ class Status
                     sta_title';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -482,7 +484,7 @@ class Status
                     prs_sta_id=?';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($sta_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -511,7 +513,7 @@ class Status
                     sta_title=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sta_title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -536,7 +538,7 @@ class Status
                     sta_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sta_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -570,7 +572,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $prj_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -608,7 +610,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $prj_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -646,7 +648,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $prj_id);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -670,7 +672,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -701,7 +703,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -724,7 +726,7 @@ class Status
                     sta_rank ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -11,6 +11,7 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
 use Eventum\Mail\Exception\RoutingException;
 
 /**
@@ -42,7 +43,7 @@ class Support
                     sup_id IN (' . DB_Helper::buildList($sup_ids) . ')';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $sup_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -93,7 +94,7 @@ class Support
                     sup_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -103,7 +104,7 @@ class Support
                     seb_sup_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -142,7 +143,7 @@ class Support
                     ' . $options['sort_by'] . ' ' . $options['sort_order'];
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -188,7 +189,7 @@ class Support
                     sup_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -246,7 +247,7 @@ class Support
                     sup_id IN (' . DB_Helper::buildList($sup_ids) . ')';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $sup_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -285,7 +286,7 @@ class Support
                     sup_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -315,7 +316,7 @@ class Support
         $params = array(Auth::getCurrentProject());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -341,7 +342,7 @@ class Support
                     sup_ema_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -924,7 +925,7 @@ class Support
                     sup_ema_id=?';
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, array($ema_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -947,7 +948,7 @@ class Support
                     sup_message_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1012,7 +1013,7 @@ class Support
         $stmt = 'INSERT INTO {{%support_email}} SET ' . DB_Helper::buildSet($params);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1031,7 +1032,7 @@ class Support
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($new_sup_id, $row['body'], $row['full_email']));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1217,7 +1218,7 @@ class Support
                     ' . Misc::escapeInteger($max) . ' OFFSET ' . Misc::escapeInteger($start);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array(
                 'list' => '',
                 'info' => '',
@@ -1422,7 +1423,7 @@ class Support
                     sup_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1539,7 +1540,7 @@ class Support
                     sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1580,7 +1581,7 @@ class Support
                 LIMIT 1 OFFSET $offset";
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1616,7 +1617,7 @@ class Support
         array_unshift($params, Auth::getCurrentProject());
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1640,7 +1641,7 @@ class Support
                     seb_sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1664,7 +1665,7 @@ class Support
                     seb_sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1699,7 +1700,7 @@ class Support
                     sup_id ASC";
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1733,7 +1734,7 @@ class Support
                     sup_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1766,7 +1767,7 @@ class Support
                     sup_id IN ($list)";
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2272,7 +2273,7 @@ class Support
                     sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2299,7 +2300,7 @@ class Support
                     sup_message_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -2330,7 +2331,7 @@ class Support
                     sup_message_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($message_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2354,7 +2355,7 @@ class Support
                     sup_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($sup_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2379,7 +2380,7 @@ class Support
                     child.sup_message_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($msg_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -2422,7 +2423,7 @@ class Support
         $params = array(Auth::getCurrentProject(), $start, $end, "%{$usr_info['usr_email']}%");
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -2451,7 +2452,7 @@ class Support
                     ema_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($ema_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2511,7 +2512,7 @@ class Support
         $params = array($new_ema_id, $issue_id, $customer_id, $sup_id, $current_ema_id);
         try {
             DB_Helper::getInstance()->query($sql, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -2681,7 +2682,7 @@ class Support
 
         try {
             DB_Helper::getInstance()->query('SET @sup_seq = 0');
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -2697,7 +2698,7 @@ class Support
                     sup_id ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 

--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -11,6 +11,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of time tracking categories in the system.
@@ -41,7 +44,7 @@ class Time_Tracking
                     ttc_title=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($prj_id, $ttc_title));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -64,7 +67,7 @@ class Time_Tracking
                     ttc_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($ttc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -88,7 +91,7 @@ class Time_Tracking
                  GROUP BY 1';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $ttc_ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 
@@ -117,7 +120,7 @@ class Time_Tracking
                     ttc_id IN (' . DB_Helper::buildList($items) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $items);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -146,7 +149,7 @@ class Time_Tracking
                     ttc_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($title, $prj_id, $ttc_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -177,7 +180,7 @@ class Time_Tracking
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, array($prj_id, $title, Date_Helper::getCurrentDateGMT()));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -223,7 +226,7 @@ class Time_Tracking
         $params[] = $prj_id;
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 
@@ -257,7 +260,7 @@ class Time_Tracking
                     ttc_title ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, array($prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -291,7 +294,7 @@ class Time_Tracking
                     ttr_iss_id';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 
@@ -317,7 +320,7 @@ class Time_Tracking
                     ttr_iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -353,7 +356,7 @@ class Time_Tracking
                     ttr_created_date ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, array($issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -407,7 +410,7 @@ class Time_Tracking
                     ttr_iss_id IN (' . DB_Helper::buildList($ids) . ')';
         try {
             DB_Helper::getInstance()->query($stmt, $ids);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -443,7 +446,7 @@ class Time_Tracking
                     ttr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($time_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -502,7 +505,7 @@ class Time_Tracking
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -548,7 +551,7 @@ class Time_Tracking
         );
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -591,8 +594,8 @@ class Time_Tracking
         $params = array($prj_id, $usr_id, $start, $end);
 
         try {
-            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, DbInterface::DB_FETCHMODE_ASSOC);
-        } catch (DbException $e) {
+            $res = DB_Helper::getInstance()->fetchAssoc($stmt, $params, AdapterInterface::DB_FETCHMODE_ASSOC);
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -627,7 +630,7 @@ class Time_Tracking
                     ttr_iss_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id, $start, $end, $issue_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return 0;
         }
 
@@ -663,7 +666,7 @@ class Time_Tracking
         $params = array_merge($params, $issue_ids);
         try {
             $result = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return;
         }
 

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Class to handle the business logic related to the administration
  * of users and permissions in the system.
@@ -75,7 +77,7 @@ class User
 
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($customer_contact_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -99,7 +101,7 @@ class User
                     usr_customer_contact_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($customer_contact_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -123,7 +125,7 @@ class User
                     usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -148,7 +150,7 @@ class User
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($sms_email, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -172,7 +174,7 @@ class User
                     usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -202,7 +204,7 @@ class User
                     usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -227,7 +229,7 @@ class User
                     usr_email=?";
         try {
             DB_Helper::getInstance()->query($stmt, array($email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -253,7 +255,7 @@ class User
                     usr_email=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -300,7 +302,7 @@ class User
                     'pending',
                 )
             );
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -399,7 +401,7 @@ class User
                     usr_external_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($external_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return null;
         }
 
@@ -522,7 +524,7 @@ class User
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -629,7 +631,7 @@ class User
                     pru_prj_id=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id, $prj_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -673,7 +675,7 @@ class User
                         usr_id IN ($itemlist)";
             try {
                 $res = DB_Helper::getInstance()->getAll($stmt, $usr_ids);
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return null;
             }
 
@@ -735,7 +737,7 @@ class User
             } else {
                 $res = DB_Helper::getInstance()->getColumn($stmt, $items);
             }
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -787,7 +789,7 @@ class User
             } else {
                 $res = DB_Helper::getInstance()->getColumn($stmt, $items);
             }
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             if (!is_array($usr_id)) {
                 return '';
             } else {
@@ -825,7 +827,7 @@ class User
                     ugr_usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getPair($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -869,7 +871,7 @@ class User
                     usr_email=?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -917,7 +919,7 @@ class User
         $params = array_merge(array($status), $usr_ids);
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -941,7 +943,7 @@ class User
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($full_name, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -966,7 +968,7 @@ class User
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($_POST['email'], $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1062,7 +1064,7 @@ class User
 
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1084,7 +1086,7 @@ class User
                         pru_usr_id=?';
             try {
                 DB_Helper::getInstance()->query($stmt, array($usr_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -1107,7 +1109,7 @@ class User
                             $prj_id, $usr_id, $role,
                         )
                     );
-                } catch (DbException $e) {
+                } catch (DatabaseException $e) {
                     return -1;
                 }
             }
@@ -1120,7 +1122,7 @@ class User
                         ugr_usr_id=?';
             try {
                 DB_Helper::getInstance()->query($stmt, array($usr_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return -1;
             }
 
@@ -1206,7 +1208,7 @@ class User
                  )';
         try {
             DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1271,7 +1273,7 @@ class User
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1324,7 +1326,7 @@ class User
                     {{%user}}';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1350,7 +1352,7 @@ class User
                     usr_full_name ASC';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1381,7 +1383,7 @@ class User
                     usr_id=?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1421,7 +1423,7 @@ class User
                     usr_clocked_in=1';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1444,7 +1446,7 @@ class User
                     usr_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1467,7 +1469,7 @@ class User
                     usr_id = ?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1495,7 +1497,7 @@ class User
                     usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return -1;
         }
 
@@ -1519,7 +1521,7 @@ class User
                         usr_id = ?';
             try {
                 $res = DB_Helper::getInstance()->getOne($sql, array($usr_id));
-            } catch (DbException $e) {
+            } catch (DatabaseException $e) {
                 return APP_DEFAULT_LOCALE;
             }
 
@@ -1542,7 +1544,7 @@ class User
                     usr_id = ?';
         try {
             DB_Helper::getInstance()->query($sql, array($language, $usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1559,7 +1561,7 @@ class User
                     ual_usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getColumn($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -1589,7 +1591,7 @@ class User
 
         try {
             DB_Helper::getInstance()->query($sql, array($usr_id, $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1605,7 +1607,7 @@ class User
                     ual_email = ?';
         try {
             DB_Helper::getInstance()->query($sql, array($usr_id, $email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1622,7 +1624,7 @@ class User
                     ual_email = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($email));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 
@@ -1639,7 +1641,7 @@ class User
                     usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1656,7 +1658,7 @@ class User
                     usr_id = ?';
         try {
             $res = DB_Helper::getInstance()->getOne($sql, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 
@@ -1680,7 +1682,7 @@ class User
                     usr_id=?';
         try {
             DB_Helper::getInstance()->query($stmt, array($usr_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return false;
         }
 

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class Workflow
 {
     /**
@@ -60,7 +62,7 @@ class Workflow
                     prj_id';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return '';
         }
 

--- a/lib/eventum/crm/class.customer.php
+++ b/lib/eventum/crm/class.customer.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 /**
  * Abstract class representing a customer
  */
@@ -174,7 +176,7 @@ abstract class Customer
                     cno_customer_id = ?';
         try {
             $res = DB_Helper::getInstance()->getRow($stmt, array($this->customer_id));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 
@@ -203,7 +205,7 @@ abstract class Customer
         $params = array($this->crm->getProjectID(), $this->customer_id);
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array();
         }
 

--- a/lib/eventum/search/class.mysql_fulltext_search.php
+++ b/lib/eventum/search/class.mysql_fulltext_search.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\DatabaseException;
+
 class MySQL_Fulltext_Search extends Abstract_Fulltext_Search
 {
     public function getIssueIDs($options)
@@ -64,7 +66,7 @@ class MySQL_Fulltext_Search extends Abstract_Fulltext_Search
         );
         try {
             $res = DB_Helper::getInstance()->getColumn($stmt, $params);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array(-1);
         }
 
@@ -81,7 +83,7 @@ class MySQL_Fulltext_Search extends Abstract_Fulltext_Search
         );
         try {
             $custom_res = DB_Helper::getInstance()->getColumn($stmt, $params1);
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
             return array(-1);
         }
 

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -11,12 +11,16 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Db\Adapter;
+
+use Eventum\Db\DatabaseException;
+
 /**
- * Interface DbInterface
+ * Interface AdapterInterface
  *
  * Database interface designed against PEAR::DB
  */
-interface DbInterface
+interface AdapterInterface
 {
     /**
      * Indicates the current default fetch mode should be used
@@ -37,7 +41,7 @@ interface DbInterface
      * Connects to the database
      *
      * @param array $config
-     * @throws DbException on connection failure
+     * @throws DatabaseException on connection failure
      */
     public function __construct(array $config);
 
@@ -46,7 +50,7 @@ interface DbInterface
      *
      * @param string $str the string to be escaped
      * @return string  the escaped string
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function escapeSimple($str);
 
@@ -59,7 +63,7 @@ interface DbInterface
      * @param mixed $params array, string or numeric data
      * @return bool|object A new DB_result object for successful SELECT queries
      * or true for successful data manipulation queries.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function query($query, $params = array());
 
@@ -70,7 +74,7 @@ interface DbInterface
      *
      * @param string $str the identifier name to be quoted
      * @return string  the quoted identifier
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function quoteIdentifier($str);
 
@@ -81,7 +85,7 @@ interface DbInterface
      * @param mixed $params array, string or numeric data
      * @param int $fetchmode the fetch mode to use
      * @return array the nested array.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function getAll($query, $params = array(), $fetchmode = self::DB_FETCHMODE_ASSOC);
 
@@ -95,7 +99,7 @@ interface DbInterface
      * @param string $query
      * @param mixed $params
      * @param int $fetchmode
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function fetchAssoc($query, $params = array(), $fetchmode = self::DB_FETCHMODE_DEFAULT);
 
@@ -106,7 +110,7 @@ interface DbInterface
      * @param string $query the SQL query
      * @param mixed $params array, string or numeric data
      * @return array the results as an array.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function getColumn($query, $params = array());
 
@@ -118,7 +122,7 @@ interface DbInterface
      * @param string $query the SQL query
      * @param mixed $params array, string or numeric data
      * @return mixed the returned value of the query.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function getOne($query, $params = array());
 
@@ -132,7 +136,7 @@ interface DbInterface
      * @param string $query
      * @param mixed $params
      * @return array  the associative array containing the query results.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function getPair($query, $params = array());
 
@@ -143,7 +147,7 @@ interface DbInterface
      * @param mixed $params array, string or numeric data
      * @param int $fetchmode the fetch mode to use
      * @return array  the first row of results as an array.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      */
     public function getRow($query, $params = array(), $fetchmode = self::DB_FETCHMODE_ASSOC);
 }

--- a/src/Db/Adapter/NullAdapter.php
+++ b/src/Db/Adapter/NullAdapter.php
@@ -11,22 +11,24 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Db\Adapter;
+
 /**
- * Class DbNull
+ * Class NullAdapter
  *
  * Database which all methods do nothing, to be used for offline.php
  */
-class DbNull implements DbInterface
+class NullAdapter implements AdapterInterface
 {
     public function __construct(array $config)
     {
     }
 
-    public function getAll($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getAll($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
     }
 
-    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT)
+    public function fetchAssoc($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_DEFAULT)
     {
     }
 
@@ -42,7 +44,7 @@ class DbNull implements DbInterface
     {
     }
 
-    public function getRow($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getRow($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
     }
 

--- a/src/Db/Adapter/PdoAdapter.php
+++ b/src/Db/Adapter/PdoAdapter.php
@@ -11,10 +11,20 @@
  * that were distributed with this source code.
  */
 
-class DbPdo extends DbBasePdo implements DbInterface
+namespace Eventum\Db\Adapter;
+
+use DB_Helper;
+use Eventum;
+use PDO;
+use UnexpectedValueException;
+
+class PdoAdapter extends PdoAdapterBase implements AdapterInterface
 {
     /** @var PDO */
     private $db;
+
+    /** @var string */
+    private $tablePrefix;
 
     /**
      * @param $config
@@ -37,19 +47,19 @@ class DbPdo extends DbBasePdo implements DbInterface
         $this->tablePrefix = $config['table_prefix'];
     }
 
-    public function getAll($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getAll($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $this->convertFetchMode($fetchmode);
 
         return $this->fetchAll($query, $params, $fetchmode);
     }
 
-    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT)
+    public function fetchAssoc($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_DEFAULT)
     {
         $flags = PDO::FETCH_GROUP | PDO::FETCH_UNIQUE;
-        if ($fetchmode == DbInterface::DB_FETCHMODE_ASSOC) {
+        if ($fetchmode == AdapterInterface::DB_FETCHMODE_ASSOC) {
             $flags |= PDO::FETCH_ASSOC;
-        } elseif ($fetchmode == DbInterface::DB_FETCHMODE_DEFAULT) {
+        } elseif ($fetchmode == AdapterInterface::DB_FETCHMODE_DEFAULT) {
             $flags |= PDO::FETCH_NUM;
         } else {
             throw new UnexpectedValueException(__FUNCTION__ . ' unsupported fetchmode: ' . $fetchmode);
@@ -85,7 +95,7 @@ class DbPdo extends DbBasePdo implements DbInterface
         return $res;
     }
 
-    public function getRow($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getRow($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $query = $this->quoteSql($query);
         $stmt = $this->db->prepare($query);

--- a/src/Db/Adapter/PdoAdapterBase.php
+++ b/src/Db/Adapter/PdoAdapterBase.php
@@ -11,10 +11,16 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Db\Adapter;
+
+use BadMethodCallException;
+use PDO;
+use UnexpectedValueException;
+
 /**
  * Class for common methods for PDO adapters
  */
-abstract class DbBasePdo
+abstract class PdoAdapterBase
 {
     const DEFAULT_DRIVER = 'mysql';
 
@@ -85,18 +91,18 @@ abstract class DbBasePdo
     }
 
     /**
-     * Convert DbInterface fetchmode to PDO Fetch mode
+     * Convert Eventum\Db\DbInterface fetchmode to PDO Fetch mode
      *
      * @param int $fetchmode
      */
     protected function convertFetchMode(&$fetchmode)
     {
         switch ($fetchmode) {
-            case DbInterface::DB_FETCHMODE_ASSOC:
+            case AdapterInterface::DB_FETCHMODE_ASSOC:
                 $fetchmode = PDO::FETCH_ASSOC;
                 break;
 
-            case DbInterface::DB_FETCHMODE_DEFAULT:
+            case AdapterInterface::DB_FETCHMODE_DEFAULT:
                 $fetchmode = PDO::FETCH_NUM;
                 break;
 

--- a/src/Db/Adapter/PearAdapter.php
+++ b/src/Db/Adapter/PearAdapter.php
@@ -11,7 +11,20 @@
  * that were distributed with this source code.
  */
 
-class DbPear implements DbInterface
+namespace Eventum\Db\Adapter;
+
+use DB;
+use DB_common;
+use DB_Helper;
+use DB_result;
+use Eventum\Db\DatabaseException;
+use Language;
+use Logger;
+use LogicException;
+use Misc;
+use PEAR_Error;
+
+class PearAdapter implements AdapterInterface
 {
     /** @var DB_common */
     private $db;
@@ -101,12 +114,12 @@ class DbPear implements DbInterface
      * @param int $fetchmode
      * @param bool $group
      * @return array  the associative array containing the query results.
-     * @throws DbException on failure.
+     * @throws DatabaseException on failure.
      * @deprecated use fetchAssoc() instead for cleaner interface
      */
     private function getAssoc(
         $query, $force_array = false, $params = array(),
-        $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT, $group = false
+        $fetchmode = AdapterInterface::DB_FETCHMODE_DEFAULT, $group = false
     ) {
         if (is_array($force_array)) {
             throw new LogicException('force_array passed as array, did you mean fetchPair or forgot extra arg?');
@@ -121,7 +134,7 @@ class DbPear implements DbInterface
     /**
      * @see DB_common::getAssoc
      */
-    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT)
+    public function fetchAssoc($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_DEFAULT)
     {
         $query = $this->quoteSql($query, $params);
         $res = $this->db->getAssoc($query, false, $params, $fetchmode, false);
@@ -154,7 +167,7 @@ class DbPear implements DbInterface
     /**
      * @see DB_common::getAll
      */
-    public function getAll($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getAll($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $query = $this->quoteSql($query, $params);
         $res = $this->db->getAll($query, $params, $fetchmode);
@@ -166,7 +179,7 @@ class DbPear implements DbInterface
     /**
      * @see DB_common::getRow
      */
-    public function getRow($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getRow($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $query = $this->quoteSql($query, $params);
         $res = $this->db->getRow($query, $params, $fetchmode);
@@ -210,7 +223,7 @@ class DbPear implements DbInterface
     }
 
     /**
-     * Check if $e is PEAR error, if so, throw as DbException
+     * Check if $e is PEAR error, if so, throw as DatabaseException
      *
      * @param $e PEAR_Error|array|object|int
      */
@@ -246,7 +259,7 @@ class DbPear implements DbInterface
 
         Logger::db()->error($e->getMessage(), $context);
 
-        $de = new DbException($e->getMessage(), $e->getCode());
+        $de = new DatabaseException($e->getMessage(), $e->getCode());
         if (isset($context['file'])) {
             $de->setExceptionLocation($context['file'], $context['line']);
         }

--- a/src/Db/Adapter/YiiAdapter.php
+++ b/src/Db/Adapter/YiiAdapter.php
@@ -11,12 +11,18 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Db\Adapter;
+
+use Eventum\Db;
+use PDO;
+use UnexpectedValueException;
+
 /**
- * Class DbYii
+ * Class YiiAdapter
  *
  * Proxy PEAR::DB like interface to Yii2
  */
-class DbYii extends DbBasePdo implements DbInterface
+class YiiAdapter extends PdoAdapterBase implements AdapterInterface
 {
     /**
      * @var \yii\db\Connection
@@ -67,7 +73,7 @@ class DbYii extends DbBasePdo implements DbInterface
         return $yiiConfig;
     }
 
-    public function getAll($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getAll($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $this->convertParams($params, $fetchmode);
         $this->convertFetchMode($fetchmode);
@@ -76,15 +82,15 @@ class DbYii extends DbBasePdo implements DbInterface
         return $command->queryAll($fetchmode);
     }
 
-    public function fetchAssoc($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_DEFAULT)
+    public function fetchAssoc($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_DEFAULT)
     {
         $this->convertParams($params);
         $command = $this->connection->createCommand($query, $params);
 
         $flags = PDO::FETCH_GROUP | PDO::FETCH_UNIQUE;
-        if ($fetchmode == DbInterface::DB_FETCHMODE_ASSOC) {
+        if ($fetchmode == AdapterInterface::DB_FETCHMODE_ASSOC) {
             $flags |= PDO::FETCH_ASSOC;
-        } elseif ($fetchmode == DbInterface::DB_FETCHMODE_DEFAULT) {
+        } elseif ($fetchmode == AdapterInterface::DB_FETCHMODE_DEFAULT) {
             $flags |= PDO::FETCH_NUM;
         } else {
             throw new UnexpectedValueException(__FUNCTION__ . ' unsupported fetchmode: ' . $fetchmode);
@@ -122,7 +128,7 @@ class DbYii extends DbBasePdo implements DbInterface
         return $res;
     }
 
-    public function getRow($query, $params = array(), $fetchmode = DbInterface::DB_FETCHMODE_ASSOC)
+    public function getRow($query, $params = array(), $fetchmode = AdapterInterface::DB_FETCHMODE_ASSOC)
     {
         $this->convertParams($params, $fetchmode);
         $this->convertFetchMode($fetchmode);
@@ -179,7 +185,7 @@ class DbYii extends DbBasePdo implements DbInterface
         if (!is_array($params)) {
             if (is_array($fetchmode)) {
                 if ($params === null) {
-                    $tmp = DbInterface::DB_FETCHMODE_DEFAULT;
+                    $tmp = AdapterInterface::DB_FETCHMODE_DEFAULT;
                 } else {
                     $tmp = $params;
                 }

--- a/src/Db/DatabaseException.php
+++ b/src/Db/DatabaseException.php
@@ -11,7 +11,11 @@
  * that were distributed with this source code.
  */
 
-class DbException extends RuntimeException
+namespace Eventum\Db;
+
+use RuntimeException;
+
+class DatabaseException extends RuntimeException
 {
     public $context;
 

--- a/src/Db/Migrate.php
+++ b/src/Db/Migrate.php
@@ -11,12 +11,20 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Db;
+
+use Closure;
+use DB_Helper;
+use Eventum\Db\Adapter\AdapterInterface;
+use InvalidArgumentException;
+use RuntimeException;
+
 /**
  * Class handling database migrations
  */
-class DbMigrate
+class Migrate
 {
-    /** @var DbInterface */
+    /** @var AdapterInterface */
     private $db;
 
     /** @var array */
@@ -164,7 +172,7 @@ class DbMigrate
      * and if they wish to echo something, should use $log() closure.
      *
      * @param string $file
-     * @param DbInterface $db
+     * @param AdapterInterface $db
      * @param array $dbconfig
      * @param Closure $log
      */

--- a/tests/DbApiTest.php
+++ b/tests/DbApiTest.php
@@ -1,5 +1,8 @@
 <?php
 
+use Eventum\Db\Adapter\NullAdapter;
+use Eventum\Db\Adapter\PearAdapter;
+
 class DbApiTest extends TestCase
 {
     public function testPearApi()
@@ -7,14 +10,14 @@ class DbApiTest extends TestCase
         $this->assertDatabase();
 
         $config = DB_Helper::getConfig();
-        $instance = new DbPear($config);
+        $instance = new PearAdapter($config);
         $this->assertNotNull($instance);
     }
 
     public function testNullApi()
     {
         $config = DB_Helper::getConfig();
-        $instance = new DbNull($config);
+        $instance = new NullAdapter($config);
         $this->assertNotNull($instance);
     }
 }

--- a/tests/DbTest.php
+++ b/tests/DbTest.php
@@ -1,4 +1,6 @@
 <?php
+use Eventum\Db\Adapter\AdapterInterface;
+use Eventum\Db\Adapter\PearAdapter;
 
 /**
  * Test DB layer to work as expected
@@ -6,7 +8,7 @@
 class DbTest extends TestCase
 {
     /**
-     * @var DbInterface
+     * @var AdapterInterface
      */
     private $db;
 
@@ -45,11 +47,11 @@ class DbTest extends TestCase
     /** @group query */
     public function testQuerySelect()
     {
-        if (!$this->db instanceof DbPear) {
-            $this->markTestSkipped('Only possible with DbPear');
+        if (!$this->db instanceof PearAdapter) {
+            $this->markTestSkipped('Only possible with Pear Adapter');
         }
 
-        // only DbPear returns resultset for SELECT statements
+        // only Pear adapter returns resultset for SELECT statements
         $res = $this->db->query("select usr_id from {{%user}} where usr_id=?", array(2));
         $this->assertNotSame(true, $res);
         print_r($res);
@@ -60,7 +62,7 @@ class DbTest extends TestCase
     {
         $res = $this->db->getAll(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?', array(2),
-            DbInterface::DB_FETCHMODE_DEFAULT
+            AdapterInterface::DB_FETCHMODE_DEFAULT
         );
         $this->assertInternalType('array', $res);
         $exp = array(
@@ -85,7 +87,7 @@ class DbTest extends TestCase
     {
         $res = $this->db->getAll(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=? AND usr_id!=42', array(2),
-            DbInterface::DB_FETCHMODE_ASSOC
+            AdapterInterface::DB_FETCHMODE_ASSOC
         );
         $this->assertInternalType('array', $res);
         $exp = array(
@@ -108,8 +110,8 @@ class DbTest extends TestCase
     /** @group getAll */
     public function testGetAllOrdered()
     {
-        if (!$this->db instanceof DbPear) {
-            $this->markTestSkipped('Only possible with DbPear');
+        if (!$this->db instanceof PearAdapter) {
+            $this->markTestSkipped('Only possible with Pear Adapter');
         }
 
         $stmt
@@ -123,8 +125,8 @@ class DbTest extends TestCase
                     lfi_id = plf_lfi_id
                 ORDER BY
                     lfi_id";
-        $res1 = $this->db->getAll($stmt, array(), DbInterface::DB_FETCHMODE_ORDERED);
-        $res2 = $this->db->getAll($stmt, array(), DbInterface::DB_FETCHMODE_DEFAULT);
+        $res1 = $this->db->getAll($stmt, array(), AdapterInterface::DB_FETCHMODE_ORDERED);
+        $res2 = $this->db->getAll($stmt, array(), AdapterInterface::DB_FETCHMODE_DEFAULT);
         $this->assertSame($res1, $res2);
     }
 
@@ -134,7 +136,7 @@ class DbTest extends TestCase
         $res = $this->db->fetchAssoc(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
             array(2),
-            DbInterface::DB_FETCHMODE_DEFAULT
+            AdapterInterface::DB_FETCHMODE_DEFAULT
         );
 
         $this->assertInternalType('array', $res);
@@ -159,7 +161,7 @@ class DbTest extends TestCase
         $res = $this->db->fetchAssoc(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
             array(2),
-            DbInterface::DB_FETCHMODE_ASSOC
+            AdapterInterface::DB_FETCHMODE_ASSOC
         );
 
         $this->assertInternalType('array', $res);
@@ -179,7 +181,7 @@ class DbTest extends TestCase
     }
 
     /**
-     * fetchAssoc with tow columns behaves differently with DbPear.
+     * fetchAssoc with tow columns behaves differently with Eventum\Db\DbPear.
      * you should really use fetchpair then
      *
      * @group fetchAssoc
@@ -187,7 +189,7 @@ class DbTest extends TestCase
     public function testFetchAssoc()
     {
         $stmt = 'SELECT sta_id, sta_title FROM {{%status}} ORDER BY sta_rank ASC';
-        if ($this->db instanceof DbPear) {
+        if ($this->db instanceof PearAdapter) {
             $res = $this->db->fetchAssoc($stmt);
         } else {
             $res = $this->db->getPair($stmt);
@@ -255,7 +257,7 @@ class DbTest extends TestCase
     {
         $res = $this->db->getRow(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
-            array(2), DbInterface::DB_FETCHMODE_DEFAULT
+            array(2), AdapterInterface::DB_FETCHMODE_DEFAULT
         );
 
         $this->assertInternalType('array', $res);
@@ -273,7 +275,7 @@ class DbTest extends TestCase
     {
         $res = $this->db->getRow(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM {{%user}} WHERE usr_id<=?',
-            array(2), DbInterface::DB_FETCHMODE_ASSOC
+            array(2), AdapterInterface::DB_FETCHMODE_ASSOC
         );
 
         $this->assertInternalType('array', $res);

--- a/tests/LoggerTest.php
+++ b/tests/LoggerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Eventum\Db\DatabaseException;
 use Monolog\Handler\StreamHandler;
 
 class LoggerTest extends TestCase
@@ -39,7 +40,7 @@ class LoggerTest extends TestCase
         $this->assertDatabase();
         try {
             DB_Helper::getInstance()->query('here -->?<-- be dragons?', array('param1', 'param2'));
-        } catch (DbException $e) {
+        } catch (DatabaseException $e) {
         }
     }
 

--- a/upgrade/patches/06_iaf_attachment_filename.php
+++ b/upgrade/patches/06_iaf_attachment_filename.php
@@ -11,12 +11,14 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Decode attachment filenames from QuotedPrintable MIME encoding.
  * Also set Untitled.jpg to unnamed attachments (Usually inline).
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 // Attachments that need to be decoded
 $res = $db->getAll('SELECT iaf_id, iaf_filename FROM {{%issue_attachment_file}} WHERE iaf_filename LIKE ?', array('%=?%'));

--- a/upgrade/patches/07_user_preference.php
+++ b/upgrade/patches/07_user_preference.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Move user preferences to a separate table.
  *
@@ -18,7 +20,7 @@
  * as want to make sure everyone migrates their preferences before deleting this.
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 $db->query('CREATE TABLE {{%user_preference}}
 (
     upr_usr_id int(11) unsigned NOT NULL,

--- a/upgrade/patches/26_decode_notes.php
+++ b/upgrade/patches/26_decode_notes.php
@@ -11,11 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Decode note bodies again which have failed to decode unicode html entities
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 /** @var Closure $log */
 
 // notes that need to be decoded

--- a/upgrade/patches/28_history_context_convert.php
+++ b/upgrade/patches/28_history_context_convert.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Try to find placeholders to old history entries not containing context information
  */
@@ -26,6 +28,7 @@
 # :%s#^msgid "#    "/^#
 # :%s#"$#$/",
 #
+
 $patterns = array(
     '/^Attachment removed by (?P<user>.*)$/',
     '/^Attachment uploaded by (?P<user>.*)$/',
@@ -148,7 +151,7 @@ $find = function ($string) use ($patterns) {
     );
 };
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 $res = $db->query("select his_id,his_summary from {{%issue_history}} where his_context=''");
 $total = $res->numRows();
 $current = $updated = 0;
@@ -163,7 +166,7 @@ $log("Total $total rows, this may take time. Please be patient.");
 
 // FIXME: PEAR::DB specific
 /** @var DB_result $res */
-while ($res->fetchInto($row, DbInterface::DB_FETCHMODE_ASSOC)) {
+while ($res->fetchInto($row, AdapterInterface::DB_FETCHMODE_ASSOC)) {
     $current++;
     $m = $find($row['his_summary']);
     if (!$m) {

--- a/upgrade/patches/30_migrate_tz.php
+++ b/upgrade/patches/30_migrate_tz.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Migrate timezone abbreviations to timezone identifier
  * The three letter timezone abbreviations do not play well with DST
@@ -25,6 +27,7 @@
 
 // build list of abbreviation => Timezone
 // we take first timezone and hope it's correct
+
 $timezones = array();
 foreach (DateTimeZone::listAbbreviations() as $abbrevation => $list) {
     // take first timezone
@@ -32,7 +35,7 @@ foreach (DateTimeZone::listAbbreviations() as $abbrevation => $list) {
     $timezones[strtoupper($abbrevation)] = $timezone['timezone_id'];
 }
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 $res = $db->getAll('select upr_usr_id, upr_timezone from {{%user_preference}}');
 
 foreach ($res as $row) {

--- a/upgrade/patches/31_fix_history.php
+++ b/upgrade/patches/31_fix_history.php
@@ -11,10 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Fix bad history keyword (which was fixed in 3e95aa4)
  */
-/** @var DbInterface $db */
+
+/** @var AdapterInterface $db */
 /** @var Closure $log */
 
 $res = $db->getAll("select his_id,his_context from {{%issue_history}} where his_summary='Note routed from {user}' and his_context like '%from%:%'");

--- a/upgrade/patches/33_set_required_fields.php
+++ b/upgrade/patches/33_set_required_fields.php
@@ -11,11 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /**
  * Set required fields to match old default configuration
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 $setup = Setup::get();
 

--- a/upgrade/patches/40_history_role.php
+++ b/upgrade/patches/40_history_role.php
@@ -11,12 +11,14 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /*
  * Add minimum role to history table and update old history entries
  * https://github.com/eventum/eventum/pull/88
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 $db->query('alter table {{%issue_history}} add `his_min_role` tinyint(1) NOT NULL DEFAULT ?', array(User::ROLE_VIEWER));
 

--- a/upgrade/patches/42_fixencoding.php
+++ b/upgrade/patches/42_fixencoding.php
@@ -11,11 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /*
  * Update database fields with fixEncoding instead doing that runtime
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 $logger = Logger::getInstance('db');
 

--- a/upgrade/patches/44_usr_relative_dates.php
+++ b/upgrade/patches/44_usr_relative_dates.php
@@ -11,11 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /*
  * Adds a user preference for using relative dates and updates preferences to current global setting.
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 $db->query('ALTER TABLE {{%user_preference}} ADD COLUMN upr_relative_date tinyint(1) NULL DEFAULT 1');
 

--- a/upgrade/patches/45_multiple_groups.php
+++ b/upgrade/patches/45_multiple_groups.php
@@ -11,11 +11,13 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Db\Adapter\AdapterInterface;
+
 /*
  * Adds the ability for users to belong in multiple groups
  */
 
-/** @var DbInterface $db */
+/** @var AdapterInterface $db */
 
 $db->query('CREATE TABLE {{%user_group}} (
   ugr_usr_id int unsigned NOT NULL,


### PR DESCRIPTION
Decided it's about time to move `Db` classes to `Eventum\` namespace.

changes visible outside Eventum core is `DbException` -> `Eventum\Db\DatabaseException`,
and `DbInterface` -> `Eventum\Db\Adapter\AdapterInterface` (used in phpdoc only, not affecting code)

`DbException` may be used in `Workflow`, `CRM` and `Custom_Field` classes, but i can make [class_alias](http://php.net/class_alias) to make it compatible if needed.

```
 rename lib/eventum/db/DbInterface.php => src/Db/Adapter/AdapterInterface.php (86%)
 rename lib/eventum/db/DbNull.php => src/Db/Adapter/NullAdapter.php (82%)
 rename lib/eventum/db/DbPdo.php => src/Db/Adapter/PdoAdapter.php (89%)
 rename lib/eventum/db/DbBasePdo.php => src/Db/Adapter/PdoAdapterBase.php (89%)
 rename lib/eventum/db/DbPear.php => src/Db/Adapter/PearAdapter.php (91%)
 rename lib/eventum/db/DbYii.php => src/Db/Adapter/YiiAdapter.php (90%)
 rename lib/eventum/db/DbException.php => src/Db/DatabaseException.php (85%)
 rename lib/eventum/db/DbMigrate.php => src/Db/Migrate.php (96%)
```
