### PR TITLE
Added visible error instead of 500 when workflow class is missing

### DIFF
--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -95,9 +95,13 @@ class Workflow
             if (file_exists(APP_LOCAL_PATH . "/workflow/$backend_class")) {
                 /** @noinspection PhpIncludeInspection */
                 require_once APP_LOCAL_PATH . "/workflow/$backend_class";
-            } else {
+            } elseif (file_exists(APP_INC_PATH . "/workflow/$backend_class")) {
                 /** @noinspection PhpIncludeInspection */
                 require_once APP_INC_PATH . "/workflow/$backend_class";
+            } else {
+                $errors[] = ev_gettext('Workflow is enabled, but backend class "%1$s" is not found.', $backend_class);
+                Misc::displayRequirementErrors($errors);
+                exit;
             }
 
             $setup_backends[$prj_id] = new $class_name();


### PR DESCRIPTION
Very small change to test whether the workflow class file is found before trying to require it. Now on error shows the standard configuration error instead of a 500 server error.
