### PR TITLE
smtp transport encapsulation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -4,6 +4,7 @@
 
 - ldap: respect `create_users` configuration
 - Fix bug creating new priority (@balsdorf)
+- add MailTransport class to encapsulate smtp transport
 
 [3.1.10]: https://github.com/eventum/eventum/compare/v3.1.9...master
 

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,9 +2,9 @@
 
 ## [3.1.10] - 2017-??-??
 
-- ldap: respect `create_users` configuration
+- ldap: respect `create_users` configuration (@glensc)
 - Fix bug creating new priority (@balsdorf)
-- add MailTransport class to encapsulate smtp transport
+- add MailTransport class to encapsulate smtp transport (@glensc, #236, #234)
 
 [3.1.10]: https://github.com/eventum/eventum/compare/v3.1.9...master
 

--- a/composer.json
+++ b/composer.json
@@ -72,7 +72,7 @@
 		"pear-pear.php.net/text_diff": "*",
 		"pear/auth_sasl": "*",
 		"pear/db": "*",
-		"pear/mail": "~1.2.0,<1.3.0",
+		"pear/mail": "~1.3.0",
 		"pear/mail_mime": "*",
 		"pear/net_smtp": "1.6.*",
 		"pear/net_socket": "*",

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -339,23 +339,6 @@ class Mail_Helper
     }
 
     /**
-     * Method used to get the application specific settings regarding
-     * which SMTP server to use, such as login and server information.
-     *
-     * @return  array
-     */
-    public static function getSMTPSettings()
-    {
-        $settings = Setup::get();
-
-        if (file_exists('/etc/mailname')) {
-            $settings['smtp']['localhost'] = trim(file_get_contents('/etc/mailname'));
-        }
-
-        return $settings['smtp'];
-    }
-
-    /**
      * Method used to set the text version of the body of the MIME
      * multipart message that you wish to send.
      *
@@ -555,6 +538,9 @@ class Mail_Helper
      */
     public function send($from, $to, $subject, $save_email_copy = 0, $issue_id = false, $type = '', $sender_usr_id = false, $type_id = false)
     {
+        if ($from === null) {
+            $from = Setup::get()->smtp->from;
+        }
         // encode the addresses
         $from = Mime_Helper::encodeAddress($from);
         $to = Mime_Helper::encodeAddress($to);
@@ -715,9 +701,8 @@ class Mail_Helper
      */
     public static function prepareHeaders($headers)
     {
-        $params = self::getSMTPSettings();
-        /** @var Mail_smtp $mail */
-        $mail = Mail::factory('smtp', $params);
+        $params = Setup::get()->smtp->toArray();
+        $mail = new Mail_smtp($params);
 
         return $mail->prepareHeaders($headers);
     }

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -686,28 +686,6 @@ class Mail_Helper
     }
 
     /**
-     * Since Mail::prepareHeaders() is not supposed to be called statically, this method
-     * instantiates an instance of the mail class and calls prepareHeaders on it.
-     *
-     * @param array $headers The array of headers to prepare, in an associative
-     *              array, where the array key is the header name (ie,
-     *              'Subject'), and the array value is the header
-     *              value (ie, 'test'). The header produced from those
-     *              values would be 'Subject: test'.
-     * @return mixed Returns false if it encounters a bad address,
-     *               otherwise returns an array containing two
-     *               elements: Any From: address found in the headers,
-     *               and the plain text version of the headers.
-     */
-    public static function prepareHeaders($headers)
-    {
-        $params = Setup::get()->smtp->toArray();
-        $mail = new Mail_smtp($params);
-
-        return $mail->prepareHeaders($headers);
-    }
-
-    /**
      * Generates the specialized headers for an email.
      *
      * @param   integer $issue_id The issue ID

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -11,6 +11,7 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Mail\MailTransport;
 use Eventum\Monolog\Logger;
 
 /**
@@ -692,12 +693,8 @@ class Mail_Helper
             $headers += self::getSpecializedHeaders($issue_id, $email['maq_type']);
         }
 
-        $params = self::getSMTPSettings();
-        $mail = Mail::factory('smtp', $params);
-        $res = $mail->send($address, $headers, $body);
-        if (Misc::isError($res)) {
-            Logger::app()->error($res->getMessage(), ['debug' => $res->getDebugInfo()]);
-        }
+        $mail = new MailTransport();
+        $mail->send($address, $headers, $body);
 
         $subjects[] = $subject;
     }
@@ -719,6 +716,7 @@ class Mail_Helper
     public static function prepareHeaders($headers)
     {
         $params = self::getSMTPSettings();
+        /** @var Mail_smtp $mail */
         $mail = Mail::factory('smtp', $params);
 
         return $mail->prepareHeaders($headers);

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -13,6 +13,7 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Mail\MailMessage;
+use Eventum\Mail\MailTransport;
 use Eventum\Monolog\Logger;
 
 class Mail_Queue
@@ -249,18 +250,9 @@ class Mail_Queue
             $headers['MIME-Version'] = '1.0';
         }
 
-        $mail = Mail::factory('smtp', Mail_Helper::getSMTPSettings());
-        // TODO: mail::send wants just bare addresses, do that ourselves
-        $recipient = Mime_Helper::encodeAddress($recipient);
-        $res = $mail->send($recipient, $headers, $body);
-        if (Misc::isError($res)) {
-            /** @var PEAR_Error $res */
-            Logger::app()->error($res->getMessage(), ['debug' => $res->getDebugInfo()]);
+        $transport = new MailTransport();
 
-            return $res;
-        }
-
-        return true;
+        return $transport->send($recipient, $headers, $body);
     }
 
     /**

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -252,6 +252,9 @@ class Mail_Queue
 
         $transport = new MailTransport();
 
+        // TODO: mail::send wants just bare addresses, do that ourselves
+        $recipient = Mime_Helper::encodeAddress($recipient);
+
         return $transport->send($recipient, $headers, $body);
     }
 

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -14,7 +14,8 @@
 use Eventum\Db\DatabaseException;
 use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
-use Eventum\Monolog\Logger;
+use Zend\Mail\AddressList;
+use Zend\Mail\Header\To;
 
 class Mail_Queue
 {
@@ -131,30 +132,21 @@ class Mail_Queue
             // TODO: handle self::MAX_RETRIES, but that should be done per queue item
             foreach (self::_getMergedList($status, $limit) as $maq_ids) {
                 $emails = self::_getEntries($maq_ids);
-                $recipients = [];
 
+                $addresslist = new AddressList();
                 foreach ($emails as $email) {
-                    $recipients[] = $email['recipient'];
+                    if (Mime_Helper::is8bit($email)) {
+                        $email = Mime_Helper::encode($email);
+                    }
+
+                    $addresslist->addFromString($email['recipient']);
                 }
 
                 $email = $emails[0];
-                $recipients = implode(',', $recipients);
-                $message = $email['headers'] . "\r\n\r\n" . $email['body'];
-                $structure = Mime_Helper::decode($message, false, false);
-                $headers = $structure->headers;
+                $m = MailMessage::createFromHeaderBody($email['headers'], $email['body']);
+                $m->setTo($addresslist);
 
-                $headers['to'] = $recipients;
-                $headers = Mime_Helper::encodeHeaders($headers);
-
-                $res = Mail_Helper::prepareHeaders($headers);
-                if (Misc::isError($res)) {
-                    Logger::app()->error($res->getMessage(), ['debug' => $res->getDebugInfo()]);
-
-                    return;
-                }
-
-                list(, $text_headers) = $res;
-                $result = self::_sendEmail($recipients, $text_headers, $email['body']);
+                $result = self::_sendEmail($m->to, $m->getHeaders()->toString(), $email['body']);
 
                 if (Misc::isError($e = $result)) {
                     /** @var PEAR_Error $e */
@@ -181,6 +173,8 @@ class Mail_Queue
                     }
                 }
             }
+            // FIXME: should not process the list again?
+            //return;
         }
 
         foreach (self::_getList($status, $limit) as $maq_id) {

--- a/lib/eventum/class.mime_helper.php
+++ b/lib/eventum/class.mime_helper.php
@@ -177,13 +177,17 @@ class Mime_Helper
         if (self::is8bit($address)) {
             // split into name and address section
             preg_match('/(.*)<(.*)>/', $address, $matches);
+
+            $qq = preg_replace_callback(
+                '/([\x80-\xFF]|[\x21-\x2F]|[\xFC]|\[|\])/',
+                function ($m) {
+                    return "=" . strtoupper(dechex(ord(stripslashes($m[1]))));
+                },
+                $matches[1]
+            );
             $address = '=?' . APP_CHARSET . '?Q?' .
                 str_replace(' ', '_', trim(
-                    // @ because of /e:
-                    // preg_replace(): The /e modifier is deprecated, use preg_replace_callback instead
-                    // This feature was DEPRECATED in PHP 5.5.0, and REMOVED as of PHP 7.0.0.
-                    // http://www.php.net/manual/en/reference.pcre.pattern.modifiers.php
-                    @preg_replace('/([\x80-\xFF]|[\x21-\x2F]|[\xFC]|\[|\])/e', '"=" . strtoupper(dechex(ord(stripslashes("\1"))))', $matches[1])
+                    $qq
                 )) . '?= <' . $matches[2] . '>';
 
             return $address;

--- a/lib/eventum/class.mime_helper.php
+++ b/lib/eventum/class.mime_helper.php
@@ -181,7 +181,7 @@ class Mime_Helper
             $qq = preg_replace_callback(
                 '/([\x80-\xFF]|[\x21-\x2F]|[\xFC]|\[|\])/',
                 function ($m) {
-                    return "=" . strtoupper(dechex(ord(stripslashes($m[1]))));
+                    return '=' . strtoupper(dechex(ord(stripslashes($m[1]))));
                 },
                 $matches[1]
             );

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -1249,7 +1249,7 @@ class Notification
             $mail = new Mail_Helper();
             $mail->setTextBody($text_message);
             $mail->setHeaders(Mail_Helper::getBaseThreadingHeaders($issue_id));
-            $setup = Mail_Helper::getSMTPSettings();
+            $setup = Setup::get()->smtp->toArray();
             $from = self::getFixedFromHeader($issue_id, $setup['from'], 'issue');
             $recipient = Mime_Helper::decodeQuotedPrintable($recipient);
             // TRANSLATORS: %1: $issue_id, %2 = iss_summary
@@ -1331,7 +1331,7 @@ class Notification
             // send email (use PEAR's classes)
             $mail = new Mail_Helper();
             $mail->setTextBody($text_message);
-            $setup = Mail_Helper::getSMTPSettings();
+            $setup = Setup::get()->smtp->toArray();
             $from = self::getFixedFromHeader($issue_id, $setup['from'], 'issue');
             $mail->setHeaders(Mail_Helper::getBaseThreadingHeaders($issue_id));
 
@@ -2325,9 +2325,8 @@ class Notification
         // send email (use PEAR's classes)
         $mail = new Mail_Helper();
         $mail->setTextBody($text_message);
-        $setup = Mail_Helper::getSMTPSettings();
         $to = Mail_Helper::getFormattedName($info['usr_full_name'], $info['usr_email']);
-        $mail->send($setup['from'], $to, $subject);
+        $mail->send(null, $to, $subject);
 
         Language::restore();
     }

--- a/lib/eventum/class.reminder_action.php
+++ b/lib/eventum/class.reminder_action.php
@@ -723,11 +723,9 @@ class Reminder_Action
                 // send email (use PEAR's classes)
                 $mail = new Mail_Helper();
                 $mail->setTextBody($text_message);
-                $setup = Mail_Helper::getSMTPSettings();
-
                 // TRANSLATORS: %1 - issue_id, %2 - rma_title
                 $subject = ev_gettext('[#%1$s] Reminder: %2$s', $issue_id, $action['rma_title']);
-                $mail->send($setup['from'], $address, $subject, 0, $issue_id, 'reminder');
+                $mail->send(null, $address, $subject, 0, $issue_id, 'reminder');
             }
         }
         // - eventum saves the day once again
@@ -764,10 +762,9 @@ class Reminder_Action
                 // send email (use PEAR's classes)
                 $mail = new Mail_Helper();
                 $mail->setTextBody($text_message);
-                $setup = Mail_Helper::getSMTPSettings();
                 // TRANSLATORS: %1 = issue_id, %2 - rma_title
                 $subject = ev_gettext('[#%1$s] Reminder Not Triggered: [#%2$s]', $issue_id, $action['rma_title']);
-                $mail->send($setup['from'], $address, $subject, 0, $issue_id);
+                $mail->send(null, $address, $subject, 0, $issue_id);
             }
         }
     }

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -441,10 +441,9 @@ class Support
         // send email (use PEAR's classes)
         $mail = new Mail_Helper();
         $mail->setTextBody($text_message);
-        $setup = Mail_Helper::getSMTPSettings();
         // TRANSLATORS: %s: APP_SHORT_NAME
         $subject = ev_gettext('%s: Postmaster notify: see transcript for details', APP_SHORT_NAME);
-        $mail->send($setup['from'], $sender_email, $subject);
+        $mail->send(null, $sender_email, $subject);
 
         if ($usr_id) {
             Language::restore();

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -519,7 +519,7 @@ class MailMessage extends Message
     /**
      * Set To: header
      *
-     * @param string $value
+     * @param string|AddressList $value
      */
     public function setTo($value)
     {
@@ -540,14 +540,18 @@ class MailMessage extends Message
      * Set AddressList type header a value
      *
      * @param string $name
-     * @param string $value
+     * @param string|AddressList $value
      */
     public function setAddressListHeader($name, $value)
     {
         /** @var AbstractAddressList $header */
         $header = $this->getHeader($name);
-        $addresslist = new AddressList();
-        $addresslist->addFromString($value);
+        if ($value instanceof AddressList) {
+            $addresslist = $value;
+        } else {
+            $addresslist = new AddressList();
+            $addresslist->addFromString($value);
+        }
         $header->setAddressList($addresslist);
     }
 

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -95,21 +95,23 @@ class MailMessage extends Message
     /**
      * Create Mail object from headers array and body string
      *
-     * @param array $headers
+     * @param string|array $headers
      * @param string $content
      * @return MailMessage
      */
     public static function createFromHeaderBody($headers, $content)
     {
-        foreach ($headers as $k => $v) {
-            // Zend\Mail does not like empty headers, "Cc:" for example
-            if ($v === '') {
-                unset($headers[$k]);
-            }
+        if (is_array($headers)) {
+            foreach ($headers as $k => $v) {
+                // Zend\Mail does not like empty headers, "Cc:" for example
+                if ($v === '') {
+                    unset($headers[$k]);
+                }
 
-            // also it doesn't like 8bit headers
-            if (Mime_Helper::is8bit($v)) {
-                $headers[$k] = Mime_Helper::encode($v);
+                // also it doesn't like 8bit headers
+                if (Mime_Helper::is8bit($v)) {
+                    $headers[$k] = Mime_Helper::encode($v);
+                }
             }
         }
 

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -57,8 +57,6 @@ class MailTransport
      */
     public function send($recipient, $headers, $body)
     {
-        // TODO: mail::send wants just bare addresses, do that ourselves
-        $recipient = Mime_Helper::encodeAddress($recipient);
         $res = $this->smtp->send($recipient, $headers, $body);
         if (Misc::isError($res)) {
             /** @var PEAR_Error $res */

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -15,9 +15,7 @@ namespace Eventum\Mail;
 
 use Eventum\Monolog\Logger;
 use Mail;
-use Mail_Helper;
 use Mail_smtp;
-use Mime_Helper;
 use Misc;
 use PEAR_Error;
 use Setup;

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -29,7 +29,7 @@ class MailTransport
 
     public function __construct()
     {
-        $this->smtp = Mail::factory('smtp', $this->getSMTPSettings());
+        $this->smtp = new Mail_smtp($this->getSMTPSettings());
     }
 
     /**

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -20,6 +20,7 @@ use Mail_smtp;
 use Mime_Helper;
 use Misc;
 use PEAR_Error;
+use Setup;
 
 class MailTransport
 {
@@ -28,7 +29,7 @@ class MailTransport
 
     public function __construct()
     {
-        $this->smtp = Mail::factory('smtp', Mail_Helper::getSMTPSettings());
+        $this->smtp = Mail::factory('smtp', $this->getSMTPSettings());
     }
 
     /**
@@ -67,5 +68,22 @@ class MailTransport
         }
 
         return true;
+    }
+
+    /**
+     * Method used to get the application specific settings regarding
+     * which SMTP server to use, such as login and server information.
+     *
+     * @return  array
+     */
+    private function getSMTPSettings()
+    {
+        $settings = Setup::get();
+
+        if (file_exists('/etc/mailname')) {
+            $settings['smtp']['localhost'] = trim(file_get_contents('/etc/mailname'));
+        }
+
+        return $settings['smtp']->toArray();
     }
 }

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Mail;
+
+use Eventum\Monolog\Logger;
+use Mail;
+use Mail_Helper;
+use Mail_smtp;
+use Mime_Helper;
+use Misc;
+use PEAR_Error;
+
+class MailTransport
+{
+    /** @var Mail_smtp */
+    private $smtp;
+
+    public function __construct()
+    {
+        $this->smtp = Mail::factory('smtp', Mail_Helper::getSMTPSettings());
+    }
+
+    /**
+     * Implements Mail::send() function using SMTP.
+     *
+     * @param mixed $recipients Either a comma-seperated list of recipients
+     *              (RFC822 compliant), or an array of recipients,
+     *              each RFC822 valid. This may contain recipients not
+     *              specified in the headers, for Bcc:, resending
+     *              messages, etc.
+     *
+     * @param array $headers The array of headers to send with the mail, in an
+     *              associative array, where the array key is the
+     *              header name (e.g., 'Subject'), and the array value
+     *              is the header value (e.g., 'test'). The header
+     *              produced from those values would be 'Subject:
+     *              test'.
+     *
+     * @param string $body The full text of the message body, including any
+     *               MIME parts, etc.
+     *
+     * @return mixed Returns true on success, or a PEAR_Error
+     *               containing a descriptive error message on
+     *               failure.
+     */
+    public function send($recipient, $headers, $body)
+    {
+        // TODO: mail::send wants just bare addresses, do that ourselves
+        $recipient = Mime_Helper::encodeAddress($recipient);
+        $res = $this->smtp->send($recipient, $headers, $body);
+        if (Misc::isError($res)) {
+            /** @var PEAR_Error $res */
+            Logger::app()->error($res->getMessage(), ['debug' => $res->getDebugInfo()]);
+
+            return $res;
+        }
+
+        return true;
+    }
+}

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -56,7 +56,7 @@ class ConfigTest extends TestCase
     }
 
     /**
-     * @see Mail_Helper::getSMTPSettings does this weird settype:
+     * @see Mail_Helper::getSMTPSettings did this weird settype:
      * settype($config['smtp']['auth'], 'boolean');
      * that does not work (Indirect modification error),
      * so test version that works

--- a/tests/MailMessageTest.php
+++ b/tests/MailMessageTest.php
@@ -790,7 +790,7 @@ class MailMessageTest extends TestCase
 
         $exp = "\"Some =?utf-8?b?w5ZuZSI=?= <Some.One@example.org>,\r\n" .
             " root@example.org,\r\n" .
-            " Root =?utf-8?b?TcOkZQ==?= <root2@example.org>";
+            ' Root =?utf-8?b?TcOkZQ==?= <root2@example.org>';
         $this->assertEquals($exp, $m->to);
     }
 }

--- a/tests/MailMessageTest.php
+++ b/tests/MailMessageTest.php
@@ -515,14 +515,14 @@ class MailMessageTest extends TestCase
         // send email (use PEAR's classes)
         $mail = new Mail_Helper();
         $mail->setTextBody($text_message);
-        $setup = $mail->getSMTPSettings();
+        $from = Setup::get()->smtp->from;
         $to = $mail->getFormattedName($info['usr_full_name'], $info['usr_email']);
-        $mail->send($setup['from'], $to, $subject);
+        $mail->send($from , $to, $subject);
 
         // the same but with ZF
         $mail = MailMessage::createNew();
         $mail->setSubject($subject);
-        $mail->setFrom($setup['from']);
+        $mail->setFrom($from);
         $mail->setTo($to);
         $mail->setContent($text_message);
         Mail_Queue::addMail($mail, $to);

--- a/tests/MailMessageTest.php
+++ b/tests/MailMessageTest.php
@@ -644,7 +644,7 @@ class MailMessageTest extends TestCase
         $transport = new \Zend\Mail\Transport\Sendmail();
         $transport->setCallable(
             function ($to, $subject, $body, $headers, $params) {
-                error_log("to[$to] subject[$subject] body[$body] headers[$headers] params[$params]");
+                //error_log("to[$to] subject[$subject] body[$body] headers[$headers] params[$params]");
             }
         );
         $transport->send($mail);
@@ -675,10 +675,10 @@ class MailMessageTest extends TestCase
         $message = new Zend\Mail\Message();
         $message->setBody($body);
 
-        echo $message->toString();
+//        echo $message->toString();
 
         $mail = MailMessage::createFromMessage($message);
-        echo $mail->getRawContent();
+//        echo $mail->getRawContent();
 
         $mail = MailMessage::createNew();
         $mime = $mail->addMimePart($textContent, 'text/plain', 'UTF-8');
@@ -743,11 +743,11 @@ class MailMessageTest extends TestCase
 
         // the same handled better in encodeQuotedPrintable
         $v = Mime_Helper::encodeQuotedPrintable($value);
-        var_dump($v);
+//        var_dump($v);
 
         // this works too
         $v = \Zend\Mail\Header\HeaderWrap::mimeEncodeValue($value, 'UTF-8');
-        var_dump($v);
+//        var_dump($v);
     }
 
     /**

--- a/tests/MailTransportTest.php
+++ b/tests/MailTransportTest.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Mail\MailTransport;
+use Eventum\Monolog\Logger;
+
+class MailTransportTest extends TestCase
+{
+    public static function setUpBeforeClass()
+    {
+        Logger::initialize();
+    }
+
+    public function test1()
+    {
+        $transport = new MailTransport();
+        $recipient = 'root@localhost';
+        $headers = [];
+        $body = 'nothing';
+        $transport->send($recipient, $headers, $body);
+    }
+}


### PR DESCRIPTION
encapsulate smtp transport use, so it could be (easily) replaced with zend mail component

fixes issues for #234
- removes internal use of PEAR Mail classes
- uses PEAR Mail 1.3.0
- removes preg_replace /e flag use 

originally i planned to replace [Mail_smtp](https://pear.php.net/package/Mail/docs/latest/Mail/Mail_smtp.html) with [Zend\Mail\Transport\Smtp](https://framework.zend.com/manual/2.4/en/modules/zend.mail.transport.html), but that can be done in a separater PR.