### PR TITLE
Error : "Manage Time Tracking Categories"

### DIFF
--- a/lib/eventum/class.time_tracking.php
+++ b/lib/eventum/class.time_tracking.php
@@ -83,12 +83,13 @@ class Time_Tracking
     {
         $stmt = 'SELECT
                     ttr_ttc_id,
-                    COUNT(*)
+                    COUNT(ttr_ttc_id)
                  FROM
-                    {{%time_tracking}}
-                 WHERE
-                    ttr_ttc_id IN (' . DB_Helper::buildList($ttc_ids) . ')
-                 GROUP BY 1';
+                    {{%time_tracking}}';
+        if (count($ttc_ids) > 0) {
+            $stmt .= ' WHERE ttr_ttc_id IN (' . DB_Helper::buildList($ttc_ids) . ')';
+        }
+        $stmt .= ' GROUP BY 1';
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $ttc_ids);
         } catch (DatabaseException $e) {


### PR DESCRIPTION
In "Manage Projects", "Manage Time Tracking Categories".
When any "Time Tracking Categories"  doesn't exists in the Project, for example a new project is created, error appear on click "Manage Time Tracking Categories".