### PR TITLE
rewrite locking code to use flock

### DIFF
--- a/bin/irc-bot.php
+++ b/bin/irc-bot.php
@@ -15,13 +15,6 @@ ini_set('memory_limit', '1024M');
 
 require_once __DIR__ . '/../init.php';
 
-// if requested, clear the lock
-if (in_array('--fix-lock', $argv)) {
-    Lock::release('irc_bot');
-    echo "The lock file was removed successfully.\n";
-    exit;
-}
-
 if (in_array('--check-process', $argv)) {
     $check = true;
 } else {
@@ -40,13 +33,4 @@ try {
     exit(1);
 }
 
-// acquire a lock to prevent multiple scripts from
-// running at the same time
-if (!$bot->lock($check)) {
-    error_log('Error: Another instance of the script is still running.');
-    error_log("If this is not accurate, you may fix it by running this script with '--fix-lock' as the only parameter.");
-    exit(1);
-}
-
 $bot->run();
-$bot->unlock();

--- a/bin/irc-bot.php
+++ b/bin/irc-bot.php
@@ -15,12 +15,6 @@ ini_set('memory_limit', '1024M');
 
 require_once __DIR__ . '/../init.php';
 
-if (in_array('--check-process', $argv)) {
-    $check = true;
-} else {
-    $check = false;
-}
-
 // NB: must require this in global context
 // otherise $SMARTIRC_nreplycodes from defines.php is not initialized
 require_once 'Net/SmartIRC/defines.php';

--- a/bin/process_all_emails.php
+++ b/bin/process_all_emails.php
@@ -1,3 +1,4 @@
+#!/usr/bin/php
 <?php
 
 /*

--- a/build.xml
+++ b/build.xml
@@ -140,6 +140,14 @@
 				<exclude name="phplot.php" />
 				<exclude name="rgb.inc.php" />
 			</fileset>
+
+			<fileset dir="${vendor}/malkusch/lock/classes">
+				<exclude name="mutex/FlockMutex.php" />
+				<exclude name="mutex/LockMutex.php" />
+				<exclude name="mutex/Mutex.php" />
+				<exclude name="util/DoubleCheckedLocking.php" />
+				<exclude name="exception/*.php" />
+			</fileset>
 		</delete>
 	</target>
 

--- a/composer.json
+++ b/composer.json
@@ -62,6 +62,7 @@
 		"ext-spl": "*",
 		"fonts/liberation":"*",
 		"ircmaxell/random-lib": "~1.1.0",
+		"malkusch/lock": "^0.4.0",
 		"monolog/monolog": "~1.17.2",
 		"pear-pear.php.net/mail_mimedecode": "*",
 		"pear-pear.php.net/math_stats": "*",

--- a/lib/eventum/class.lock.php
+++ b/lib/eventum/class.lock.php
@@ -11,6 +11,10 @@
  * that were distributed with this source code.
  */
 
+/**
+ * Class Lock
+ * @deprecated use ConcurrentLock instead
+ */
 class Lock
 {
     /**

--- a/src/Command/Command.php
+++ b/src/Command/Command.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Command;
 
-use Lock;
+use Eventum\ConcurrentLock;
 
 abstract class Command
 {
@@ -37,58 +37,13 @@ abstract class Command
         $this->configure();
 
         if ($this->lock_name) {
-            $this->lock($this->lock_name);
+            $lock = new ConcurrentLock($this->lock_name);
+            $lock->synchronized(function () {
+                $this->execute();
+            });
+        } else {
+            $this->execute();
         }
-
-        $this->execute();
-
-        if ($this->lock_name) {
-            $this->unlock($this->lock_name);
-        }
-    }
-
-    /**
-     * acquire a lock to prevent multiple scripts from running at the same time.
-     */
-    protected function lock($lockname)
-    {
-        global $argv;
-
-        // if requested, clear the lock
-        if (in_array('--fix-lock', $argv)) {
-            if (Lock::release($lockname)) {
-                $this->msg("Removed lock file '$lockname'.");
-                exit(0);
-            }
-            exit(1);
-        }
-
-        $locked = Lock::acquire($lockname);
-
-        if (!$locked) {
-            // acquire a lock to prevent multiple scripts from
-            // running at the same time
-            if ($this->SAPI_CLI) {
-                $this->fatal(
-                    'Another instance of the script is still running for the specified account.',
-                    "If this is not accurate, you may fix it by running this script with '--fix-lock'",
-                    "as the 4th parameter or you may unlock ALL accounts by running this script with '--fix-lock'",
-                    'as the only parameter.'
-                );
-            } else {
-                $this->fatal(
-                    'Another instance of the script is still running for the specified account. ',
-                    "If this is not accurate, you may fix it by running this script with 'fix-lock=1'",
-                    "in the query string or you may unlock ALL accounts by running this script with 'fix-lock=1'",
-                    'as the only parameter.'
-                );
-            }
-        }
-    }
-
-    public function unlock($lockname)
-    {
-        Lock::release($lockname);
     }
 
     /**

--- a/src/Command/DownloadEmailsCommand.php
+++ b/src/Command/DownloadEmailsCommand.php
@@ -136,7 +136,6 @@ class DownloadEmailsCommand extends Command
     {
         // some defaults,
         $config = [
-            'fix-lock' => false,
             'username' => null,
             'hostname' => null,
             'mailbox' => null,
@@ -144,12 +143,6 @@ class DownloadEmailsCommand extends Command
 
         if ($this->SAPI_CLI) {
             global $argc, $argv;
-            // --fix-lock may be only the last argument (first or fourth)
-            if ($argv[$argc - 1] == '--fix-lock') {
-                // no other args are allowed
-                $config['fix-lock'] = true;
-            }
-
             if ($argc > 1) {
                 $config['username'] = $argv[1];
             }

--- a/src/ConcurrentLock.php
+++ b/src/ConcurrentLock.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum;
+
+use malkusch\lock\mutex\FlockMutex;
+use RuntimeException;
+
+class ConcurrentLock
+{
+    private $mutex;
+
+    public function __construct($lockname)
+    {
+        $lockfile = APP_LOCKS_PATH . '/' . $lockname . '.lck';
+
+        $fh = fopen($lockfile, 'c');
+        if (!$fh) {
+            throw new RuntimeException("Unable to create lock file: $lockfile");
+        }
+
+        $this->mutex = new FlockMutex($fh);
+    }
+
+    public function synchronized(callable $code)
+    {
+        $this->mutex->synchronized($code);
+    }
+}


### PR DESCRIPTION
i've planning to do this long time ago. the locking can be made really accurate in scope of one machine by using [flock](http://php.net/flock).

this should also solve user errors, who are unable to remove locks: #202

this removes writing pid files and `--fix-lock` arguments as it is no longer necessary.

the current code uses [malkusch/lock](https://github.com/malkusch/lock):
```php
$mutex->synchronized(function () use ($bankAccount, $amount) {
    $balance = $bankAccount->getBalance();
    $balance -= $amount;
    if ($balance < 0) {
        throw new \DomainException("You have no credit.");

    }
    $bankAccount->setBalance($balance);
});
```
the lock is automatically released when the code block exits.

the downside is that the locks are waited forever until the locked process still runs (lock is removed if process is terminated), this may queue up processes if one process stays running for too long.

i bet the error rate of users having stale pid files is way greater than actual situation when one process runs for very long.

however, maybe if lock is finally acquired and it had waited it over 300 seconds, assume lock acquire was unsuccessful and abort?