### PR TITLE
Automatically set page ID based on template path and name

### DIFF
--- a/docs/examples/templates/customer/customer_expired.tpl.html
+++ b/docs/examples/templates/customer/customer_expired.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}customer_expired{/block}
 {block title}{t}Customer Expired{/t}{/block}
 
 {block "content"}

--- a/docs/examples/templates/customer/customer_lookup.tpl.html
+++ b/docs/examples/templates/customer/customer_lookup.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}customer_lookup{/block}
 {block title}{t}Customer Lookup{/t}{/block}
 
 {block "content"}

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -9,13 +9,6 @@
  * that were distributed with this source code.
  */
 
-/* Stats Page */
-body#stats {
-
-}
-
-/* END Stats Page */
-
 /* Setup Page */
 body#setup {
     line-height: 1.25em;
@@ -34,7 +27,7 @@ body#new_issue #create_issue {
 
 
 /* Login Page */
-body#login h1 {
+body#index h1 {
     text-align: center;
 }
 
@@ -128,72 +121,72 @@ body#login form#login_form table td.button {
     text-align: center;
 }
 
-body#issue_view div#issue_links {
+body.issue_view div#issue_links {
     width: 100%;
 }
-body#issue_view div#issue_links a {
+body.issue_view div#issue_links a {
     text-decoration: none;
 }
 
-body#issue_view div#issue_links div:first-child {
+body.issue_view div#issue_links div:first-child {
     float: left;
     width: 300px;
 }
 
-body#issue_view div#issue_links div.right {
+body.issue_view div#issue_links div.right {
     float: right;
     width: 300px;
     text-align: right;
 }
 
-body#issue_view div.issue_section {
+body.issue_view div.issue_section {
     margin-bottom: 1em;
 }
 
-body#issue_view div.issue_section div.content table {
+body.issue_view div.issue_section div.content table {
     width: 100%;
 }
 td#email_message,
-body#issue_view div.issue_section div.content table tr.note_content {
+body.issue_view div.issue_section div.content table tr.note_content {
     -ms-word-break: break-all;
     word-break: break-all;
     word-break: break-word;
 }
 
-body#issue_view div#time_tracking tr.total_time td:first-child {
+body.issue_view div#time_tracking tr.total_time td:first-child {
     background: #9c494b;
     color: #FFFFFF;
     text-align: right;
 }
 
-body#issue_view div#custom_fields div.content th {
+body.issue_view div#custom_fields div.content th {
     width: 200px;
 }
 
-body#issue_view #drafts .buttons_div {
+body.issue_view #drafts .buttons_div {
     width: 200px;
     text-align: right;
 }
 
-body#issue_view .revision {
+body.issue_view .revision {
     max-width: 5em;
     overflow: hidden;
     text-decoration: underline;
 }
 
-body#issue_view td.checkins > a {
+body.issue_view td.checkins > a {
     display: inline-block;
     overflow: hidden;
     vertical-align: top;
 }
 
-body#issue_view td.message > span {
+body.issue_view td.message > span {
     display: inline-block;
     max-height: 200px;
     overflow: auto;
 }
 
-body#issue_view #issue_summary {
+body.issue_view #issue_summary {
     font-weight: bold;
     border-bottom: 1px solid #eeeeee;
 }
@@ -211,17 +204,17 @@ body#issue_update #page_locked {
 /* End Issue Update Page */
 
 /* Begin List issue page */
-body#list_issues div#quick_filter {
+body#list div#quick_filter {
     width: 80%;
     margin: 0 auto;
 }
 
-body#list_issues div#quick_filter div#ft_options div {
+body#list div#quick_filter div#ft_options div {
     width: 50%;
     float: left;
 }
 
-body#list_issues div#quick_filter div.bottom_bar {
+body#list div#quick_filter div.bottom_bar {
     background: #dddddd;
     border-bottom-left-radius: 0.5em;
     -webkit-border-bottom-left-radius: 0.5em;
@@ -232,36 +225,36 @@ body#list_issues div#quick_filter div.bottom_bar {
 
 }
 
-body#list_issues div#quick_filter div.bottom_bar table {
+body#list div#quick_filter div.bottom_bar table {
     width: 100%;
 }
 
-body#list_issues div#quick_filter div.bottom_bar table td {
+body#list div#quick_filter div.bottom_bar table td {
     width: 33%;
 }
 
-body#list_issues #current_filters {
+body#list #current_filters {
     text-align: center;
     margin: 1em;
 }
 
-body#list_issues #current_filters span {
+body#list #current_filters span {
     background: #ffffaa;
     padding: .5em;
     display: inline-block;
     width: inherit;
 }
 
-body#list_issues #bulk_update {
+body#list #bulk_update {
     width: 80%;
     margin: 1em auto;
 }
 
-body#list_issues #bulk_update table {
+body#list #bulk_update table {
     width: 100%;
 }
 
-body#list_issues td.custom_field {
+body#list td.custom_field {
     cursor: pointer;
 }
 
@@ -378,12 +371,12 @@ body#adv_search #date_fields, body#adv_search #custom_fields_row {
     display: block;
 }
 
-#custom_fields_popup .chosen-select {
+#custom_fields_form .chosen-select {
     width:360px;
 }
 
 /* SCM style fixes */
-#issue_view  ul.scm_checkin {
+.issue_view  ul.scm_checkin {
     list-style: outside none disc;
     padding: 0 1.5em;
     margin: 0;
@@ -430,11 +423,11 @@ div.phpdebugbar {
 }
 
 /* % complete progressbar in view issues page */
-#list_issues .ui-progressbar {
+#list .ui-progressbar {
     position: relative;
     height: 19px;
 }
-#list_issues .progress-label {
+#list .progress-label {
     position: absolute;
     width: 100%;
     text-align: center;
@@ -443,12 +436,12 @@ div.phpdebugbar {
 }
 
 /* % complete progressbar in issue view */
-#issue_view .ui-progressbar {
+.issue_view .ui-progressbar {
     position: relative;
     height: 16px;
     max-width: 200px;
 }
-#issue_view .progress-label {
+.issue_view .progress-label {
     position: absolute;
     width: 100%;
     text-align: center;
@@ -456,13 +449,13 @@ div.phpdebugbar {
     font-size: 13px;
     line-height: 1.05em;
 }
-#issue_view .ui-widget-header {
+.issue_view .ui-widget-header {
     background: #89A989;
 }
 
 /* Disable white background image */
-#issue_view .ui-progressbar.ui-widget-content,
-#list_issues .ui-progressbar.ui-widget-content
+.issue_view .ui-progressbar.ui-widget-content,
+#list .ui-progressbar.ui-widget-content
 {
     background: transparent;
     border: 1px solid #c0c0c0;

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -175,6 +175,7 @@ class Template_Helper
             'roles' => User::getAssocRoleIDs(),
             'auth_backend' => strtolower(APP_AUTH_BACKEND),
             'current_url' => $_SERVER['PHP_SELF'],
+            'template_id'    =>  str_replace(array("/", '.tpl.html'), array("_"), $this->tpl_name),
         ];
 
         // If VCS version is present "Eventum 2.3.3-148-g78b3368", link ref to github

--- a/templates/access.tpl.html
+++ b/templates/access.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}access{/block}
 {block title}#{$issue_id} - Access List{/block}
 
 {block "content"}

--- a/templates/add_phone_entry.tpl.html
+++ b/templates/add_phone_entry.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}add_phone_entry{/block}
 {block "title"}#{$issue_id} - Add Phone Entry{/block}
 
 {block "content"}

--- a/templates/adv_search.tpl.html
+++ b/templates/adv_search.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block "page_id"}adv_search{/block}
 {block title}{t}Advanced Search{/t}{/block}
 
 {block "content"}

--- a/templates/associate.tpl.html
+++ b/templates/associate.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}associate_email{/block}
 {block title}{t}Associate Email{/t}{/block}
 
 {block content}

--- a/templates/authentication_error.tpl.html
+++ b/templates/authentication_error.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}authentication_error{/block}
 
 {block "content"}
 {t 1=$error_message}Sorry, there was an error logging you in: %1{/t}

--- a/templates/authorized_replier.tpl.html
+++ b/templates/authorized_replier.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}authorized_replier{/block}
 {block title}#{$issue_id} - Authorized Replier List{/block}
 
 {block "content"}

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -61,10 +61,10 @@
   {* local directory can add overrides *}
   {include file="extra_header.tpl.html"}
 </head>
-<!--[if lt IE 7 ]> <body class="ie6 {block "page_classes"}{/block} {block "page_id"}{/block}" id="{block "page_id"}{/block}"> <![endif]-->
-<!--[if IE 7 ]> <body class="ie7 {block "page_classes"}{/block} {block "page_id"}{/block}" id="{block "page_id"}{/block}"> <![endif]-->
-<!--[if IE 8 ]> <body class="ie8 {block "page_classes"}{/block} {block "page_id"}{/block}" id="{block "page_id"}{/block}"> <![endif]-->
-<!--[if !IE]>--> <body class="{block "page_classes"}{/block} {block "page_id"}{/block}" id="{block "page_id"}{/block}"><!--<![endif]-->
+<!--[if lt IE 7 ]> <body class="ie6 {block page_classes}{/block}" id="{$core.template_id}"> <![endif]-->
+<!--[if IE 7 ]> <body class="ie7 {block page_classes}{/block}" id="{$core.template_id}"> <![endif]-->
+<!--[if IE 8 ]> <body class="ie8 {block page_classes}{/block}" id="{$core.template_id}"> <![endif]-->
+<!--[if !IE]>--> <body class="{block page_classes}{/block}" id="{$core.template_id}"><!--<![endif]-->
 <div id="container">
     {block "header"}{/block}
 

--- a/templates/close.tpl.html
+++ b/templates/close.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}close_issue{/block}
 {block page_classes}CustomField{/block}
 {block "title"}#{$issue_id} - Close{/block}
 

--- a/templates/confirm.tpl.html
+++ b/templates/confirm.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Confirm{/block}
-{block "page_id"}confirm{/block}
 
 {block "content"}
 

--- a/templates/custom_fields_form.tpl.html
+++ b/templates/custom_fields_form.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}#{$issue_id} - Custom Fields{/block}
-{block "page_id"}custom_fields_popup{/block}
 
 {block "javascripts" append}
   <script type="text/javascript" src="{$core.rel_url}ajax/dynamic_custom_field.js.php?iss_id={$smarty.get.issue_id}"></script>

--- a/templates/duplicate.tpl.html
+++ b/templates/duplicate.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}duplicate{/block}
 {block title}{t 1=$smarty.get.id|intval}Issue #%1 - Duplicate{/t}{/block}
 
 {block "content"}

--- a/templates/edit_reporter.tpl.html
+++ b/templates/edit_reporter.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}edit_reporter{/block}
 {block title}{t 1=$smarty.get.iss_id|intval}Issue #%1 - Edit Reporter{/t}{/block}
 
 {block "content"}

--- a/templates/emails.tpl.html
+++ b/templates/emails.tpl.html
@@ -1,6 +1,5 @@
 {extends "base_full.tpl.html"}
 {block "title"}{t}Associate Emails{/t}{/block}
-{block "page_id"}emails{/block}
 
 {block "content"}
 

--- a/templates/error_message.tpl.html
+++ b/templates/error_message.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}error{/block}
 {block title}{t}Error{/t}{/block}
 
 {block "content"}

--- a/templates/faq.tpl.html
+++ b/templates/faq.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}issue_view{/block}
 {block title}Internal FAQ{if $faq|default:'' != ''} - {$faq.faq_title}{/if}{/block}
 
 {block "content"}

--- a/templates/forgot_password.tpl.html
+++ b/templates/forgot_password.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Request a Password{/block}
-{block "page_id"}forgot_password{/block}
 
 {block "content"}
 <br /><br />

--- a/templates/help/index.tpl.html
+++ b/templates/help/index.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}help{/block}
 {block "title"}Help{/block}
 
 {block "content"}

--- a/templates/history.tpl.html
+++ b/templates/history.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block "page_id"}history{/block}
 {block "title"}#{$issue_id} - History{/block}
 
 {block "content"}

--- a/templates/index.tpl.html
+++ b/templates/index.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Login{/block}
-{block "page_id"}login{/block}
 
 {block "content"}
 

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block "page_id"}list_issues{/block}
 
 {block "content"}
 {if $core.current_role != $core.roles.customer}

--- a/templates/mail_queue.tpl.html
+++ b/templates/mail_queue.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}mail_queue{/block}
 {block title}{t 1=$smarty.get.iss_id|intval}Issue #%1 - Mail Queue{/t}{/block}
 
 {block "content"}

--- a/templates/main.tpl.html
+++ b/templates/main.tpl.html
@@ -1,6 +1,6 @@
 {extends "base_full.tpl.html"}
 {block "title"}Stats{/block}
-{block "page_id"}stats{/block}
+{block "page_classes"}stats{/block}
 
 {block "content"}
 {if $core.current_role == $core.roles.customer}

--- a/templates/maintenance.tpl.html
+++ b/templates/maintenance.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}associate_email{/block}
 {block title}{t}Associate Email{/t}{/block}
 
 {block content}

--- a/templates/new.tpl.html
+++ b/templates/new.tpl.html
@@ -1,6 +1,5 @@
 {extends "base_full.tpl.html"}
-{block "page_id"}new_issue{/block}
-{block "page_classes"}CustomField GrowingFileField{/block}
+{block "page_classes"}new_issue CustomField GrowingFileField{/block}
 
 {block "javascripts" append}
   <script type="text/javascript" src="{$core.rel_url}ajax/dynamic_custom_field.js.php?form_type=report_form"></script>

--- a/templates/news.tpl.html
+++ b/templates/news.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}news{/block}
 {block title}{t}News{/t}{/block}
 
 {block "content"}

--- a/templates/notification.tpl.html
+++ b/templates/notification.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}notification{/block}
 {block title}#{$issue_id} - Notification List{/block}
 
 {block "javascripts"}

--- a/templates/offline.tpl.html
+++ b/templates/offline.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Offline{/block}
-{block "page_id"}offline{/block}
 
 {block "content"}
 

--- a/templates/permission_denied.tpl.html
+++ b/templates/permission_denied.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}permission_denied{/block}
 {block title}{t}Permission Denied{/t}{/block}
 
 {block "content"}

--- a/templates/popup.tpl.html
+++ b/templates/popup.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block "page_id"}popup{/block}
 {block "page_classes"}popup_{$cat}{/block}
 
 {block "content"}

--- a/templates/post.tpl.html
+++ b/templates/post.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
-{block "page_id"}anon_post{/block}
-{block "page_classes"}CustomField GrowingFileField{/block}
+{block "page_classes"}anon_post CustomField GrowingFileField{/block}
 
 {block name="content"}
 <div class="note_box">

--- a/templates/preferences.tpl.html
+++ b/templates/preferences.tpl.html
@@ -1,6 +1,5 @@
 {extends "base_full.tpl.html"}
 {block "title"}{t}Preferences{/t}{/block}
-{block "page_id"}preferences{/block}
 
 {block "content"}
 

--- a/templates/redeem_incident.tpl.html
+++ b/templates/redeem_incident.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}redeem_incident{/block}
 {block title}{t 1=$issue_id}Redeem Incident - Issue#%1{/t}{/block}
 
 {block content}

--- a/templates/removed_emails.tpl.html
+++ b/templates/removed_emails.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Removed Emails{/block}
-{block "page_id"}view_email{/block}
 
 {block "content"}
 {if $result_msg|default:'' != ''}

--- a/templates/reports/category_statuses.tpl.html
+++ b/templates/reports/category_statuses.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}category_statuses{/block}
 {block "title"}Categories and Statuses{/block}
 
 {block "report_content"}<br />

--- a/templates/reports/custom_fields.tpl.html
+++ b/templates/reports/custom_fields.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}custom_fields_report{/block}
 {block "title"}Custom Fields{/block}
 
 {block "report_content"}

--- a/templates/reports/custom_fields_weekly.tpl.html
+++ b/templates/reports/custom_fields_weekly.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}custom_fields_report_weekly{/block}
 {block "title"}Custom Fields Weekly{/block}
 
 {block "report_content"}

--- a/templates/reports/estimated_dev_time.tpl.html
+++ b/templates/reports/estimated_dev_time.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}development_time_report{/block}
 {block "title"}Estimated Development Time by Category{/block}
 
 {block "report_content"}

--- a/templates/reports/recent_activity.tpl.html
+++ b/templates/reports/recent_activity.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}recent_activity_report{/block}
 {block "title"}Recent Activity{/block}
 
 {block "report_content"}

--- a/templates/reports/stalled_issues.tpl.html
+++ b/templates/reports/stalled_issues.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}recent_activity_report{/block}
 {block "title"}Stalled Issues{/block}
 
 {block "report_content"}

--- a/templates/reports/workload_date_range.tpl.html
+++ b/templates/reports/workload_date_range.tpl.html
@@ -1,5 +1,4 @@
 {extends "reports/reports_base.tpl.html"}
-{block "page_id"}recent_activity_report{/block}
 {block "title"}Workload Date Range{/block}
 
 {block "report_content"}

--- a/templates/requirement.tpl.html
+++ b/templates/requirement.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}requirement{/block}
 {block title}{/block}
 
 {block "content"}

--- a/templates/select_customer.tpl.html
+++ b/templates/select_customer.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Select Customer{/block}
-{block "page_id"}select_customer{/block}
 
 {block "content"}
 <br />

--- a/templates/select_partners.tpl.html
+++ b/templates/select_partners.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}select_partners{/block}
 {block title}{t 1=$smarty.get.id|intval}Issue #%1 -  Select Partners{/t}{/block}
 
 {block content}

--- a/templates/select_project.tpl.html
+++ b/templates/select_project.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}Select Project{/block}
-{block "page_id"}select_project{/block}
 
 {block "content"}
 <br />

--- a/templates/self_assign.tpl.html
+++ b/templates/self_assign.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block "page_id"}self_assign{/block}
 {block "title"}#{$issue_id} - Self Assign{/block}
 
 {block "content"}

--- a/templates/setup.tpl.html
+++ b/templates/setup.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block "page_id"}setup{/block}
 {block "title"}Eventum Installation{/block}
 
 {block javascripts}

--- a/templates/signup.tpl.html
+++ b/templates/signup.tpl.html
@@ -1,5 +1,4 @@
 {extends "base.tpl.html"}
-{block page_id}account_signup{/block}
 {block title}{t}Account Signup{/t}{/block}
 
 {block "content"}

--- a/templates/spell_check.tpl.html
+++ b/templates/spell_check.tpl.html
@@ -1,5 +1,4 @@
 {extends "base_full.tpl.html"}
-{block page_id}mpab_escalate_view{/block}
 {block title}{t 1=$issue_id 2=$escalation_id}Escalate #%1 on Issue #%1{/t}{/block}
 
 {block "content"}

--- a/templates/update.tpl.html
+++ b/templates/update.tpl.html
@@ -1,6 +1,5 @@
 {extends "base_full.tpl.html"}
-{block page_id}issue_update{/block}
-{block page_classes}issue_view product CustomField{/block}
+{block page_classes}issue_update issue_view product CustomField{/block}
 {block title}{t 1=$issue_id}Issue #%1 - Update{/t}{/block}
 
 {block "content"}

--- a/templates/view.tpl.html
+++ b/templates/view.tpl.html
@@ -1,5 +1,5 @@
 {extends "base_full.tpl.html"}
-{block page_id}issue_view{/block}
+{block page_classes}issue_view{/block}
 
 {block "content"}
 {if $issue|default:'' != ''}

--- a/templates/view_email.tpl.html
+++ b/templates/view_email.tpl.html
@@ -1,6 +1,5 @@
 {extends "base.tpl.html"}
 {block "title"}{$extra_title}{/block}
-{block "page_id"}view_email{/block}
 
 {block "content"}
 


### PR DESCRIPTION
This removes the need to manually set page ids in each template.  This also removes the page id from page classes to remove duplication.

Most page ids stayed the same, but a few have changed to match the template name.