### PR TITLE
Remove duplicate variables from templates

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Throw Exception in CLI if Eventum is not configured (@glensc, 9f04950)
 - Fix Time Tracking administration bugs (@glensc, @yangmx, #197, #196)
 - Add back Authorized Repliers user picker (@glensc, #210)
+- Removed non '$core' default variables from templates (@balsdorf, #211)
 
 ## 2016-09-25, Version [3.1.3]
 

--- a/docs/examples/templates/customer/customer_info.tpl.html
+++ b/docs/examples/templates/customer/customer_info.tpl.html
@@ -49,7 +49,7 @@
                   {$issue.iss_contact_timezone}
                 </td>
               </tr>
-              {if $current_role > $roles.standard_user}
+              {if $current_role > $core.roles.standard_user}
               <tr>
                 <td bgcolor="{$internal_color}">
                   <nobr><b>{t}Contact's Local Time{/t}:</b>&nbsp;</nobr>
@@ -103,7 +103,7 @@
                   {$issue.customer_info.expiration_date}
                 </td>
               </tr>
-              {if $current_role > $roles.standard_user}
+              {if $current_role > $core.roles.standard_user}
               <tr>
                 <td bgcolor="{$internal_color}">
                   <b>{t}Sales Account Manager{/t}:</b>&nbsp;<br />
@@ -115,7 +115,7 @@
               <tr>
                 <td bgcolor="{$internal_color}">
                   <b>{t}Notes About Customer{/t}:</b>&nbsp;<br />
-                  {if $current_role > $roles.developer}
+                  {if $current_role > $core.roles.developer}
                     {if $issue.customer_info.note.cno_id eq ''}
                         <a href="{$core.base_url}manage/customer_notes.php?customer_id={$issue.iss_customer_id}" class="white_link">{t}Add{/t}</a>
                     {else}

--- a/docs/examples/templates/customer/report_form_fields.tpl.html
+++ b/docs/examples/templates/customer/report_form_fields.tpl.html
@@ -55,14 +55,14 @@ function validateCustomer(f)
             <b>{t}Customer Details{/t}</b>
           </td>
         </tr>
-        {if $current_role != $roles.customer}
+        {if $current_role != $core.roles.customer}
         <tr>
           <td width="150" bgcolor="{$internal_color}">
             <b>{t}Customer{/t}:</b>
           </td>
           <td bgcolor="{$light_color}">
             <b><div id="customer_div">{$customer_name}</div></b>&nbsp;
-            {if $current_role > $roles.standard_user}
+            {if $current_role > $core.roles.standard_user}
             <a href="javascript:void(null);" onClick="javascript:lookupCustomer();" tabindex="{$tabindex++}">{t}Lookup Customer{/t}</a>
             {/if}
           </td>

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -166,6 +166,7 @@ class Template_Helper
      */
     private function processTemplate()
     {
+        $setup = Setup::get();
         $core = [
             'rel_url' => APP_RELATIVE_URL,
             'base_url' => APP_BASE_URL,
@@ -175,6 +176,7 @@ class Template_Helper
             'roles' => User::getAssocRoleIDs(),
             'current_url' => $_SERVER['PHP_SELF'],
             'template_id'    =>  str_replace(['/', '.tpl.html'], ['_'], $this->tpl_name),
+            'handle_clock_in'   =>  $setup['handle_clock_in'] == 'enabled',
         ];
 
         // If VCS version is present "Eventum 2.3.3-148-g78b3368", link ref to github
@@ -192,7 +194,6 @@ class Template_Helper
         if ($usr_id) {
             $core['user'] = User::getDetails($usr_id);
             $prj_id = Auth::getCurrentProject();
-            $setup = Setup::get();
             if (!empty($prj_id)) {
                 $role_id = User::getRoleByUser($usr_id, $prj_id);
                 $has_crm = CRM::hasCustomerIntegration($prj_id);
@@ -237,12 +238,6 @@ class Template_Helper
                     'is_current_user_partner' => !empty($info['usr_par_code']),
                     'current_user_prefs' => Prefs::get($usr_id),
                 ];
-            $this->assign('current_full_name', $core['user']['usr_full_name']);
-            $this->assign('current_email', $core['user']['usr_email']);
-            $this->assign('current_user_id', $usr_id);
-            $this->assign('handle_clock_in', $setup['handle_clock_in'] == 'enabled');
-            $this->assign('is_current_user_clocked_in', $core['is_current_user_clocked_in']);
-            $this->assign('roles', $core['roles']);
         }
         $this->assign('core', $core);
 

--- a/templates/base_full.tpl.html
+++ b/templates/base_full.tpl.html
@@ -60,7 +60,7 @@
                   <a href="{$core.rel_url}signup.php">{t}Register{/t}</a>
                 {else}
                   <a title="{t}modify your account details and preferences{/t}" href="{$core.rel_url}preferences.php">{t}Preferences{/t}</a>&nbsp;
-                  {if $core.current_role > $core.roles.standard_user && $handle_clock_in}
+                  {if $core.current_role > $core.roles.standard_user && $core.handle_clock_in}
                     <a id="change_clock_status" title="{t}change your account clocked-in status{/t}" href="">
                     {if $core.is_current_user_clocked_in}{t}Clock Out{/t}{else}{t}Clock In{/t}{/if}</a>
                   {/if}


### PR DESCRIPTION
All variables set by default are now part of the $core variable.

This might impact 3rd party templates, but the fix is a simple search and replace.