### PR TITLE
Add option to control how custom field options are ordered.

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -5,6 +5,7 @@
 - ldap: respect `create_users` configuration (@glensc)
 - Fix bug creating new priority (@balsdorf)
 - add MailTransport class to encapsulate smtp transport (@glensc, #236, #234)
+- Add option to control ordering of custom field options (@balsdorf, #240)
 
 [3.1.10]: https://github.com/eventum/eventum/compare/v3.1.9...master
 

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -584,3 +584,16 @@ span.toggle-trimmed-email a:active {
     color: #fff;
     background-color: #4078c0;
 }
+
+.ui-sortable {
+    margin: 0;
+    padding: 0;
+}
+
+.ui-sortable-handle {
+    border: 1px dashed #000000;
+    list-style: none;
+    margin: 1em;
+    padding: 1em;
+    cursor: move;
+}

--- a/htdocs/css/page.css
+++ b/htdocs/css/page.css
@@ -507,3 +507,33 @@ option.select_icon_priority {
     background: transparent;
     border: 1px solid #c0c0c0;
 }
+
+/* manage custom field options */
+.custom_field_options #add_option {
+    margin-left: 1em;
+    cursor: pointer;
+}
+
+.custom_field_options .new_options {
+    margin: 0;
+    padding: 0;
+}
+
+.custom_field_options .new_options li {
+    border: 1px solid #000000;
+    list-style: none;
+    margin: 1em;
+    padding: 1em;
+    cursor: move;
+}
+
+.custom_field_options .delete {
+    float: right;
+    cursor: pointer;
+}
+
+.custom_field_options .instructions {
+    margin-left: 1em;
+    margin-top: .5em;
+    font-style: italic;
+}

--- a/htdocs/js/page.js
+++ b/htdocs/js/page.js
@@ -1112,3 +1112,44 @@ preferences.confirmRegenerateToken = function()
     }
     return false;
 };
+
+
+function custom_field_options()
+{
+}
+
+custom_field_options.ready = function()
+{
+    $('#sortable').sortable();
+
+    custom_field_options.bind_actions();
+
+    $('#add_option').click(custom_field_options.add_option);
+    custom_field_options.add_option();
+};
+
+custom_field_options.bind_actions = function()
+{
+    $('.ui-sortable-handle .delete').off('click.delete').on('click.delete', function(e) {
+        $(e.target).parent().fadeOut(function() {
+            $(this).remove();
+        });
+    });
+
+    $('#custom_field_options input').off('keydown.blockenter').on('keydown.blockenter', function(e) {
+        if(e.keyCode == 13) {
+            if ($(this).prop('name') == 'new_options[]' && $(this).val() != '') {
+                custom_field_options.add_option();
+                $("input[name='new_options[]']:last").focus()
+            }
+            e.preventDefault();
+            return false;
+        }
+    })
+}
+
+custom_field_options.add_option = function() {
+    var template = $('#new_option_template').first();
+    template.clone().prop('id', '').insertAfter('.new_options li:last').show()
+    custom_field_options.bind_actions();
+}

--- a/htdocs/manage/custom_field_options.php
+++ b/htdocs/manage/custom_field_options.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+require_once __DIR__ . '/../../init.php';
+
+$controller = new Eventum\Controller\Manage\CustomFieldOptionsController();
+$controller->run();

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -26,8 +26,7 @@ class Custom_Field
         'cfo_id DESC' => 'Reverse insert',
         'cfo_value ASC' => 'Alphabetical',
         'cfo_value DESC' => 'Reverse alphabetical',
-        'cfo_rank ASC' => 'Manual',
-        'cfo_rank DESC' => 'Reverse manual',
+        'cfo_rank ASC' => 'Manual'
     ];
 
     public static function updateOptions($fld_id, $options, $new_options)
@@ -46,7 +45,7 @@ class Custom_Field
         }
 
         if (count($new_options) > 0) {
-            self:;self::addOptions($fld_id, $new_options);
+            self::addOptions($fld_id, $new_options, $rank);
         }
 
         return 1;
@@ -95,9 +94,10 @@ class Custom_Field
      *
      * @param   integer $fld_id The custom field ID
      * @param   array $options The list of options that need to be added
+     * @param   integer $start_rank The rank for the first new option to be inserted with
      * @return  integer 1 if the insert worked, -1 otherwise
      */
-    public static function addOptions($fld_id, $options)
+    public static function addOptions($fld_id, $options, $start_rank)
     {
         if (!is_array($options)) {
             $options = [$options];
@@ -111,12 +111,14 @@ class Custom_Field
                         {{%custom_field_option}}
                      (
                         cfo_fld_id,
-                        cfo_value
+                        cfo_value,
+                        cfo_rank
                      ) VALUES (
                         ?,
-                        ' . DB_Helper::buildList($option) . '
+                        ?,
+                        ?
                      )';
-            $params = array_merge([$fld_id, $option]);
+            $params = [$fld_id, $option, $start_rank++];
             try {
                 DB_Helper::getInstance()->query($stmt, $params);
             } catch (DatabaseException $e) {

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -21,6 +21,37 @@ class Custom_Field
 {
     public static $option_types = ['combo', 'multiple', 'checkbox'];
 
+    public static $order_by_choices = [
+        'cfo_id ASC' => 'Insert',
+        'cfo_id DESC' => 'Reverse insert',
+        'cfo_value ASC' => 'Alphabetical',
+        'cfo_value DESC' => 'Reverse alphabetical',
+        'cfo_rank ASC' => 'Manual',
+        'cfo_rank DESC' => 'Reverse manual',
+    ];
+
+    public static function updateOptions($fld_id, $options, $new_options)
+    {
+        $old_options = self::getOptions($fld_id);
+
+        $rank = 1;
+        foreach ($options as $cfo_id => $cfo_value) {
+            self::updateOption($cfo_id, $cfo_value, $rank++);
+            unset($old_options[$cfo_id]);
+        }
+
+        // delete any options leftover
+        if (count($old_options) > 0) {
+            self::removeOptions($fld_id, array_keys($old_options));
+        }
+
+        if (count($new_options) > 0) {
+            self:;self::addOptions($fld_id, $new_options);
+        }
+
+        return 1;
+    }
+
     /**
      * Method used to remove a group of custom field options.
      *
@@ -73,6 +104,9 @@ class Custom_Field
         }
 
         foreach ($options as $option) {
+            if (empty($option)) {
+                continue;
+            }
             $stmt = 'INSERT INTO
                         {{%custom_field_option}}
                      (
@@ -98,18 +132,20 @@ class Custom_Field
      *
      * @param   integer $cfo_id The custom field option ID
      * @param   string $cfo_value The custom field option value
+     * @param   integer $rank The rank of the custom field option
      * @return  boolean
      */
-    public static function updateOption($cfo_id, $cfo_value)
+    public static function updateOption($cfo_id, $cfo_value, $rank=null)
     {
         $stmt = 'UPDATE
                     {{%custom_field_option}}
                  SET
-                    cfo_value=?
+                    cfo_value=?,
+                    cfo_rank=?
                  WHERE
                     cfo_id=?';
         try {
-            DB_Helper::getInstance()->query($stmt, [$cfo_value, $cfo_id]);
+            DB_Helper::getInstance()->query($stmt, [$cfo_value, $rank, $cfo_id]);
         } catch (DatabaseException $e) {
             return false;
         }
@@ -956,12 +992,6 @@ class Custom_Field
         }
 
         $new_id = DB_Helper::get_last_insert_id();
-        if (in_array($_POST['field_type'], self::$option_types)) {
-            foreach ($_POST['field_options'] as $option_value) {
-                $params = self::parseParameters($option_value);
-                self::addOptions($new_id, $params['value']);
-            }
-        }
         // add the project associations!
         foreach ($_POST['projects'] as $prj_id) {
             self::associateProject($prj_id, $new_id);
@@ -1028,6 +1058,8 @@ class Custom_Field
             }
             $row['min_role_name'] = User::getRole($row['fld_min_role']);
             $row['min_role_edit_name'] = User::getRole($row['fld_min_role_edit']);
+            $row['has_options'] = in_array($row['fld_type'], self::$option_types);
+            $row['field_options'] = self::getOptions($row['fld_id']);
         }
 
         return $res;
@@ -1088,13 +1120,13 @@ class Custom_Field
         } catch (DatabaseException $e) {
             return '';
         }
+        if (empty($res)) {
+            return null;
+        }
 
         $res['projects'] = @array_keys(self::getAssociatedProjects($fld_id));
+        $res['field_options'] = self::getOptions($fld_id, null, null, null, $res['fld_order_by']);
 
-        $options = self::getOptions($fld_id);
-        foreach ($options as $cfo_id => $cfo_value) {
-            $res['field_options']['existing:' . $cfo_id . ':' . $cfo_value] = $cfo_value;
-        }
         $returns[$fld_id] = $res;
 
         return $res;
@@ -1107,9 +1139,11 @@ class Custom_Field
      * @param   integer $fld_id The custom field ID
      * @param   array $ids An array of ids to return values for.
      * @param   integer $issue_id The ID of the issue
-     * @return  array The list of custom field options
+     * @param   string $form_type
+     * @param   string $order_by The field and order to sort by. If null it will use the field setting
+     * @return array The list of custom field options
      */
-    public static function getOptions($fld_id, $ids = null, $issue_id = null, $form_type = null)
+    public static function getOptions($fld_id, $ids = null, $issue_id = null, $form_type = null, $order_by = null)
     {
         static $returns;
 
@@ -1133,6 +1167,11 @@ class Custom_Field
             return $list;
         }
 
+        if (is_null($order_by)) {
+            $fld_details = self::getDetails($fld_id);
+            $order_by = $fld_details['fld_order_by'];
+        }
+
         $stmt = 'SELECT
                     cfo_id,
                     cfo_value
@@ -1148,44 +1187,16 @@ class Custom_Field
         }
         $stmt .= '
                  ORDER BY
-                    cfo_id ASC';
+                    ' . $order_by;
         try {
             $res = DB_Helper::getInstance()->getPair($stmt, $params);
         } catch (DatabaseException $e) {
             return '';
         }
 
-        asort($res);
         $returns[$return_key] = $res;
 
         return $res;
-    }
-
-    /**
-     * Method used to parse the special format used in the combo boxes
-     * in the administration section of the system, in order to be
-     * used as a way to flag the system for whether the custom field
-     * option is a new one or one that should be updated.
-     *
-     * @param   string $value The custom field option format string
-     * @return  array Parameters used by the update/insert methods
-     */
-    private function parseParameters($value)
-    {
-        if (substr($value, 0, 4) == 'new:') {
-            return [
-                'type'  => 'new',
-                'value' => substr($value, 4),
-            ];
-        }
-
-        $value = substr($value, strlen('existing:'));
-
-        return [
-            'type'  => 'existing',
-            'id'    => substr($value, 0, strpos($value, ':')),
-            'value' => substr($value, strpos($value, ':') + 1),
-        ];
     }
 
     /**
@@ -1228,6 +1239,9 @@ class Custom_Field
         if (!isset($_POST['rank'])) {
             $_POST['rank'] = (self::getMaxRank() + 1);
         }
+        if (!isset($_POST['order_by'])) {
+            $_POST['order_by'] = 'cfo_id ASC';
+        }
         $old_details = self::getDetails($_POST['id']);
         $stmt = 'UPDATE
                     {{%custom_field}}
@@ -1246,7 +1260,8 @@ class Custom_Field
                     fld_min_role=?,
                     fld_min_role_edit=?,
                     fld_rank = ?,
-                    fld_backend = ?
+                    fld_backend = ?,
+                    fld_order_by = ?
                  WHERE
                     fld_id=?';
         try {
@@ -1266,6 +1281,7 @@ class Custom_Field
                 $_POST['min_role_edit'],
                 $_POST['rank'],
                 @$_POST['custom_field_backend'],
+                $_POST['order_by'],
                 $_POST['id'],
             ]);
         } catch (DatabaseException $e) {
@@ -1294,34 +1310,10 @@ class Custom_Field
                 self::updateValuesForNewType($_POST['id']);
             }
         }
-        // update the custom field options, if any
-        if (in_array($_POST['field_type'], self::$option_types)) {
-            $updated_options = [];
-            foreach ($_POST['field_options'] as $option_value) {
-                $params = self::parseParameters($option_value);
-                if ($params['type'] == 'new') {
-                    self::addOptions($_POST['id'], $params['value']);
-                } else {
-                    $updated_options[] = $params['id'];
-                    // check if the user is trying to update the value of this option
-                    if ($params['value'] != self::getOptionValue($_POST['id'], $params['id'])) {
-                        self::updateOption($params['id'], $params['value']);
-                    }
-                }
-            }
-        }
-        // get the diff between the current options and the ones posted by the form
-        // and then remove the options not found in the form submissions
-        if (in_array($_POST['field_type'], self::$option_types)) {
-            $diff_ids = @array_diff($current_options, $updated_options);
-            if (@count($diff_ids) > 0) {
-                self::removeOptions($_POST['id'], array_values($diff_ids));
-            }
-        }
+
         // now we need to check for any changes in the project association of this custom field
         // and update the mapping table accordingly
         $old_proj_ids = @array_keys(self::getAssociatedProjects($_POST['id']));
-        // COMPAT: this next line requires PHP > 4.0.4
         $diff_ids = array_diff($old_proj_ids, $_POST['projects']);
         if (count($diff_ids) > 0) {
             foreach ($diff_ids as $removed_prj_id) {

--- a/src/Controller/Manage/CustomFieldOptionsController.php
+++ b/src/Controller/Manage/CustomFieldOptionsController.php
@@ -1,0 +1,89 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Controller\Manage;
+
+use Custom_Field;
+use Eventum\Controller\Helper\MessagesHelper;
+use User;
+
+class CustomFieldOptionsController extends ManageBaseController
+{
+    /** @var string */
+    protected $tpl_name = 'manage/custom_field_options.tpl.html';
+
+    /** @var int */
+    protected $min_role = User::ROLE_ADMINISTRATOR;
+
+    /** @var string */
+    private $cat;
+
+    /** @var int */
+    private $fld_id;
+
+    /** @var array */
+    private $field_info;
+
+    /**
+     * @inheritdoc
+     */
+    protected function configure()
+    {
+        $request = $this->getRequest();
+
+        $this->fld_id = $request->request->get('fld_id') ?: $request->query->get('fld_id');
+        $this->field_info = Custom_Field::getDetails($this->fld_id);
+
+        $this->cat = $request->request->get('cat') ?: $request->query->get('cat');
+
+        if (empty($this->field_info)) {
+            $this->error(ev_gettext("Invalid custom field ID"));
+        }
+    }
+
+    /**
+     * @inheritdoc
+     */
+    protected function defaultAction()
+    {
+        if ($this->cat == 'update') {
+            $this->updateAction();
+        }
+    }
+
+
+    private function updateAction()
+    {
+        $post = $this->getRequest()->request;
+        $res = Custom_Field::updateOptions($this->fld_id, $post->get('existing_options'), $post->get('new_options'));
+        $this->messages->mapMessages(
+            $res, [
+                1 => [ev_gettext('Thank you, the custom field options were updated successfully.'), MessagesHelper::MSG_INFO],
+                -1 => [ev_gettext('An error occurred while trying to update the custom field options.'), MessagesHelper::MSG_ERROR],
+            ]
+        );
+        $this->redirect(APP_RELATIVE_URL . 'manage/custom_field_options.php?fld_id=' . $this->fld_id);
+    }
+
+
+    /**
+     * @inheritdoc
+     */
+    protected function prepareTemplate()
+    {
+        $this->tpl->assign([
+                'info' => $this->field_info,
+                'options'   =>  Custom_Field::getOptions($this->fld_id),
+        ]);
+    }
+}

--- a/src/Controller/Manage/CustomFieldOptionsController.php
+++ b/src/Controller/Manage/CustomFieldOptionsController.php
@@ -42,13 +42,8 @@ class CustomFieldOptionsController extends ManageBaseController
         $request = $this->getRequest();
 
         $this->fld_id = $request->request->get('fld_id') ?: $request->query->get('fld_id');
-        $this->field_info = Custom_Field::getDetails($this->fld_id);
 
         $this->cat = $request->request->get('cat') ?: $request->query->get('cat');
-
-        if (empty($this->field_info)) {
-            $this->error(ev_gettext("Invalid custom field ID"));
-        }
     }
 
     /**
@@ -81,8 +76,14 @@ class CustomFieldOptionsController extends ManageBaseController
      */
     protected function prepareTemplate()
     {
+
+        $field_info = Custom_Field::getDetails($this->fld_id);
+        if (empty($field_info)) {
+            $this->error(ev_gettext("Invalid custom field ID"));
+        }
+
         $this->tpl->assign([
-                'info' => $this->field_info,
+                'info' => $field_info,
                 'options'   =>  Custom_Field::getOptions($this->fld_id),
         ]);
     }

--- a/src/Controller/Manage/CustomFieldOptionsController.php
+++ b/src/Controller/Manage/CustomFieldOptionsController.php
@@ -31,9 +31,6 @@ class CustomFieldOptionsController extends ManageBaseController
     /** @var int */
     private $fld_id;
 
-    /** @var array */
-    private $field_info;
-
     /**
      * @inheritdoc
      */

--- a/src/Controller/Manage/CustomFieldOptionsController.php
+++ b/src/Controller/Manage/CustomFieldOptionsController.php
@@ -76,7 +76,6 @@ class CustomFieldOptionsController extends ManageBaseController
      */
     protected function prepareTemplate()
     {
-
         $field_info = Custom_Field::getDetails($this->fld_id);
         if (empty($field_info)) {
             $this->error(ev_gettext("Invalid custom field ID"));

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -117,6 +117,7 @@ class CustomFieldsController extends ManageBaseController
                 'list' => Custom_Field::getList(),
                 'user_roles' => $user_roles,
                 'backend_list' => Custom_Field::getBackendList(),
+                'order_by_list' =>  Custom_Field::$order_by_choices
             ]
         );
     }

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -40,10 +40,12 @@
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/core.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/datepicker.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/widget.js"></script>
+  <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/mouse.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/progressbar.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/position.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/menu.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/selectmenu.js"></script>
+  <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/sortable.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-chosen/chosen.jquery.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/dropzone/dist/dropzone.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/autosize/dist/autosize.js"></script>

--- a/templates/manage/custom_field_options.tpl.html
+++ b/templates/manage/custom_field_options.tpl.html
@@ -1,0 +1,57 @@
+{extends "manage/manage.tpl.html"}
+{block page_classes}custom_field_options{/block}
+
+{block "manage_content"}
+<form id="custom_field_options" method="post">
+  <input type="hidden" name="cat" value="update">
+  <input type="hidden" name="fld_id" value="{$info.fld_id|intval}">
+  <table class="bordered">
+    <tr class="title">
+      <th colspan="2">
+        {t}Manage Custom Field Options{/t}
+        <div class="right">
+          <a href="custom_fields.php?cat=edit&id={$info.fld_id}">Back to Custom Field</a>
+        </div>
+      </th>
+    </tr>
+    <tr>
+      <td>
+        <div class="instructions">
+          Drag and drop options to re-order them. This only matters if option sort order is set to &quot;Manual&quot; or
+          &quot;Reverse Manual&quot;.
+          </div>
+        <ul id="sortable">
+          {foreach from=$options key=cfo_id item=option}
+          <li data-cfo-id="{$cfo_id}">
+            <input type="text" name="existing_options[{$cfo_id}]" value="{$option}" />
+            <div class="delete">[remove]</div>
+          </li>
+          {/foreach}
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th>
+        New Options
+      </th>
+    </tr>
+    <tr>
+      <td>
+        <ul class="new_options">
+          <li id="new_option_template" class="hidden">
+            <input type="text" name="new_options[]" />
+             <div class="delete">[remove]</div>
+          </li>
+        </ul>
+        <div id="add_option">Add Another Option</div>
+      </td>
+    </tr>
+    <tr class="buttons">
+      <td colspan="2">
+        <input type="submit" value="{t}Save Options{/t}">
+      </td>
+    </tr>
+  </table>
+</form>
+
+{/block}

--- a/templates/manage/custom_fields.tpl.html
+++ b/templates/manage/custom_fields.tpl.html
@@ -306,47 +306,21 @@
                   {t}Field Options{/t}
                 </th>
                 <td>
-                  <table>
-                    <tr>
-                      <td valign="top">
-                        <span>{t}Set available options{/t}</span><br />
-                        <input type="text" name="new_value" size="26" class="custom_option"><input name="add_button" type="button" value="{t}Add{/t}" class="custom_option">{if $smarty.get.cat|default:'' == 'edit'}<input name="update_button" type="button" value="{t}Update Value{/t}" disabled>{/if}<br />
-                      </td>
-                      <td rowspan="3">
-                        &nbsp;&nbsp;&nbsp;&nbsp;<strong>{t}AND / OR{/t}</strong>&nbsp;&nbsp;&nbsp;&nbsp;
-                      </td>
-                      <td valign="top">
-                        <span>{t}Choose Custom Field Backend{/t}</span><br />
-                        <select name="custom_field_backend">
-                          <option value="" label="{t}Please select a backend{/t}">{t}Please select a backend{/t}</option>
-                          {html_options options=$backend_list selected=$info.fld_backend|default:''}
-                        </select>
-                      </td>
-                    </tr>
-                    <tr>
-                      <td>
-                        <table border="0" cellspacing="0" cellpadding="0">
-                          <tr>
-                            <td>
-                              <select name="field_options[]" multiple size="3">
-                              {if $info.field_options|default:'' == ""}
-                                <option value="-1">{t}enter a new option above{/t}</option>
-                              {else}
-                                {html_options options=$info.field_options|default:''}
-                              {/if}
-                              </select>
-                            </td>
-                            <td valign="top">
-                              {if $smarty.get.cat|default:'' == 'edit'}
-                              <input type="button" name="edit_button" value="{t}Edit Option{/t}" class="custom_option"><br />
-                              {/if}
-                              <input type="button" name="remove_button" value="{t}Remove{/t}" class="custom_option">
-                            </td>
-                          </tr>
-                        </table>
-                      </td>
-                    </tr>
-                  </table>
+                  {if $info|default:''}
+                    <a href="custom_field_options.php?fld_id={$info.fld_id}">Edit Options ({$info.field_options|@count})</a>
+                  {else}
+                    <em>You must save the new custom field before editing options.</em>
+                  {/if}
+                </td>
+              </tr>
+              <tr>
+                <th width="120">
+                  {t}Order Options By{/t}
+                </th>
+                <td>
+                  <select name="order_by">
+                    {html_options options=$order_by_list selected=$info.fld_order_by|default:'cfo_id ASC'}
+                  </select>
                 </td>
               </tr>
               <tr>
@@ -435,7 +409,9 @@
                 <nobr>&nbsp;{if $list[i].fld_type == 'combo'}{t}Combo Box{/t}{elseif $list[i].fld_type == 'multiple'}{t}Multiple Combo Box{/t}{elseif $list[i].fld_type == 'textarea'}{t}Textarea{/t}{elseif $list[i].fld_type == 'date'}{t}Date{/t}{elseif $list[i].fld_type == 'integer'}{t}Integer{/t}{elseif $list[i].fld_type == 'checkbox'}Checkbox{else}{t}Text Input{/t}{/if}</nobr>
               </td>
               <td width="50%">
-                &nbsp;{$list[i].field_options|default:''}
+                 {if $list[i].has_options}
+                  &nbsp;<a href="custom_field_options.php?fld_id={$list[i].fld_id}">Edit Options ({$list[i].field_options|@count})</a>
+                 {/if}
               </td>
             </tr>
             {sectionelse}

--- a/upgrade/patches/64_custom_field_option_order.sql
+++ b/upgrade/patches/64_custom_field_option_order.sql
@@ -1,0 +1,6 @@
+/**
+ * Control the order of custom fields
+ *
+ */
+ALTER TABLE {{%custom_field_option}} ADD COLUMN cfo_rank int(10) NOT NULL DEFAULT 0;
+ALTER TABLE {{%custom_field}} ADD COLUMN fld_order_by varchar(20) NOT NULL DEFAULT 'cfo_id ASC'

--- a/upgrade/patches/64_custom_field_option_order.sql
+++ b/upgrade/patches/64_custom_field_option_order.sql
@@ -2,5 +2,5 @@
  * Control the order of custom fields
  *
  */
-ALTER TABLE {{%custom_field_option}} ADD COLUMN cfo_rank int(10) NOT NULL DEFAULT 0;
+ALTER TABLE {{%custom_field_option}} ADD COLUMN cfo_rank INT UNSIGNED NOT NULL DEFAULT 0 AFTER cfo_fld_id;
 ALTER TABLE {{%custom_field}} ADD COLUMN fld_order_by varchar(20) NOT NULL DEFAULT 'cfo_id ASC'


### PR DESCRIPTION
Historically custom field options have been ordered alphabetically. I've now added the option to order them:
* Alphabetically / Reverse Alphabetically
* Insert / Reverse Insert
* Manually

Custom field options have also been moved to a separate page to allow for ordering and editing.