### PR TITLE
rewrite issue association code

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,7 +3,7 @@
 ## 2016-??-??, Version [3.1.4]
 
 - Add 'reply as email' option to notes (@balsdorf, #205)
-- Encryption: assume no key present if `secret_key.php` file is empty (@glensc)
+- encryption: assume no key present if `secret_key.php` file is empty (@glensc)
 - Fix bugs in issue association code (@glensc, #207)
 
 ## 2016-09-25, Version [3.1.3]

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -3,8 +3,8 @@
 ## 2016-??-??, Version [3.1.4]
 
 - Add 'reply as email' option to notes (@balsdorf, #205)
-- encryption: assume no key present if `secret_key.php` file is empty (@glensc)
-- rewrite issue association code (@glensc)
+- Encryption: assume no key present if `secret_key.php` file is empty (@glensc)
+- Fix bugs in issue association code (@glensc, #207)
 
 ## 2016-09-25, Version [3.1.3]
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - Add 'reply as email' option to notes (@balsdorf, #205)
 - encryption: assume no key present if `secret_key.php` file is empty (@glensc)
+- rewrite issue association code (@glensc)
 
 ## 2016-09-25, Version [3.1.3]
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1394,13 +1394,13 @@ class Issue
     /**
      * Update the issue associations
      *
+     * @param int $usr_id User Id performing the operation
      * @param int $issue_id issue to associate
      * @param array $associated_issues issue_id's to associate with
      * @deprecated use IssueAssociationRepository
      */
-    private function updateAssociatedIssuesRelations($issue_id, $associated_issues)
+    private function updateAssociatedIssuesRelations($usr_id, $issue_id, $associated_issues)
     {
-        $usr_id = Auth::getUserID();
         $repo = IssueAssociationRepository::create();
         $res = $repo->updateAssociations($usr_id, $issue_id, $associated_issues);
 
@@ -1432,7 +1432,7 @@ class Issue
         $current = self::getDetails($issue_id);
 
         $associated_issues = isset($_POST['associated_issues']) ? explode(',', $_POST['associated_issues']) : [];
-        self::updateAssociatedIssuesRelations($issue_id, $associated_issues);
+        self::updateAssociatedIssuesRelations($usr_id, $issue_id, $associated_issues);
 
         $assignments_changed = false;
         if (@$_POST['keep_assignments'] == 'no' && Access::canChangeAssignee($issue_id, $usr_id)) {
@@ -2276,7 +2276,7 @@ class Issue
             if ($clone_iss_id) {
                 $associated_issues[] = $clone_iss_id;
             }
-            self::updateAssociatedIssuesRelations($issue_id, $associated_issues);
+            self::updateAssociatedIssuesRelations($usr_id, $issue_id, $associated_issues);
         }
 
         Workflow::handleNewIssue($prj_id, $issue_id, $has_TAM, $has_RR);

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1760,20 +1760,6 @@ class Issue
     }
 
     /**
-     * Method used to remove a issue association from an issue.
-     *
-     * @param   integer $issue_id The issue ID
-     * @param   integer $associated_id The associated issue ID to remove.
-     * @deprecated use IssueAssociationRepository
-     */
-    public static function deleteAssociation($issue_id, $associated_id)
-    {
-        $usr_id = Auth::getUserID();
-        $repo = IssueAssociationRepository::create();
-        $repo->removeAssociation($usr_id, $issue_id, $associated_id);
-    }
-
-    /**
      * Method used to assign an issue with an user.
      *
      * @param   integer $usr_id The user ID of the person performing this change

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -2088,8 +2088,7 @@ class Issue
         }
 
         $prj_id = Auth::getCurrentProject();
-        $current_usr_id = Auth::getUserID();
-        $usr_id = $current_usr_id;
+        $usr_id = Auth::getUserID();
 
         // if we are creating an issue for a customer, put the
         // main customer contact as the reporter for it
@@ -2114,16 +2113,16 @@ class Issue
         $has_RR = false;
         $info = User::getNameEmail($usr_id);
         // log the creation of the issue
-        History::add($issue_id, $current_usr_id, 'issue_opened', 'Issue opened by {user}', [
-            'user' => User::getFullName($current_usr_id),
+        History::add($issue_id, $usr_id, 'issue_opened', 'Issue opened by {user}', [
+            'user' => User::getFullName($usr_id),
         ]);
 
         $clone_iss_id = isset($_POST['clone_iss_id']) ? (int) $_POST['clone_iss_id'] : null;
-        if ($clone_iss_id && Access::canCloneIssue($clone_iss_id, $current_usr_id)) {
-            History::add($issue_id, $current_usr_id, 'issue_cloned_from', 'Issue cloned from issue #{issue_id}', [
+        if ($clone_iss_id && Access::canCloneIssue($clone_iss_id, $usr_id)) {
+            History::add($issue_id, $usr_id, 'issue_cloned_from', 'Issue cloned from issue #{issue_id}', [
                 'issue_id' => $clone_iss_id
             ]);
-            History::add($clone_iss_id, $current_usr_id, 'issue_cloned_to', 'Issue cloned to issue #{issue_id}', [
+            History::add($clone_iss_id, $usr_id, 'issue_cloned_to', 'Issue cloned to issue #{issue_id}', [
                 'issue_id' => $issue_id,
             ]);
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1734,19 +1734,6 @@ class Issue
     }
 
     /**
-     * Method used to associate an existing issue with another one.
-     *
-     * @param   integer $issue_id The issue ID
-     * @param   integer $issue_id The other issue ID
-     * @deprecated use IssueAssociationRepository
-     */
-    public static function addAssociation($issue_id, $associated_id, $usr_id)
-    {
-        $repo = IssueAssociationRepository::create();
-        $repo->addIssueAssociation($usr_id, $issue_id, $associated_id);
-    }
-
-    /**
      * Method used to remove the issue associations related to a specific issue.
      *
      * @param int|array $issue_id The issue ID
@@ -2139,7 +2126,9 @@ class Issue
             History::add($clone_iss_id, $current_usr_id, 'issue_cloned_to', 'Issue cloned to issue #{issue_id}', [
                 'issue_id' => $issue_id,
             ]);
-            self::addAssociation($issue_id, $clone_iss_id, $usr_id);
+
+            IssueAssociationRepository::create()
+                ->addIssueAssociation($usr_id, $issue_id, $clone_iss_id);
         }
 
         $emails = [];

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1780,7 +1780,7 @@ class Issue
      * @param   integer $issue_id The other issue ID
      * @return  void
      */
-    public function addAssociation($issue_id, $associated_id, $usr_id, $link_issues = true)
+    public static function addAssociation($issue_id, $associated_id, $usr_id, $link_issues = true)
     {
         $stmt = 'INSERT INTO
                     {{%issue_association}}

--- a/src/Model/Entity/BaseModel.php
+++ b/src/Model/Entity/BaseModel.php
@@ -94,6 +94,14 @@ abstract class BaseModel
         return $res;
     }
 
+    protected function deleteByQuery($query, $params)
+    {
+        $tableName = $this->getTableName();
+        $stmt = "DELETE FROM {$tableName} WHERE " . $query;
+        $db = DB_Helper::getInstance();
+        $db->query($stmt, $params);
+    }
+
     /**
      * Get db_field => value pairs of current object
      *

--- a/src/Model/Entity/BaseModel.php
+++ b/src/Model/Entity/BaseModel.php
@@ -53,7 +53,7 @@ abstract class BaseModel
         return $id;
     }
 
-    protected function findAllByConditions($where, $limit = null, $order = null)
+    protected function findAllByConditions($where, $limit = null, $order = null, $conditionJoin = ' AND ')
     {
         $tableName = $this->getTableName();
         $stmt = "SELECT * FROM {$tableName} WHERE ";
@@ -63,7 +63,7 @@ abstract class BaseModel
             $conditions[] = "$col=?";
             $params[] = $val;
         }
-        $stmt .= implode(' AND ', $conditions);
+        $stmt .= implode($conditionJoin, $conditions);
         if ($order) {
             $stmt .= " ORDER BY $order";
         }

--- a/src/Model/Entity/IssueAssociation.php
+++ b/src/Model/Entity/IssueAssociation.php
@@ -89,4 +89,14 @@ class IssueAssociation extends BaseModel
 
         return $this->findAllByConditions($where, null, null, $conditionJoin = ' OR ');
     }
+
+    public function removeAssociation($issue_id, $associated_id)
+    {
+        $query = '(isa_issue_id = ? AND isa_associated_id = ?) OR (isa_issue_id = ? AND isa_associated_id = ?)';
+        $params = [
+            $issue_id, $associated_id,
+            $associated_id, $issue_id,
+        ];
+        $this->deleteByQuery($query, $params);
+    }
 }

--- a/src/Model/Entity/IssueAssociation.php
+++ b/src/Model/Entity/IssueAssociation.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+namespace Eventum\Model\Entity;
+
+/**
+ * IssueAssociation
+ *
+ */
+class IssueAssociation extends BaseModel
+{
+    /**
+     * @var integer
+     */
+    protected $isa_issue_id;
+
+    /**
+     * @var integer
+     */
+    protected $isa_associated_id;
+
+    public function setId($id)
+    {
+        // method ignored, needed for BaseModel save
+    }
+
+    /**
+     * Set Issue Id
+     *
+     * @param integer $isa_issue_id
+     * @return IssueAssociation
+     */
+    public function setIssueId($isa_issue_id)
+    {
+        $this->isa_issue_id = $isa_issue_id;
+
+        return $this;
+    }
+
+    /**
+     * Get Issue Id
+     *
+     * @return integer
+     */
+    public function getIssueId()
+    {
+        return $this->isa_issue_id;
+    }
+
+    /**
+     * Set associated Issue Id
+     *
+     * @param integer $isa_associated_id
+     * @return IssueAssociation
+     */
+    public function setAssociatedId($isa_associated_id)
+    {
+        $this->isa_associated_id = $isa_associated_id;
+
+        return $this;
+    }
+
+    /**
+     * Get associated Issue Id
+     *
+     * @return integer
+     */
+    public function getAssociatedId()
+    {
+        return $this->isa_associated_id;
+    }
+
+    /**
+     * @param int $issue_id
+     * @return $this[]
+     */
+    public function findByIssueId($issue_id)
+    {
+        $where = ['isa_issue_id' => $issue_id, 'isa_associated_id' => $issue_id];
+
+        return $this->findAllByConditions($where, null, null, $conditionJoin = ' OR ');
+    }
+}

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -1,0 +1,91 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+namespace Eventum\Model\Repository;
+
+use DB_Helper;
+use Eventum\Db\DatabaseException;
+use Eventum\Model\Entity;
+use History;
+use InvalidArgumentException;
+use LogicException;
+use User;
+
+class IssueAssociationRepository extends BaseRepository
+{
+    /**
+     * Method used to get the list of issues associated to a specific issue.
+     *
+     * @param   integer $issue_id The issue ID
+     * @return  array The list of associated issues
+     */
+    public function getAssociatedIssues($issue_id)
+    {
+        $res = [];
+        $isa = Entity\IssueAssociation::create()->findByIssueId($issue_id);
+        if (!$isa) {
+            return $res;
+        }
+
+        foreach ($isa as $ia) {
+            // check which column to use
+            if ($ia->getIssueId() == $issue_id) {
+                $iss_id = $ia->getAssociatedId();
+            } else {
+                $iss_id = $ia->getIssueId();
+            }
+
+            // can't be itself!
+            if ($iss_id == $issue_id) {
+                throw new LogicException();
+                continue;
+            }
+
+            $res[] = $iss_id;
+        }
+
+        // make unique
+        $res = array_unique($res);
+
+        // and sort
+        asort($res);
+
+        return $res;
+    }
+
+    /**
+     * Method used to associate an existing issue with another one.
+     *
+     * @param   integer $issue_id The issue ID
+     * @param   integer $associated_issue_id The other issue ID
+     */
+    public function addIssueAssociation($usr_id, $issue_id, $associated_issue_id)
+    {
+        // see if there already is association
+        $assoc = $this->getAssociatedIssues($issue_id);
+        if (in_array($associated_issue_id, $assoc)) {
+            throw new InvalidArgumentException("Issue $issue_id already associated to $associated_issue_id");
+        }
+
+        Entity\IssueAssociation::create()
+            ->setIssueId($issue_id)
+            ->setAssociatedId($associated_issue_id)
+            ->save();
+
+        History::add(
+            $issue_id, $usr_id, 'issue_associated', 'Issue associated to Issue #{associated_id} by {user}', [
+                'associated_id' => $associated_issue_id,
+                'user' => User::getFullName($usr_id)
+            ]
+        );
+    }
+}

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -140,7 +140,7 @@ class IssueAssociationRepository extends BaseRepository
         $add = array_diff($issues, $existing_associations);
         $remove = array_diff($existing_associations, $issues);
         if (!$add && !$remove) {
-            return [];
+            return $errors;
         }
 
         foreach ($add as $associated_id) {

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -156,14 +156,11 @@ class IssueAssociationRepository extends BaseRepository
     /**
      * Filter issues for invalid input and issues that do not exist.
      *
-     * XXX: check_project was false in old code even if it said it does check for project
-     *
      * @param int[] $issues
      * @param int $issue_id current issue id to remove if present
-     * @param bool $check_project
      * @return array
      */
-    private function filterExistingIssues($issues, $issue_id, $check_project = false)
+    private function filterExistingIssues($issues, $issue_id)
     {
         // make issues list unique by flipping the array
         // otherwise removing $issue_id from the list (using array_search) would removes only first occurrence
@@ -177,7 +174,7 @@ class IssueAssociationRepository extends BaseRepository
                 // XXX: add to $errors[] that invalid input was skipped?
                 continue;
             }
-            if (!Issue::exists($iss_id, $check_project)) {
+            if (!Issue::exists($iss_id, false)) {
                 $errors[] = $this->getIssueRemovedError($iss_id);
                 continue;
             }

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -90,7 +90,7 @@ class IssueAssociationRepository extends BaseRepository
     }
 
     /**
-     * Method used to remove a issue association from an issue.
+     * Method used to remove an issue association from an issue.
      *
      * @param int $usr_id User Id performing the operation
      * @param int $issue_id The issue ID
@@ -166,8 +166,8 @@ class IssueAssociationRepository extends BaseRepository
      */
     private function filterExistingIssues($issues, $issue_id, $check_project = false)
     {
-        // make unique first by flipping it
-        // otherwise removing itself from the list removes only first occurrence
+        // make issues list unique by flipping the array
+        // otherwise removing $issue_id from the list (using array_search) would removes only first occurrence
         $issues = array_flip(array_filter($issues));
         unset($issues[$issue_id]);
 
@@ -175,7 +175,7 @@ class IssueAssociationRepository extends BaseRepository
         foreach (array_keys($issues) as $iss_id) {
             $iss_id = (int)$iss_id;
             if ($iss_id <= 0) {
-                // add error it being invalid?
+                // XXX: add to $errors[] that invalid input was skipped?
                 continue;
             }
             if (!Issue::exists($iss_id, $check_project)) {

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -12,7 +12,6 @@
  */
 namespace Eventum\Model\Repository;
 
-use Auth;
 use Eventum\Model\Entity;
 use History;
 use InvalidArgumentException;
@@ -24,8 +23,8 @@ class IssueAssociationRepository extends BaseRepository
     /**
      * Method used to get the list of issues associated to a specific issue.
      *
-     * @param   integer $issue_id The issue ID
-     * @return  array The list of associated issues
+     * @param int $issue_id The issue ID
+     * @return int[] The list of associated issues
      */
     public function getAssociatedIssues($issue_id)
     {
@@ -64,8 +63,9 @@ class IssueAssociationRepository extends BaseRepository
     /**
      * Method used to associate an existing issue with another one.
      *
-     * @param   integer $issue_id The issue ID
-     * @param   integer $associated_issue_id The other issue ID
+     * @param int $usr_id User Id performing the operation
+     * @param int $issue_id The issue ID
+     * @param int $associated_issue_id The other issue ID
      */
     public function addIssueAssociation($usr_id, $issue_id, $associated_issue_id)
     {
@@ -91,10 +91,11 @@ class IssueAssociationRepository extends BaseRepository
     /**
      * Method used to remove a issue association from an issue.
      *
-     * @param integer $issue_id The issue ID
-     * @param integer $associated_issue_id The associated issue ID to remove.
+     * @param int $usr_id User Id performing the operation
+     * @param int $issue_id The issue ID
+     * @param int $associated_issue_id The associated issue ID to remove.
      */
-    public function removeAssociation($issue_id, $associated_issue_id)
+    public function removeAssociation($usr_id, $issue_id, $associated_issue_id)
     {
         // see if there already is association
         $assoc = $this->getAssociatedIssues($issue_id);
@@ -104,7 +105,6 @@ class IssueAssociationRepository extends BaseRepository
 
         Entity\IssueAssociation::create()->removeAssociation($issue_id, $associated_issue_id);
 
-        $usr_id = Auth::getUserID();
         $full_name = User::getFullName($usr_id);
         $pairs = [
             [$issue_id, $associated_issue_id],

--- a/src/Model/Repository/IssueAssociationRepository.php
+++ b/src/Model/Repository/IssueAssociationRepository.php
@@ -46,7 +46,6 @@ class IssueAssociationRepository extends BaseRepository
             // can't be itself!
             if ($iss_id == $issue_id) {
                 throw new LogicException();
-                continue;
             }
 
             $res[] = $iss_id;

--- a/tests/IssueAssociationTest.php
+++ b/tests/IssueAssociationTest.php
@@ -52,16 +52,16 @@ class IssueAssociation extends TestCase
         }
 
         // now remove the association
-        $repo->removeAssociation($iss1_id, $iss2_id);
+        $repo->removeAssociation($usr_id, $iss1_id, $iss2_id);
         // second remove should fail both sides
         try {
-            $repo->removeAssociation($iss1_id, $iss2_id);
+            $repo->removeAssociation($usr_id, $iss1_id, $iss2_id);
             $this->fail();
         } catch (InvalidArgumentException $e) {
             $this->assertEquals("Issue $iss1_id not associated to $iss2_id", $e->getMessage());
         }
         try {
-            $repo->removeAssociation($iss2_id, $iss1_id);
+            $repo->removeAssociation($usr_id, $iss2_id, $iss1_id);
             $this->fail();
         } catch (InvalidArgumentException $e) {
             $this->assertEquals("Issue $iss2_id not associated to $iss1_id", $e->getMessage());

--- a/tests/IssueAssociationTest.php
+++ b/tests/IssueAssociationTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Model\Repository\IssueAssociationRepository;
+use Eventum\Monolog\Logger;
+
+class IssueAssociation extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Logger::initialize();
+    }
+
+    public function testAssociateIssue()
+    {
+        $usr_id = APP_SYSTEM_USER_ID;
+        $iss1_id = 12;
+        $iss2_id = 13;
+
+        $repo = IssueAssociationRepository::create();
+
+        $repo->addIssueAssociation($usr_id, $iss1_id, $iss2_id);
+        $assoc1 = $repo->getAssociatedIssues($iss1_id);
+        $assoc2 = $repo->getAssociatedIssues($iss2_id);
+
+        // the association exists both ways
+        $this->assertEquals([$iss2_id], $assoc1);
+        $this->assertEquals([$iss1_id], $assoc2);
+
+        // adding association again throws
+        try {
+            $repo->addIssueAssociation($usr_id, $iss1_id, $iss2_id);
+            $this->fail();
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals("Issue 12 already associated to 13", $e->getMessage());
+        }
+        try {
+            $repo->addIssueAssociation($usr_id, $iss2_id, $iss1_id);
+            $this->fail();
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals("Issue 13 already associated to 12", $e->getMessage());
+        }
+    }
+}

--- a/tests/IssueAssociationTest.php
+++ b/tests/IssueAssociationTest.php
@@ -42,13 +42,29 @@ class IssueAssociation extends TestCase
             $repo->addIssueAssociation($usr_id, $iss1_id, $iss2_id);
             $this->fail();
         } catch (InvalidArgumentException $e) {
-            $this->assertEquals("Issue 12 already associated to 13", $e->getMessage());
+            $this->assertEquals("Issue $iss1_id already associated to $iss2_id", $e->getMessage());
         }
         try {
             $repo->addIssueAssociation($usr_id, $iss2_id, $iss1_id);
             $this->fail();
         } catch (InvalidArgumentException $e) {
-            $this->assertEquals("Issue 13 already associated to 12", $e->getMessage());
+            $this->assertEquals("Issue $iss2_id already associated to $iss1_id", $e->getMessage());
+        }
+
+        // now remove the association
+        $repo->removeAssociation($iss1_id, $iss2_id);
+        // second remove should fail both sides
+        try {
+            $repo->removeAssociation($iss1_id, $iss2_id);
+            $this->fail();
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals("Issue $iss1_id not associated to $iss2_id", $e->getMessage());
+        }
+        try {
+            $repo->removeAssociation($iss2_id, $iss1_id);
+            $this->fail();
+        } catch (InvalidArgumentException $e) {
+            $this->assertEquals("Issue $iss2_id not associated to $iss1_id", $e->getMessage());
         }
     }
 }


### PR DESCRIPTION
there's some bug that sometimes adding issue association shows up only one side of issue pair, and each time trying to fix that adds the associated issue id to the other issue that already had one, and the first issue stays without association.

decided to rewrite that portion of code and add unit tests to resolve this issue.

the change involves that into `issue_association` table only one row of association is inserted instead of current two, thus simplifying all logic.