### PR TITLE
make public attachments visible for Reporters fixes #214

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,7 @@
 
 ## 2016-??-??, Version [3.1.5]
 - Fix SCM checkins being displayed as "public" (@glensc, #215, #216)
+- Make public attachments visible for Viewers (@glensc, #214, #217)
 
 ## 2016-10-26, Version [3.1.4]
 

--- a/lib/eventum/class.access.php
+++ b/lib/eventum/class.access.php
@@ -126,7 +126,7 @@ class Access
                 return $partner;
             }
         }
-        if (User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_CUSTOMER) {
+        if (User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_VIEWER) {
             return true;
         }
 


### PR DESCRIPTION
make public attachments visible for Reporters, fixes #214

the [Access::canViewAttachedFiles()](https://github.com/eventum/eventum/blame/v3.1.4/lib/eventum/class.access.php#L117-L131) was added in 3836501 and it checked for `Customer` Role. That change was released first as 2.4.0pre1

the change also added `{if $issue_access.files}` condition in [view.tpl](https://github.com/eventum/eventum/commit/38365011f33a19dae2d2816f9fe2b04af882f008#diff-0b7308e0fb8a837778d273399e99a1ee) which was not present before, i.e the `{include file="attachments.tpl.html"}` was loaded unconditionally