### PR TITLE
drop Mail_rfc822 PEAR Mail requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -73,7 +73,6 @@
 		"pear-pear.php.net/net_url": "*",
 		"pear-pear.php.net/text_diff": "*",
 		"pear/auth_sasl": "*",
-		"pear/mail": "~1.3.0",
 		"pear/mail_mime": "*",
 		"pear/net_smartirc": "~1.1.0",
 		"pear/net_smtp": "1.6.*",

--- a/lib/eventum/class.authorized_replier.php
+++ b/lib/eventum/class.authorized_replier.php
@@ -139,7 +139,7 @@ class Authorized_Replier
             return -1;
         }
 
-        $email = strtolower(Mail_Helper::getEmailAddress($email));
+        $email = Mail_Helper::getEmailAddress($email);
 
         $workflow = Workflow::handleAuthorizedReplierAdded(Issue::getProjectID($issue_id), $issue_id, $email);
         if ($workflow === false) {
@@ -231,7 +231,7 @@ class Authorized_Replier
     {
         // XXX: Add caching
 
-        $email = strtolower(Mail_Helper::getEmailAddress($email));
+        $email = Mail_Helper::getEmailAddress($email);
         // first check if this is an actual user or just an email address
         $usr_id = User::getUserIDByEmail($email, true);
         if (!empty($usr_id)) {

--- a/lib/eventum/class.edit_reporter.php
+++ b/lib/eventum/class.edit_reporter.php
@@ -28,7 +28,7 @@ class Edit_Reporter
      */
     public static function update($issue_id, $email, $add_history = true)
     {
-        $email = strtolower(Mail_Helper::getEmailAddress($email));
+        $email = Mail_Helper::getEmailAddress($email);
         $usr_id = User::getUserIDByEmail($email, true);
 
         // If no valid user found reset to system account

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -14,6 +14,7 @@
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\MailTransport;
 use Eventum\Monolog\Logger;
+use Zend\Mail\Address;
 
 /**
  * Class to handle the business logic related to sending email to
@@ -239,20 +240,18 @@ class Mail_Helper
 
     /**
      * Method used to get the email address portion of a given
-     * recipient information.
+     * recipient information. Normalizes the address by lowercasing it.
      *
-     * @param   string $address The email address value
-     * @return  string The email address
+     * @param Address|string $address The email address value
+     * @return string The email address
      */
     public static function getEmailAddress($address)
     {
-        $address = Mime_Helper::encodeAddress($address);
-        $info = self::getAddressInfo($address);
-        if (Misc::isError($info)) {
-            return $info;
+        if (!$address instanceof Address) {
+            $address = AddressHeader::fromString($address)->getAddress();
         }
 
-        return $info['email'];
+        return strtolower($address->getEmail());
     }
 
     /**

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -135,43 +135,6 @@ class Mail_Helper
     }
 
     /**
-     * Method used to break down the email address information and
-     * return it for easy manipulation.
-     *
-     * Expands "Groups" into single addresses.
-     *
-     * @param   string $address The email address value
-     * @param   bool $multiple If multiple addresses should be returned
-     * @return  array The address information
-     * @deprecated use AddressHeader directly
-     */
-    public static function getAddressInfo($address, $multiple = false)
-    {
-        $header = AddressHeader::fromString($address);
-
-        $addresses = [];
-        foreach ($header->getAddressList() as $address) {
-            $email = $address->getEmail();
-            $sender_name = $address->getName();
-
-            list($username, $hostname) = explode('@', $email);
-            $item = [
-                'email' => $email,
-                'sender_name' => $sender_name ? sprintf('"%s"', $sender_name) : '',
-                'username' => $username,
-                'host' => $hostname,
-            ];
-            $addresses[] = $item;
-        }
-
-        if (!$multiple) {
-            return $addresses[0];
-        }
-
-        return $addresses;
-    }
-
-    /**
      * Parses a one or more email addresses (could be QP encoded)
      * and returns them encoded in utf-8.
      *

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -15,6 +15,7 @@ use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\MailTransport;
 use Eventum\Monolog\Logger;
 use Zend\Mail\Address;
+use Zend\Mail\Header\HeaderInterface;
 
 /**
  * Class to handle the business logic related to sending email to
@@ -219,23 +220,24 @@ class Mail_Helper
     }
 
     /**
-     * Parses a one or more email addresses and returns them separated by a comma and a space (", ").
+     * Parses a one or more email addresses (could be QP encoded)
+     * and returns them encoded in utf-8.
      *
-     * @param $input
+     * Method should be used when displaying header values to user.
+     *
+     * @param Address|string $address The email address value
      * @return string
      */
-    public static function formatEmailAddresses($input)
+    public static function formatEmailAddresses($address)
     {
-        if (empty($input)) {
+        if (!$address) {
             return '';
         }
-        $addresses = self::getAddressInfo($input, true);
-        $returns = [];
-        foreach ($addresses as $address) {
-            $returns[] = self::getFormattedName($address['sender_name'], $address['email']);
+        if (!$address instanceof Address) {
+            $address = AddressHeader::fromString($address);
         }
 
-        return implode(', ', $returns);
+        return $address->toString(HeaderInterface::FORMAT_RAW);
     }
 
     /**
@@ -985,8 +987,9 @@ class Mail_Helper
 
     /**
      * Removes newlines and tabs from subject
-     * @param string $subject The subject to clean
-     * @return string
+     *
+     * @param $subject string The subject to clean
+     * @return mixed string
      */
     public static function cleanSubject($subject)
     {

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -118,34 +118,8 @@ class Mail_Helper
      * Method used to parse a string and return all email addresses contained
      * within it.
      *
-     * @param   string $str The string containing email addresses
-     * @return  array The list of email addresses
-     * @deprecated use AddressHeader helper instead
-     */
-    public static function getEmailAddresses($str)
-    {
-        $str = self::fixAddressQuoting($str);
-        $str = Mime_Helper::encode($str);
-        $structs = self::parseAddressList($str);
-        if (Misc::isError($structs)) {
-            /** @var PEAR_Error $e */
-            $e = $structs;
-            Logger::app()->error($e->getMessage(), ['addresses' => $str]);
-
-            return [];
-        }
-
-        $addresses = [];
-        foreach ($structs as $structure) {
-            if ((!empty($structure->mailbox)) && (!empty($structure->host))) {
-                $addresses[] = $structure->mailbox . '@' . $structure->host;
-            }
-        }
-
-        return $addresses;
-    }
-
-    /**
+     * @param   string $str
+     /**
      * Wrapper around Mail_RFC822::parseAddressList to avoid calling it statically
      *
      * @param string  $address         the address(es) to validate

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -257,34 +257,24 @@ class Mail_Helper
     }
 
     /**
-     * Method used to get the name portion of a given recipient information.
+     * Method used to get the display name of a given recipient information.
      *
-     * @param   string $address The email address value
+     * Method should be used when displaying header values to user.
+     *
+     * @param Address|string $address The email address(es) value
      * @param   bool $multiple If multiple addresses should be returned
-     * @return  mixed The name or an array of names if multiple is true
+     * @throws \Zend\Mail\Header\Exception\InvalidArgumentException
+     * @return string[]|string The name or an array of names if multiple is true
      */
     public static function getName($address, $multiple = false)
     {
-        $info = self::getAddressInfo($address, true);
-        if (Misc::isError($info)) {
-            return $info;
-        }
-        $returns = [];
-        foreach ($info as $row) {
-            if (!empty($row['sender_name'])) {
-                if ((substr($row['sender_name'], 0, 1) == '"') && (substr($row['sender_name'], -1) == '"')) {
-                    $row['sender_name'] = substr($row['sender_name'], 1, -1);
-                }
-                $returns[] = Mime_Helper::decodeQuotedPrintable($row['sender_name']);
-            } else {
-                $returns[] = $row['email'];
-            }
-        }
-        if ($multiple) {
-            return $returns;
+        if (!$address instanceof Address) {
+            $address = AddressHeader::fromString($address);
         }
 
-        return $returns[0];
+        $names = $address->getNames();
+
+        return $multiple ? $names : $names[0];
     }
 
     /**

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -118,27 +118,6 @@ class Mail_Helper
     }
 
     /**
-     * Method used to parse a string and return all email addresses contained
-     * within it.
-     *
-     * @param   string $str
-     /**
-     * Wrapper around Mail_RFC822::parseAddressList to avoid calling it statically
-     *
-     * @param string  $address         the address(es) to validate
-     * @param string  $default_domain  default domain/host etc
-     * @param bool $nest_groups     whether to return the structure with groups nested for easier viewing
-     * @param bool $validate        Whether to validate atoms. Turn this off if you need to run addresses through before encoding the personal names, for instance.
-     * @return array a structured array of addresses
-     */
-    public static function parseAddressList($address, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
-    {
-        $obj = new Mail_RFC822($address, $default_domain, $nest_groups, $validate, $limit);
-
-        return $obj->parseAddressList();
-    }
-
-    /**
      * Method used to build a properly quoted email address, in the form of
      * "Sender Name" <sender@example.com>.
      *

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -549,7 +549,7 @@ class Note
         $unknown_user = self::getUnknownUser($note_id);
         $structure = Mime_Helper::decode($blocked_message, true, true);
         $body = $structure->body;
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($structure->headers['from']));
+        $sender_email = Mail_Helper::getEmailAddress($structure->headers['from']);
 
         $current_usr_id = Auth::getUserID();
         if ($target == 'email') {

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -29,8 +29,9 @@ class Notification
      */
     public static function isSubscribedToEmails($issue_id, $email)
     {
-        $email = strtolower(Mail_Helper::getEmailAddress($email));
+        $email = Mail_Helper::getEmailAddress($email);
         if ($email == '@') {
+            // XXX: never happens with ZF, try catch above call?
             // broken address, don't send the email...
             return true;
         }
@@ -256,8 +257,8 @@ class Notification
     public static function isIssueRoutingSender($issue_id, $sender)
     {
         $check = self::getFixedFromHeader($issue_id, $sender, 'issue');
-        $check_email = strtolower(Mail_Helper::getEmailAddress($check));
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($sender));
+        $check_email = Mail_Helper::getEmailAddress($check);
+        $sender_email = Mail_Helper::getEmailAddress($sender);
         if ($check_email == $sender_email) {
             return true;
         }
@@ -282,7 +283,7 @@ class Notification
 
         $full_message = $message['full_email'];
         $sender = $message['from'];
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($sender));
+        $sender_email = Mail_Helper::getEmailAddress($sender);
 
         // get ID of whoever is sending this.
         $sender_usr_id = User::getUserIDByEmail($sender_email, true);
@@ -336,7 +337,7 @@ class Notification
                 }
                 if (($prefs['receive_copy_of_own_action'][$prj_id] == 0) &&
                         ((!empty($user['sub_usr_id'])) && ($sender_usr_id == $user['sub_usr_id']) ||
-                        (strtolower(Mail_Helper::getEmailAddress($email)) == $sender_email))) {
+                        (Mail_Helper::getEmailAddress($email) == $sender_email))) {
                     continue;
                 }
             }
@@ -2240,7 +2241,7 @@ class Notification
      */
     public static function update($issue_id, $sub_id, $email)
     {
-        $usr_id = User::getUserIDByEmail(strtolower(Mail_Helper::getEmailAddress($email)), true);
+        $usr_id = User::getUserIDByEmail(Mail_Helper::getEmailAddress($email), true);
         if (!empty($usr_id)) {
             $email = '';
         } else {

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -182,7 +182,7 @@ class Routing
         Mime_Helper::parse_output($structure, $parts);
 
         // get the sender's email address
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($structure->headers['from']));
+        $sender_email = Mail_Helper::getEmailAddress($structure->headers['from']);
 
         // strip out the warning message sent to staff users
         if (($setup['email_routing']['status'] == 'enabled') &&
@@ -495,7 +495,7 @@ class Routing
 
         $prj_id = Issue::getProjectID($issue_id);
         // check if the sender is allowed in this issue' project and if it is an internal user
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($structure->headers['from']));
+        $sender_email = Mail_Helper::getEmailAddress($structure->headers['from']);
         $sender_usr_id = User::getUserIDByEmail($sender_email, true);
         if (!empty($sender_usr_id)) {
             $sender_role = User::getRoleByUser($sender_usr_id, $prj_id);

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -233,7 +233,7 @@ class Setup
     /**
      * Method used to get the system-wide defaults.
      *
-     * @return  string array of the default preferences
+     * @return array of the default preferences
      */
     private static function getDefaults()
     {

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1344,7 +1344,7 @@ class Support
         }
 
         // figure out who should be the 'owner' of this attachment
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($input->headers['from']));
+        $sender_email = Mail_Helper::getEmailAddress($input->headers['from']);
         $usr_id = User::getUserIDByEmail($sender_email);
         $prj_id = Issue::getProjectID($issue_id);
         $unknown_user = false;
@@ -2526,7 +2526,7 @@ class Support
 
         $issue_id = $email['issue_id'];
         $prj_id = Issue::getProjectID($issue_id);
-        $sender_email = strtolower(Mail_Helper::getEmailAddress($email['from']));
+        $sender_email = Mail_Helper::getEmailAddress($email['from']);
         list($text_headers, $body) = Mime_Helper::splitHeaderBody($email['full_email']);
         if ((Mail_Helper::isVacationAutoResponder($email['headers'])) ||
                 (Notification::isBounceMessage($sender_email)) ||

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1246,10 +1246,11 @@ class Support
             if ((empty($row['sup_to'])) && (!empty($row['sup_iss_id']))) {
                 $row['sup_to'] = 'Notification List';
             } else {
-                $to = Mail_Helper::getName($row['sup_to']);
-                // Ignore unformattable headers
-                if (!Misc::isError($to)) {
-                    $row['sup_to'] = $to;
+                try {
+                    $row['sup_to'] = Mail_Helper::getName($row['sup_to']);
+                } catch (\Zend\Mail\Header\Exception\InvalidArgumentException $e) {
+                    // Ignore unformattable headers
+                    Logger::app()->error($e->getMessage(), ['exception' => $e]);
                 }
             }
             if (CRM::hasCustomerIntegration($prj_id)) {

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -18,6 +18,7 @@ use Mime_Helper;
 use Zend\Mail\Address;
 use Zend\Mail\AddressList;
 use Zend\Mail\Header\AbstractAddressList;
+use Zend\Mail\Header\HeaderInterface;
 use Zend\Mail\Header\To;
 
 /**
@@ -68,6 +69,16 @@ class AddressHeader
     public function getAddressList()
     {
         return $this->header->getAddressList();
+    }
+
+    /**
+     * @param bool $format Whether to Mime-Encode header or not
+     *
+     * @return string
+     */
+    public function toString($format = HeaderInterface::FORMAT_ENCODED)
+    {
+        return $this->header->getFieldValue($format);
     }
 
     /**

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -13,7 +13,10 @@
 
 namespace Eventum\Mail\Helper;
 
+use InvalidArgumentException;
 use Mime_Helper;
+use Zend\Mail\Address;
+use Zend\Mail\AddressList;
 use Zend\Mail\Header\AbstractAddressList;
 use Zend\Mail\Header\To;
 
@@ -60,10 +63,27 @@ class AddressHeader
     }
 
     /**
-     * @return \Zend\Mail\AddressList
+     * @return AddressList
      */
     public function getAddressList()
     {
         return $this->header->getAddressList();
+    }
+
+    /**
+     * Get Address object of the AddressList.
+     * The input may contain only one address.
+     *
+     * @return Address
+     */
+    public function getAddress()
+    {
+        $addressList = $this->getAddressList();
+        $count = $addressList->count();
+        if ($count !== 1) {
+            throw new InvalidArgumentException("Expected 1 address, got $count");
+        }
+
+        return $addressList->current();
     }
 }

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -34,6 +34,11 @@ class AddressHeader
         $this->header = $addresses;
     }
 
+    /**
+     * @param string $addresses
+     * @throws \Zend\Mail\Header\Exception\InvalidArgumentException
+     * @return static
+     */
     public static function fromString($addresses)
     {
         // avoid exceptions if NULL or empty string passed as input
@@ -49,15 +54,32 @@ class AddressHeader
     }
 
     /**
-     * Collect email addresses from addresslist
+     * Collect email addresses from AddressList
      *
-     * @return array
+     * @return string[]
      */
     public function getEmails()
     {
         $res = [];
         foreach ($this->header->getAddressList() as $address) {
             $res[] = $address->getEmail();
+        }
+
+        return $res;
+    }
+
+    /**
+     * Collect display names from AddressList.
+     * If display name is missing email is used.
+     *
+     * @return string[]
+     */
+    public function getNames()
+    {
+        $res = [];
+        foreach ($this->header->getAddressList() as $address) {
+            $name = $address->getName();
+            $res[] = $name ? $name : $address->getEmail();
         }
 
         return $res;

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -44,6 +44,11 @@ class AddressHeader
         return new static(To::fromString('To:' . $addresses));
     }
 
+    /**
+     * Collect email addresses from addresslist
+     *
+     * @return array
+     */
     public function getEmails()
     {
         $res = [];
@@ -52,5 +57,13 @@ class AddressHeader
         }
 
         return $res;
+    }
+
+    /**
+     * @return \Zend\Mail\AddressList
+     */
+    public function getAddressList()
+    {
+        return $this->header->getAddressList();
     }
 }

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -325,6 +325,8 @@ class MailHelperTest extends TestCase
     public function testFormatEmailAddresses($input, $exp)
     {
         $res = Mail_Helper::formatEmailAddresses($input);
+        // spaces are irrelevant
+        $res = preg_replace("/\s+/", ' ', $res);
         $this->assertEquals($exp, $res);
     }
 
@@ -337,11 +339,11 @@ class MailHelperTest extends TestCase
             ],
             [
                 'Test Name <test@example.com>,blah@example.com',
-                '"Test Name" <test@example.com>, blah@example.com',
+                'Test Name <test@example.com>, blah@example.com',
             ],
             [
                 '"Bob O\'Reilly" <bob@example.com>,blah@example.com',
-                '"Bob O\'Reilly" <bob@example.com>, blah@example.com',
+                'Bob O\'Reilly <bob@example.com>, blah@example.com',
             ],
             ['', ''],
         ];

--- a/tests/MailHelperTest.php
+++ b/tests/MailHelperTest.php
@@ -69,9 +69,6 @@ class MailHelperTest extends TestCase
 
     /**
      * test that @see Support::addExtraRecipientsToNotificationList adds cc addresses that are not 7bit
-     * but @see Mail_Helper::getEmailAddresses results errors
-     * because @see Mail_Helper::fixAddressQuoting encodes just wrong.
-     * test the alternative implementation using Zend Mail
      *
      * @dataProvider validGetEmailAddressesData
      */


### PR DESCRIPTION
the changes are done, but they need good testing, as i had to assume what some methods return. i.e RAW or QP-encoded. and the results are different, but still valid. however if eventum combines result by it's own then the statement is no longer true.