### PR TITLE
replace buggy Mail_Helper::getEmailAddresses with Zend\Mail based implementation

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -2,6 +2,8 @@
 
 ## [3.1.11] - 2017-??-??
 
+- replace buggy `Mail_Helper::getEmailAddresses` with Zend\Mail based implementation (@glensc, #238)
+
 [3.1.11]: https://github.com/eventum/eventum/compare/v3.1.10...master
 
 ## [3.1.10] - 2017-04-21

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -127,6 +127,14 @@ class Mail_Helper
         $str = self::fixAddressQuoting($str);
         $str = Mime_Helper::encode($str);
         $structs = self::parseAddressList($str);
+        if (Misc::isError($structs)) {
+            /** @var PEAR_Error $e */
+            $e = $structs;
+            Logger::app()->error($e->getMessage(), ['addresses' => $str]);
+
+            return [];
+        }
+
         $addresses = [];
         foreach ($structs as $structure) {
             if ((!empty($structure->mailbox)) && (!empty($structure->host))) {

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -121,6 +121,7 @@ class Mail_Helper
      *
      * @param   string $str The string containing email addresses
      * @return  array The list of email addresses
+     * @deprecated use AddressHeader helper instead
      */
     public static function getEmailAddresses($str)
     {
@@ -166,7 +167,8 @@ class Mail_Helper
      * "Sender Name" <sender@example.com>.
      *
      * @param   string $address The email address value
-     * @return  array The address information
+     * @return  string The address information
+     * @deprecated stay away from this method, it corrupts data!
      */
     public static function fixAddressQuoting($address)
     {

--- a/lib/eventum/class.mime_helper.php
+++ b/lib/eventum/class.mime_helper.php
@@ -453,13 +453,15 @@ class Mime_Helper
      * @param   string $hdr_value The string to be encoded
      * @param   string $charset The charset of the string
      * @return  string The encoded string
-     * @deprecated method not used
      */
-    public function encodeValue($hdr_value, $charset = 'iso-8859-1')
+    public static function encodeValue($hdr_value, $charset = APP_CHARSET)
     {
         preg_match_all('/(\w*[\x80-\xFF]+\w*)/', $hdr_value, $matches);
+        $cb = function ($m) {
+            return '=' . strtoupper(dechex(ord($m[1])));
+        };
         foreach ($matches[1] as $value) {
-            $replacement = preg_replace('/([\x80-\xFF])/e', '"=" . strtoupper(dechex(ord("\1")))', $value);
+            $replacement = preg_replace_callback('/([\x80-\xFF])/', $cb, $value);
             $hdr_value = str_replace($value, '=?' . $charset . '?Q?' . $replacement . '?=', $hdr_value);
         }
 

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Mail\Exception\RoutingException;
+use Eventum\Mail\Helper\AddressHeader;
 
 /**
  * Class to handle all routing functionality
@@ -380,12 +381,13 @@ class Routing
 
         // parse the Cc: list, if any, and add these internal users to the issue notification list
         $addresses = [];
-        $to_addresses = Mail_Helper::getEmailAddresses(@$structure->headers['to']);
-        if (count($to_addresses)) {
+
+        $to_addresses = AddressHeader::fromString(@$structure->headers['to'])->getEmails();
+        if ($to_addresses) {
             $addresses = $to_addresses;
         }
-        $cc_addresses = Mail_Helper::getEmailAddresses(@$structure->headers['cc']);
-        if (count($cc_addresses)) {
+        $cc_addresses = AddressHeader::fromString(@$structure->headers['cc'])->getEmails();
+        if ($cc_addresses) {
             $addresses = array_merge($addresses, $cc_addresses);
         }
         $cc_users = [];

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -13,6 +13,7 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Mail\Exception\RoutingException;
+use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Monolog\Logger;
 
 /**
@@ -603,14 +604,16 @@ class Support
                         $users = array_flip($users);
 
                         $addresses = [];
-                        $to_addresses = Mail_Helper::getEmailAddresses(@$structure->headers['to']);
-                        if (count($to_addresses)) {
+
+                        $to_addresses = AddressHeader::fromString(@$structure->headers['to'])->getEmails();
+                        if ($to_addresses) {
                             $addresses = $to_addresses;
                         }
-                        $cc_addresses = Mail_Helper::getEmailAddresses(@$structure->headers['cc']);
-                        if (count($cc_addresses)) {
+                        $cc_addresses = AddressHeader::fromString(@$structure->headers['cc'])->getEmails();
+                        if ($cc_addresses) {
                             $addresses = array_merge($addresses, $cc_addresses);
                         }
+
                         $cc_users = [];
                         foreach ($addresses as $email) {
                             if (in_array(strtolower($email), $user_emails)) {
@@ -2605,14 +2608,16 @@ class Support
         array_push($addresses_not_too_add, $project_details['prj_outgoing_sender_email']);
 
         $addresses = [];
-        $to_addresses = Mail_Helper::getEmailAddresses(@$email['to']);
-        if (count($to_addresses)) {
+
+        $to_addresses = AddressHeader::fromString(@$email['to'])->getEmails();
+        if ($to_addresses) {
             $addresses = $to_addresses;
         }
-        $cc_addresses = Mail_Helper::getEmailAddresses(@$email['cc']);
-        if (count($cc_addresses)) {
+        $cc_addresses = AddressHeader::fromString($email['cc'])->getEmails();
+        if ($cc_addresses) {
             $addresses = array_merge($addresses, $cc_addresses);
         }
+
         $subscribers = Notification::getSubscribedEmails($email['issue_id']);
         foreach ($addresses as $address) {
             $address = strtolower($address);

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -38,7 +38,7 @@ class AddressHeader
         }
 
         // fromString expects 7bit input
-        $addresses = Mime_Helper::encode($addresses);
+        $addresses = Mime_Helper::encodeValue($addresses);
 
         // use To header to utilize AddressList functionality
         return new static(To::fromString('To:' . $addresses));

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Mail\Helper;
+
+use Mime_Helper;
+use Zend\Mail\Header\AbstractAddressList;
+use Zend\Mail\Header\To;
+
+/**
+ * Helper to parse any address list type header (to, from, cc, bcc, reply-to) into Header object
+ */
+class AddressHeader
+{
+    /** @var To */
+    private $header;
+
+    public function __construct(AbstractAddressList $addresses)
+    {
+        $this->header = $addresses;
+    }
+
+    public static function fromString($addresses)
+    {
+        // fromString expects 7bit input
+        $addresses = Mime_Helper::encode($addresses);
+
+        // use To header to utilize AddressList functionality
+        return new static(To::fromString('To:' . $addresses));
+    }
+
+    public function getEmails()
+    {
+        $res = [];
+        foreach ($this->header->getAddressList() as $address) {
+            $res[] = $address->getEmail();
+        }
+
+        return $res;
+    }
+}

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -32,6 +32,11 @@ class AddressHeader
 
     public static function fromString($addresses)
     {
+        // avoid exceptions if NULL or empty string passed as input
+        if (!$addresses) {
+            return new static(new To());
+        }
+
         // fromString expects 7bit input
         $addresses = Mime_Helper::encode($addresses);
 

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -71,32 +71,37 @@ class MailHelperTest extends TestCase
      * but @see Mail_Helper::getEmailAddresses results errors
      * because @see Mail_Helper::fixAddressQuoting encodes just wrong.
      * test the alternative implementation using Zend Mail
+     *
+     * @dataProvider validGetEmailAddressesData
      */
-    public function testGetEmailAddresses()
+    public function testGetEmailAddresses($input, $exp)
     {
-        $addresses = '"Erika Mkaitė" <erika@example.net>, Rööt (Šuperuser) <root@example.org>';
+        $res = AddressHeader::fromString($input)->getEmails();
+        $this->assertEquals($exp, $res);
+    }
 
-        $res = AddressHeader::fromString($addresses)->getEmails();
-        $exp = [
-            'erika@example.net',
-            'root@example.org',
+    public function validGetEmailAddressesData()
+    {
+        return [
+            [
+                // decoded input
+                '"Erika Mkaitė" <erika@example.net>, Rööt (Šuperuser) <root@example.org>',
+                [
+                    'erika@example.net',
+                    'root@example.org',
+                ],
+            ],
+            [
+                // test that QP encoded input also works
+                'Erika =?utf-8?b?TWthaXTElyI=?= <erika@example.net>, =?utf-8?b?UsO2w7Z0IA==?= =?utf-8?b?KMWgdXBlcnVzZXIp?= <root@example.org>',
+                [
+                    'erika@example.net',
+                    'root@example.org',
+                ],
+            ],
+            // the @$array['foo'] results NULL
+            [null, []],
         ];
-        $this->assertEquals($exp, $res);
-
-        // test that QP encoded input also works
-        $addresses = 'Erika =?utf-8?b?TWthaXTElyI=?= <erika@example.net>, =?utf-8?b?UsO2w7Z0IA==?= =?utf-8?b?KMWgdXBlcnVzZXIp?= <root@example.org>';
-        $res = AddressHeader::fromString($addresses)->getEmails();
-        $exp = [
-            'erika@example.net',
-            'root@example.org',
-        ];
-        $this->assertEquals($exp, $res);
-
-        // the @$array['foo'] results NULL
-        $addresses = null;
-        $res = AddressHeader::fromString($addresses)->getEmails();
-        $exp = [];
-        $this->assertEquals($exp, $res);
     }
 
     /**

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -108,6 +108,17 @@ class MailHelperTest extends TestCase
                 'ted@example.com (Ted Bloggs)',
                 ['ted@example.com'],
             ],
+            [
+                // https://github.com/zendframework/zend-mail/pull/13
+                'undisclosed-recipients:;',
+                [],
+            ],
+            [
+                // https://github.com/zendframework/zend-mail/pull/13
+                // https://github.com/eventum/eventum/issues/91
+                'destinatarios-no-revelados:;',
+                [],
+            ],
         ];
     }
 

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -101,6 +101,13 @@ class MailHelperTest extends TestCase
             ],
             // the @$array['foo'] results NULL
             [null, []],
+
+            // test comments
+            // https://github.com/zendframework/zend-mail/pull/12
+            [
+                'ted@example.com (Ted Bloggs)',
+                ['ted@example.com'],
+            ],
         ];
     }
 

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -83,6 +83,15 @@ class MailHelperTest extends TestCase
         ];
         $this->assertEquals($exp, $res);
 
+        // test that QP encoded input also works
+        $addresses = 'Erika =?utf-8?b?TWthaXTElyI=?= <erika@example.net>, =?utf-8?b?UsO2w7Z0IA==?= =?utf-8?b?KMWgdXBlcnVzZXIp?= <root@example.org>';
+        $res = AddressHeader::fromString($addresses)->getEmails();
+        $exp = [
+            'erika@example.net',
+            'root@example.org',
+        ];
+        $this->assertEquals($exp, $res);
+
         // the @$array['foo'] results NULL
         $addresses = null;
         $res = AddressHeader::fromString($addresses)->getEmails();

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Test;
 
+use Eventum\Mail\Helper\AddressHeader;
 use Mail_Helper;
 
 /**
@@ -63,6 +64,24 @@ class MailHelperTest extends TestCase
         // <eventum.md5.54hebbwge.myyt4c@eventum.example.org>
         $exp = '<eventum\.md5\.[0-9a-z]{8,64}\.[0-9a-z]{8,64}@' . APP_HOSTNAME . '>';
         $this->assertRegExp($exp, $msgid, 'Missing msg-id header');
+    }
+
+    /**
+     * test that @see Support::addExtraRecipientsToNotificationList adds cc addresses that are not 7bit
+     * but @see Mail_Helper::getEmailAddresses results errors because
+     * @see Mail_Helper::fixAddressQuoting encodes just wrong.
+     * test the alternative implementation using Zend Mail
+     */
+    public function getEmailAddresses()
+    {
+        $addresses = '"Erika Mkaitė" <erika@example.net>, Rööt (Šuperuser) <root@example.org>';
+
+        $res = AddressHeader::fromString($addresses)->getEmails();
+        $exp = [
+            'erika@example.net',
+            'root@example.org',
+        ];
+        $this->assertEquals($exp, $res);
     }
 
     /**
@@ -208,7 +227,7 @@ class MailHelperTest extends TestCase
                         // this is how it currently is parsed
                         'sender_name' => '"My Group: \"Richard"',
                         // this is how it should be parsed if fixAddressQuoting didn't break it
-//                        'sender_name' => '"Richard"',
+                        //'sender_name' => '"Richard"',
                         'email' => 'richard@localhost',
                         'username' => 'richard',
                         'host' => 'localhost',

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -68,11 +68,11 @@ class MailHelperTest extends TestCase
 
     /**
      * test that @see Support::addExtraRecipientsToNotificationList adds cc addresses that are not 7bit
-     * but @see Mail_Helper::getEmailAddresses results errors because
-     * @see Mail_Helper::fixAddressQuoting encodes just wrong.
+     * but @see Mail_Helper::getEmailAddresses results errors
+     * because @see Mail_Helper::fixAddressQuoting encodes just wrong.
      * test the alternative implementation using Zend Mail
      */
-    public function getEmailAddresses()
+    public function testGetEmailAddresses()
     {
         $addresses = '"Erika Mkaitė" <erika@example.net>, Rööt (Šuperuser) <root@example.org>';
 
@@ -81,6 +81,12 @@ class MailHelperTest extends TestCase
             'erika@example.net',
             'root@example.org',
         ];
+        $this->assertEquals($exp, $res);
+
+        // the @$array['foo'] results NULL
+        $addresses = null;
+        $res = AddressHeader::fromString($addresses)->getEmails();
+        $exp = [];
         $this->assertEquals($exp, $res);
     }
 


### PR DESCRIPTION
this one parses input properly. our implementation messed up addresslist with quotes and 8bit data
resulting `Invalid address spec. Unclosed bracket or quotes` errors from PEAR

`Mail_Helper::getEmailAddresses` is now unused, to be dropped later.

the underlying problem was that `Mail_Helper::fixAddressQuoting` corrupted data. it should be ripped out as well.