### PR TITLE
Add Message-Id column to mail queue table

### DIFF
--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -25,6 +25,11 @@ $logger = Logger::getInstance('db');
 
 $db->query("ALTER TABLE {{%mail_queue}} ADD maq_message_id VARCHAR(255) DEFAULT NULL AFTER maq_subject");
 
+// Lock mail queue table for the patch run
+// as the patch is likely deployed with new code,
+// and new code will not work ok if message_id field is not yet filled properly
+$db->query("LOCK TABLES {{%mail_queue}} READ");
+
 $maq_ids = $db->getColumn(
     // TODO: process only status pending?
     "SELECT maq_id FROM {{%mail_queue}} WHERE maq_message_id IS NULL"
@@ -75,3 +80,5 @@ foreach ($maq_ids as $maq_id) {
 }
 
 $logger->info("Updated $changed out of $total entries");
+
+$db->query("UNLOCK TABLES {{%mail_queue}} READ");

--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -81,4 +81,4 @@ foreach ($maq_ids as $maq_id) {
 
 $logger->info("Updated $changed out of $total entries");
 
-$db->query("UNLOCK TABLES {{%mail_queue}} READ");
+$db->query("UNLOCK TABLES");

--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\Adapter\AdapterInterface;
+use Zend\Mail\Headers;
+
+/*
+ * Update mail queue table by adding Message-ID column
+ */
+
+/** @var Closure $log */
+/** @var AdapterInterface $db */
+
+$logger = Logger::getInstance('db');
+
+$db->query("alter table {{%mail_queue}} add maq_message_id varchar(255) DEFAULT NULL AFTER maq_subject");
+
+$res = $db->getAll(
+    // TODO: process only status pending?
+    "select maq_id,maq_headers from {{%mail_queue}} where maq_message_id is null"
+);
+
+$total = count($res);
+$current = $changed = 0;
+
+if (!$total) {
+    // nothing to do
+    return;
+}
+
+$log("Total $total rows, this may take time. Please be patient.");
+foreach ($res as $row) {
+    $current++;
+
+    $headers = Headers::fromString($row['maq_headers']);
+    $message_id = $headers->get('Message-Id');
+    if (!$message_id) {
+        var_dump($row['maq_headers']);
+        $logger->info(
+            "skipped maq_id={$row['maq_id']}, no message-id header"
+        );
+        continue;
+    }
+    $message_id = $message_id->getFieldValue();
+
+    $logger->info(
+        "updated maq_id={$row['maq_id']}", array('maq_id' => $row['maq_id'], 'message_id' => $message_id)
+    );
+
+    $db->query('UPDATE {{%mail_queue}} SET maq_message_id=? WHERE maq_id=?', array($message_id, $row['maq_id']));
+    $changed++;
+
+    if ($current % 5000 == 0) {
+        $p = round($current / $total * 100, 2);
+        $log("... updated $current rows, $p%");
+    }
+}
+
+$count = count($res);
+$logger->info("Updated $changed out of $count entries");

--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -81,6 +81,6 @@ $db->query("ALTER TABLE {{%mail_queue}} ADD maq_message_id VARCHAR(255) DEFAULT 
 // Lock mail queue table for the patch run
 // as the patch is likely deployed with new code,
 // and new code will not work ok if message_id field is not yet filled properly
-$db->query("LOCK TABLES {{%mail_queue}} READ");
+$db->query("LOCK TABLES {{%mail_queue}} WRITE");
 $process_messages();
 $db->query("UNLOCK TABLES");

--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -74,5 +74,4 @@ foreach ($maq_ids as $maq_id) {
     }
 }
 
-$count = count($res);
-$logger->info("Updated $changed out of $count entries");
+$logger->info("Updated $changed out of $total entries");

--- a/upgrade/patches/48_maq_message_id.php
+++ b/upgrade/patches/48_maq_message_id.php
@@ -21,7 +21,60 @@ use Zend\Mail\Headers;
 /** @var Closure $log */
 /** @var AdapterInterface $db */
 
-$logger = Logger::getInstance('db');
+$process_messages = function () use ($db, $log) {
+    $logger = Logger::getInstance('db');
+
+    // TODO: process only status pending?
+    $maq_ids = $db->getColumn(
+        "SELECT maq_id FROM {{%mail_queue}} WHERE maq_message_id IS NULL"
+    );
+
+    $total = count($maq_ids);
+    $current = $changed = 0;
+
+    if (!$total) {
+        // nothing to do
+        return;
+    }
+
+    $log("Total $total rows, this may take time. Please be patient.");
+    foreach ($maq_ids as $maq_id) {
+        $current++;
+
+        $maq_headers = $db->getOne("SELECT maq_headers FROM {{%mail_queue}} WHERE maq_id=?", array($maq_id));
+
+        try {
+            $headers = Headers::fromString($maq_headers);
+        } catch (Exception $e) {
+            $logger->info(
+                "skipped maq_id={$maq_id}, exception: {$e->getMessage()}"
+            );
+            continue;
+        }
+        $message_id = $headers->get('Message-Id');
+        if (!$message_id) {
+            $logger->info(
+                "skipped maq_id={$maq_id}, no message-id header"
+            );
+            continue;
+        }
+        $message_id = $message_id->getFieldValue();
+
+        $logger->info(
+            "updated maq_id={$maq_id}", array('maq_id' => $maq_id, 'message_id' => $message_id)
+        );
+
+        $db->query('UPDATE {{%mail_queue}} SET maq_message_id=? WHERE maq_id=?', array($message_id, $maq_id));
+        $changed++;
+
+        if ($current % 5000 == 0) {
+            $p = round($current / $total * 100, 2);
+            $log("... updated $current rows, $p%");
+        }
+    }
+
+    $logger->info("Updated $changed out of $total entries");
+};
 
 $db->query("ALTER TABLE {{%mail_queue}} ADD maq_message_id VARCHAR(255) DEFAULT NULL AFTER maq_subject");
 
@@ -29,56 +82,5 @@ $db->query("ALTER TABLE {{%mail_queue}} ADD maq_message_id VARCHAR(255) DEFAULT 
 // as the patch is likely deployed with new code,
 // and new code will not work ok if message_id field is not yet filled properly
 $db->query("LOCK TABLES {{%mail_queue}} READ");
-
-$maq_ids = $db->getColumn(
-    // TODO: process only status pending?
-    "SELECT maq_id FROM {{%mail_queue}} WHERE maq_message_id IS NULL"
-);
-
-$total = count($maq_ids);
-$current = $changed = 0;
-
-if (!$total) {
-    // nothing to do
-    return;
-}
-
-$log("Total $total rows, this may take time. Please be patient.");
-foreach ($maq_ids as $maq_id) {
-    $current++;
-
-    $maq_headers = $db->getOne("SELECT maq_headers FROM {{%mail_queue}} WHERE maq_id=?", array($maq_id));
-
-    try {
-        $headers = Headers::fromString($maq_headers);
-    } catch (Exception $e) {
-        $logger->info(
-            "skipped maq_id={$maq_id}, exception: {$e->getMessage()}"
-        );
-        continue;
-    }
-    $message_id = $headers->get('Message-Id');
-    if (!$message_id) {
-        $logger->info(
-            "skipped maq_id={$maq_id}, no message-id header"
-        );
-        continue;
-    }
-    $message_id = $message_id->getFieldValue();
-
-    $logger->info(
-        "updated maq_id={$maq_id}", array('maq_id' => $maq_id, 'message_id' => $message_id)
-    );
-
-    $db->query('UPDATE {{%mail_queue}} SET maq_message_id=? WHERE maq_id=?', array($message_id, $maq_id));
-    $changed++;
-
-    if ($current % 5000 == 0) {
-        $p = round($current / $total * 100, 2);
-        $log("... updated $current rows, $p%");
-    }
-}
-
-$logger->info("Updated $changed out of $total entries");
-
+$process_messages();
 $db->query("UNLOCK TABLES");


### PR DESCRIPTION
Add Message-Id column to mail queue table

idea is to implement 5d043aaccbee438091081232125684fe3a6e0da5 better, using Message-Id
see discussion in Launchpad
https://bugs.launchpad.net/pld-linux/+bug/1195856

This depends on #139, so it should be merged first