### PR TITLE
Use "in-reply-to" mail header to find Issue ID

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -11,6 +11,7 @@
 - Throw Exception in CLI if Eventum is not configured (@glensc, 9f04950)
 - Fix Time Tracking administration bugs (@glensc, @yangmx, #197, #196)
 - Add back Authorized Repliers user picker (@glensc, #210)
+- Allow replies to original message to use "in-reply-to" header for message-id matching (@cpinfold, #212)
 
 ## 2016-09-25, Version [3.1.3]
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -773,11 +773,9 @@ class Support
             $issue_id = $workflow;
         } else {
             $setup = Setup::get();
-            if ($setup['subject_based_routing']['status'] == 'enabled') {
-                // Look for issue ID in the subject line
-
-                // look for [#XXXX] in the subject line
-                if (preg_match("/\[#(\d+)\]( Note| BLOCKED)*/", $subject, $matches)) {
+            if (($setup['subject_based_routing']['status'] == 'enabled') 
+                and (preg_match("/\[#(\d+)\]( Note| BLOCKED)*/", $subject, $matches))) {
+                    // look for [#XXXX] in the subject line
                     $should_create_issue = false;
                     $issue_id = $matches[1];
                     if (!Issue::exists($issue_id, false)) {
@@ -785,9 +783,6 @@ class Support
                     } elseif (!empty($matches[2])) {
                         $type = 'note';
                     }
-                } else {
-                    $should_create_issue = true;
-                }
             } else {
                 // - if this email is a reply:
                 if (count($references) > 0) {


### PR DESCRIPTION
This is a redo of #190 to avoid the merge mess.

Allowed replies to use non-subject based "in-reply-to" for message-id matching (when subject based routing is enabled).

It does this by allowing the existing else clause and references behaviour for non-subject based routing to also occur when the subject line does not contain [#IssueID].

@glensc The change adds to the if so that when subject based routing is enabled it still processes the else block if there is no [#IssueID] in the subject line.  
```
and (preg_match("/\[#(\d+)\]( Note| BLOCKED)*/", $subject, $matches)))
```
This allows those who enable subject based routing to also follow the "in-reply-to" message id back to the original issue.  This code was already in place if subject based routing was not enabled.

Changelog also updated.

I'll close #190 which didn't rebase correctly (my error).
