### PR TITLE
replace abandoned malsup/form with jquery-form/form

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -113,7 +113,7 @@
 		"eventum/rpc": "~4.0.0",
 		"jackmoore/autosize":"*",
 		"jasig/phpcas":"~1.3.3",
-		"malsup/form" :"*",
+		"jquery-form/form": "^4.2",
 		"maximebf/debugbar": "1.*",
 		"rmm5t/jquery-timeago": "*",
 		"roave/security-advisories": "dev-master",

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -35,7 +35,7 @@
 
   <script type="text/javascript" src="{$core.rel_url}components/jquery/jquery.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-blockui/jquery.blockUI.js"></script>
-  <script type="text/javascript" src="{$core.rel_url}components/form/jquery.form.js"></script>
+  <script type="text/javascript" src="{$core.rel_url}components/form/src/jquery.form.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-cookie/jquery.cookie.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/core.js"></script>
   <script type="text/javascript" src="{$core.rel_url}components/jquery-ui/ui/datepicker.js"></script>


### PR DESCRIPTION
https://github.com/jquery-form/form/releases/tag/v4.0.0

> jQuery Form has a new home! The new canonical URL for the project is https://github.com/jquery-form/form.
> The major version has been incremented to 4 due to the new home of project.
> Version 4 is expected to be backward compatible with 3.51.0.

however. I can not find where do we use this library in templates.