### PR TITLE
Delete issue association to issue itself. refs #207

### DIFF
--- a/upgrade/patches/65_isa_self_refs.sql
+++ b/upgrade/patches/65_isa_self_refs.sql
@@ -1,0 +1,4 @@
+/*
+ * Delete issue association to issue itself
+ */
+delete from {{%issue_association}} where isa_issue_id=isa_associated_id;


### PR DESCRIPTION
Some old broken database entries caused `InvalidArgumentException` otherwise:

```
PHP Fatal error: Uncaught exception 'LogicException' in 
src/Model/Repository/IssueAssociationRepository.php:51
```