### PR TITLE
Do not associate forwarded emails to original issue

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -14,6 +14,7 @@ Eventum Issue Tracking System
 - Add category to notification emails (@balsdorf)
 - Don't display Status Change Date column if it has not been customized (@balsdorf)
 - Strip tabs and newlines from note / email subjects (@balsdorf)
+- Do not associate forwarded emails to original issue (@glen)
 
 2016-06-06, Version [3.1.2]
 ----------------------------

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -861,6 +861,12 @@ class Mail_Helper
     public static function getAllReferences($text_headers)
     {
         $references = [];
+
+        // if X-Forwarded-Message-Id is present, assume this is forwarded email and this root email
+        if (preg_match('/^X-Forwarded-Message-Id: .*/mi', $text_headers)) {
+            return $references;
+        }
+
         if (preg_match('/^In-Reply-To: (.*)/mi', $text_headers, $matches)) {
             $references[] = trim($matches[1]);
         }

--- a/tests/ForwardedRoutingTest.php
+++ b/tests/ForwardedRoutingTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use Eventum\Mail\MailMessage;
+
+class ForwardedRoutingTest extends PHPUnit_Framework_TestCase
+{
+    /**
+     * Test that message forwarded by Thunderbird gets new issue
+     * i.e if mail has Matching In-Reply-To header, but also X-Forwarded-Message-Id header
+     * the email is not associated by new issue created
+     */
+    public function testForwardedMailRouting()
+    {
+        $full_message = file_get_contents(__DIR__ . '/data/thunderbird-forwarded.txt');
+        $message = MailMessage::createFromString($full_message);
+
+        $headers = $message->getHeaders();
+
+        $references = Mail_Helper::getAllReferences($headers->toString());
+        $this->assertEmpty($references);
+    }
+}

--- a/tests/data/thunderbird-forwarded.txt
+++ b/tests/data/thunderbird-forwarded.txt
@@ -1,0 +1,37 @@
+Subject: Problematic query report for example.local
+References: <20160815020206.A0FCB10116B@example.local>
+To: Support List <support@example.local>
+From: =?UTF-8?Q?Elan_Ruusam=c3=a4e?= <glen@delfi.ee>
+X-Forwarded-Message-Id: <20160815020206.A0FCB10116B@example.local>
+Message-ID: <57BAA4F3.2040909@example.local>
+Date: Mon, 22 Aug 2016 10:08:35 +0300
+User-Agent: Mozilla/5.0 (X11; Linux x86_64; rv:38.0) Gecko/20100101
+ Icedove/38.5.0
+MIME-Version: 1.0
+In-Reply-To: <20160815020206.A0FCB10116B@example.local>
+Content-Type: multipart/alternative;
+ boundary="------------060106020003010809010007"
+
+This is a multi-part message in MIME format.
+--------------060106020003010809010007
+Content-Type: text/plain; charset=windows-1252; format=flowed
+Content-Transfer-Encoding: 8bit
+
+kuku
+
+--------------060106020003010809010007
+Content-Type: text/html; charset=windows-1252
+Content-Transfer-Encoding: 8bit
+
+<html>
+  <head>
+
+    <meta http-equiv="content-type" content="text/html; charset=windows-1252">
+  </head>
+  <body text="#000000" bgcolor="#FFFFFF">
+
+
+  </body>
+</html>
+
+--------------060106020003010809010007--


### PR DESCRIPTION
Time to time you take existing Eventum Note or Email and forward it to `support@` address.

Your intention is to create new issue from it, but Thunderbird includes `In-Reply-To` header like it's `reply`, but it's really `forward`. It also includes `X-Forwarded-Message-Id` header. use that to detect it's forward not reply.