### PR TITLE
add ExtensionLoader class

### DIFF
--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -304,8 +304,8 @@ abstract class CRM
             APP_LOCAL_PATH . '/crm',
         ];
 
-        $extensionLoader = new ExtensionLoader();
-        $files = $extensionLoader->getFileList($dirs);
+        $extensionLoader = new ExtensionLoader($dirs);
+        $files = $extensionLoader->getFileList();
 
         $list = [];
         foreach ($files as $file => $classname) {

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -299,14 +299,7 @@ abstract class CRM
      */
     public static function getBackendList()
     {
-        $files = static::getExtensionLoader()->getFileList();
-
-        $list = [];
-        foreach ($files as $file => $classname) {
-            $list['class.' . $file . '.php'] = $classname;
-        }
-
-        return $list;
+        return static::getExtensionLoader()->getFileList();
     }
 
     /**
@@ -773,6 +766,6 @@ abstract class CRM
             APP_LOCAL_PATH . '/crm',
         ];
 
-        return new ExtensionLoader($dirs);
+        return new ExtensionLoader($dirs, '%s', 'CRM');
     }
 }

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -13,6 +13,7 @@
 
 use Eventum\Db\Adapter\AdapterInterface;
 use Eventum\Db\DatabaseException;
+use Eventum\Extension\ExtensionLoader;
 
 define('CRM_EXCLUDE_EXPIRED', 'exclude_expired');
 
@@ -298,11 +299,17 @@ abstract class CRM
      */
     public static function getBackendList()
     {
-        $files = Misc::getFileList(APP_INC_PATH . 'crm/');
-        $files = array_merge($files, Misc::getFileList(APP_LOCAL_PATH . '/crm'));
+        $dirs = [
+            APP_INC_PATH . '/crm',
+            APP_LOCAL_PATH . '/crm',
+        ];
+
+        $extensionLoader = new ExtensionLoader();
+        $files = $extensionLoader->getFileList($dirs);
+
         $list = [];
-        foreach ($files as $file) {
-            $list['class.' . $file . '.php'] = $file;
+        foreach ($files as $file => $classname) {
+            $list['class.' . $file . '.php'] = $classname;
         }
 
         return $list;

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -299,13 +299,7 @@ abstract class CRM
      */
     public static function getBackendList()
     {
-        $dirs = [
-            APP_INC_PATH . '/crm',
-            APP_LOCAL_PATH . '/crm',
-        ];
-
-        $extensionLoader = new ExtensionLoader($dirs);
-        $files = $extensionLoader->getFileList();
+        $files = static::getExtensionLoader()->getFileList();
 
         $list = [];
         foreach ($files as $file => $classname) {
@@ -353,7 +347,7 @@ abstract class CRM
      * given project ID, instantiates it and returns the class.
      *
      * @param   int $prj_id The project ID
-     * @return  bool
+     * @return bool|CRM
      */
     private static function getBackendByProject($prj_id)
     {
@@ -375,17 +369,8 @@ abstract class CRM
      */
     private static function getBackend($backend_class, $prj_id)
     {
-        $file_name_chunks = explode('.', $backend_class);
-        $class_name = $file_name_chunks[1];
-
-        if (file_exists(APP_LOCAL_PATH . "/crm/$class_name/$backend_class")) {
-            require_once APP_LOCAL_PATH . '/crm/' . $class_name . "/$backend_class";
-        } else {
-            require_once APP_INC_PATH . '/crm/backends/' . $class_name . "/$backend_class";
-        }
-
         /** @var CRM $backend */
-        $backend = new $class_name();
+        $backend = static::getExtensionLoader()->createInstance($backend_class);
         $backend->setup($prj_id);
         $backend->prj_id = $prj_id;
 
@@ -776,5 +761,18 @@ abstract class CRM
         } catch (CRMException $e) {
             return null;
         }
+    }
+
+    /**
+     * @return ExtensionLoader
+     */
+    private static function getExtensionLoader()
+    {
+        $dirs = [
+            APP_INC_PATH . '/crm',
+            APP_LOCAL_PATH . '/crm',
+        ];
+
+        return new ExtensionLoader($dirs);
     }
 }

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1841,6 +1841,6 @@ class Custom_Field
             APP_LOCAL_PATH . '/custom_field',
         ];
 
-        return new ExtensionLoader($dirs, '%_Custom_Field_Backend');
+        return new ExtensionLoader($dirs, '%s_Custom_Field_Backend');
     }
 }

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1633,9 +1633,9 @@ class Custom_Field
             APP_LOCAL_PATH . '/custom_field',
         ];
 
-        $extensionLoader = new ExtensionLoader();
+        $extensionLoader = new ExtensionLoader($dirs, '%_Custom_Field_Backend');
 
-        return $extensionLoader->getFileList($dirs);
+        return $extensionLoader->getFileList();
     }
 
     /**

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Db\DatabaseException;
+use Eventum\Extension\ExtensionLoader;
 
 /**
  * Class to handle the business logic related to the administration
@@ -1627,18 +1628,14 @@ class Custom_Field
      */
     public static function getBackendList()
     {
-        $list = [];
-        $files = Misc::getFileList(APP_INC_PATH . '/custom_field');
-        $files = array_merge($files, Misc::getFileList(APP_LOCAL_PATH . '/custom_field'));
-        foreach ($files as $file) {
-            // make sure we only list the backends
-            if (preg_match('/^class\.(.*)\.php$/', $file)) {
-                // display a prettyfied backend name in the admin section
-                $list[$file] = self::getBackendName($file);
-            }
-        }
+        $dirs = [
+            APP_INC_PATH . '/custom_field',
+            APP_LOCAL_PATH . '/custom_field',
+        ];
 
-        return $list;
+        $extensionLoader = new ExtensionLoader();
+
+        return $extensionLoader->getFileList($dirs);
     }
 
     /**

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -356,8 +356,8 @@ class Misc
     }
 
     /**
-     * Method used to get the full list of files contained in a specific
-     * directory.
+     * Method used to get the list of files contained in a specific
+     * directory with their absolute paths.
      *
      * @param   string $directory The path to list the files from
      * @return  array The list of files
@@ -370,7 +370,7 @@ class Misc
             if (($item == '.') || ($item == '..') || ($item == 'CVS') || ($item == 'SCCS')) {
                 continue;
             }
-            $files[] = $item;
+            $files[] = "$directory/$item";
         }
 
         return $files;

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Db\DatabaseException;
+use Eventum\Extension\ExtensionLoader;
 
 /**
  * Handles the interactions between Eventum and partner backends.
@@ -306,20 +307,23 @@ class Partner
      */
     public static function getBackendList()
     {
-        $files = Misc::getFileList(APP_INC_PATH . '/partner');
-        $files = array_merge($files, Misc::getFileList(APP_LOCAL_PATH . '/partner'));
-        $list = [];
-        foreach ($files as $file) {
-            // display a prettyfied backend name in the admin section
+        $dirs = [
+            APP_INC_PATH . '/partner',
+            APP_LOCAL_PATH . '/partner',
+        ];
+
+        $extensionLoader = new ExtensionLoader();
+        $files = $extensionLoader->getFileList($dirs);
+
+        foreach ($files as $file => $classname) {
             if (preg_match('/^class\.(.*)\.php$/', $file, $matches)) {
                 if (substr($matches[1], 0, 8) == 'abstract') {
-                    continue;
+                    unset($files[$file]);
                 }
-                $list[$file] = $matches[1];
             }
         }
 
-        return $list;
+        return $files;
     }
 
     public static function getName($par_code)

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -32,17 +32,9 @@ class Partner
 
         if (empty($setup_backends[$par_code])) {
             $file_name = 'class.' . $par_code . '.php';
-            $class_name = $par_code . '_Partner_Backend';
 
-            if (file_exists(APP_LOCAL_PATH . "/partner/$file_name")) {
-                /** @noinspection PhpIncludeInspection */
-                require_once APP_LOCAL_PATH . "/partner/$file_name";
-            } else {
-                /** @noinspection PhpIncludeInspection */
-                require_once APP_INC_PATH . "/partner/$file_name";
-            }
-
-            $setup_backends[$par_code] = new $class_name();
+            $instance = static::getExtensionLoader()->createInstance($file_name);
+            $setup_backends[$par_code] = $instance;
         }
 
         return $setup_backends[$par_code];
@@ -303,18 +295,11 @@ class Partner
     /**
      * Returns a list of backends available
      *
-     * @return  array An array of workflow backends
+     * @return  array An array of partner backends
      */
     public static function getBackendList()
     {
-        $dirs = [
-            APP_INC_PATH . '/partner',
-            APP_LOCAL_PATH . '/partner',
-        ];
-
-        $extensionLoader = new ExtensionLoader($dirs, '%s_Partner_Backend');
-
-        return $extensionLoader->getFileList();
+        return static::getExtensionLoader()->getFileList();
     }
 
     public static function getName($par_code)
@@ -404,5 +389,18 @@ class Partner
         }
 
         return null;
+    }
+
+    /**
+     * @return ExtensionLoader
+     */
+    private static function getExtensionLoader()
+    {
+        $dirs = [
+            APP_INC_PATH . '/partner',
+            APP_LOCAL_PATH . '/partner',
+        ];
+
+        return new ExtensionLoader($dirs, '%s_Partner_Backend');
     }
 }

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -312,18 +312,9 @@ class Partner
             APP_LOCAL_PATH . '/partner',
         ];
 
-        $extensionLoader = new ExtensionLoader();
-        $files = $extensionLoader->getFileList($dirs);
+        $extensionLoader = new ExtensionLoader($dirs, '%s_Partner_Backend');
 
-        foreach ($files as $file => $classname) {
-            if (preg_match('/^class\.(.*)\.php$/', $file, $matches)) {
-                if (substr($matches[1], 0, 8) == 'abstract') {
-                    unset($files[$file]);
-                }
-            }
-        }
-
-        return $files;
+        return $extensionLoader->getFileList();
     }
 
     public static function getName($par_code)

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Db\DatabaseException;
+use Eventum\Extension\ExtensionLoader;
 use Eventum\Mail\MailMessage;
 use Eventum\Model\Entity;
 
@@ -24,21 +25,17 @@ class Workflow
      */
     public static function getBackendList()
     {
-        $files = Misc::getFileList(APP_INC_PATH . '/workflow');
-        $files = array_merge($files, Misc::getFileList(APP_LOCAL_PATH . '/workflow'));
-        $list = [];
-        foreach ($files as $file) {
-            // display a prettyfied backend name in the admin section
-            if (preg_match('/^class\.(.*)\.php$/', $file, $matches)) {
-                if ($matches[1] == 'abstract_workflow_backend') {
-                    continue;
-                }
-                $name = ucwords(str_replace('_', ' ', $matches[1]));
-                $list[$file] = $name;
-            }
-        }
+        $dirs = [
+            APP_INC_PATH . '/workflow',
+            APP_LOCAL_PATH . '/workflow',
+        ];
 
-        return $list;
+        $extensionLoader = new ExtensionLoader();
+        $files = $extensionLoader->getFileList($dirs);
+
+        unset($files['class.abstract_workflow_backend.php']);
+
+        return $files;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -30,8 +30,8 @@ class Workflow
             APP_LOCAL_PATH . '/workflow',
         ];
 
-        $extensionLoader = new ExtensionLoader();
-        $files = $extensionLoader->getFileList($dirs);
+        $extensionLoader = new ExtensionLoader($dirs, '%s_Workflow_Backend');
+        $files = $extensionLoader->getFileList();
 
         unset($files['class.abstract_workflow_backend.php']);
 

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -27,8 +27,6 @@ class Workflow
     {
         $files = static::getExtensionLoader()->getFileList();
 
-        unset($files['class.abstract_workflow_backend.php']);
-
         return $files;
     }
 

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -67,7 +67,7 @@ class Workflow
      * given project ID, instantiates it and returns the class.
      *
      * @param   int $prj_id The project ID
-     * @return  Abstract_Workflow_Backend
+     * @return bool|Abstract_Workflow_Backend
      */
     public static function _getBackend($prj_id)
     {
@@ -92,7 +92,7 @@ class Workflow
      * Checks whether the given project ID is setup to use workflow integration
      * or not.
      *
-     * @param   int integer $prj_id The project ID
+     * @param   int $prj_id The project ID
      * @return  bool
      */
     public static function hasWorkflowIntegration($prj_id)

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -82,6 +82,8 @@ class Workflow
             }
 
             $instance = static::getExtensionLoader()->createInstance($filename);
+            $instance->prj_id = $prj_id;
+
             $setup_backends[$prj_id] = $instance;
         }
 

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -20,6 +20,14 @@ use Eventum\Model\Entity;
 class Abstract_Workflow_Backend
 {
     /**
+     * Project Id this Workflow was created for.
+     * The value is set by Eventum Core.
+     *
+     * @var int
+     */
+    public $prj_id;
+
+    /**
      * Interface for using config values within Workflow class.
      *
      * To read an option:
@@ -667,6 +675,7 @@ class Abstract_Workflow_Backend
 
     /**
      * Downgrade config: remove all EncryptedValue elements
+     *
      * @see \Eventum\Crypto\CryptoUpgradeManager::downgradeConfig
      *
      * @since 3.1.0

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use Misc;
+
+class ExtensionLoader
+{
+    /**
+     * Get Filename -> Classname of extensions found
+     *
+     * @return array
+     */
+    public function getFileList($paths)
+    {
+        $list = $files = [];
+        foreach ($paths as $path) {
+            $files = array_merge($files, Misc::getFileList($path));
+        }
+
+        foreach ($files as $file) {
+            // make sure we only list the backends
+            if (!preg_match('/^class\.(.*)\.php$/', $file)) {
+                continue;
+            }
+
+            $list[$file] = $this->getClassname($file);
+        }
+
+        return $list;
+    }
+
+    /**
+     * Returns the 'pretty' name of the backend
+     *
+     * @param string $backend The full backend file name
+     * @return string the pretty name of the backend
+     */
+    private function getClassname($backend)
+    {
+        preg_match('/^class\.(.*)\.php$/', $backend, $matches);
+
+        return ucwords(str_replace('_', ' ', $matches[1]));
+    }
+}

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -30,12 +30,14 @@ class ExtensionLoader
         }
 
         foreach ($files as $file) {
+            $fileName = basename($file);
+
             // make sure we only list the backends
-            if (!preg_match('/^class\.(.*)\.php$/', $file)) {
+            if (!preg_match('/^class\.(.+)\.php$/', $file)) {
                 continue;
             }
 
-            $list[$file] = $this->getClassname($file);
+            $list[$fileName] = $this->getDisplayName($fileName);
         }
 
         return $list;
@@ -44,13 +46,11 @@ class ExtensionLoader
     /**
      * Returns the 'pretty' name of the backend
      *
-     * @param string $backend The full backend file name
-     * @return string the pretty name of the backend
+     * @param string $fileName
+     * @return string
      */
-    private function getClassname($backend)
+    private function getDisplayName($fileName)
     {
-        preg_match('/^class\.(.*)\.php$/', $backend, $matches);
-
-        return ucwords(str_replace('_', ' ', $matches[1]));
+        return ucwords(str_replace('_', ' ', $fileName));
     }
 }

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -99,11 +99,6 @@ class ExtensionLoader
             return false;
         }
 
-        // TODO: move abstract classes elsewhere
-        if (substr(strtolower($className), 0, 9) == 'abstract_') {
-            return false;
-        }
-
         // autoload, or load manually
         if (!class_exists($className)) {
             require_once $filename;

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -25,16 +25,21 @@ class ExtensionLoader
     /** @var string */
     private $classFormat;
 
+    /** @var string */
+    private $parent_class;
+
     /**
      * ExtensionLoader constructor.
      *
      * @param array|string $paths
      * @param string $classFormat format for creating class from filename
+     * @param string $parent_class Only include classes that are a subclass of this
      */
-    public function __construct($paths, $classFormat = null)
+    public function __construct($paths, $classFormat = null, $parent_class = null)
     {
         $this->paths = is_string($paths) ? [$paths] : $paths;
         $this->classFormat = $classFormat;
+        $this->parent_class = $parent_class;
     }
 
     /**
@@ -75,6 +80,10 @@ class ExtensionLoader
             $className = $this->getClassName($fileName);
 
             if (!$this->isExtension($file, $className)) {
+                continue;
+            }
+
+            if ($this->parent_class && !is_subclass_of($className, $this->parent_class)) {
                 continue;
             }
 

--- a/upgrade/patches/39_var_paths.php
+++ b/upgrade/patches/39_var_paths.php
@@ -41,6 +41,7 @@ if (!$files) {
 $count = count($files);
 $log("Migrating $count files from $old_dir to $new_dir");
 foreach ($files as $file) {
+    $file = basename($file);
     $old_file = "$old_dir/$file";
     $new_file = "$new_dir/$file";
     $res = copy($old_file, $new_file);


### PR DESCRIPTION
ExtensionLoader encapsulates repeated code for loading "backends".

changed also how classes are listed, abstract classes are automatically skipped.

also crm had different naming convention, perhaps allow such breakage and unify it's filename to classname mapping with other backends?

i have no examples how the crm files should be named (documentation did not explain it either).

also crm has such hack, perhaps it could be dropped by defining new standard and naming convention:

```php
            $list['class.' . $file . '.php'] = $classname;
```

maybe also move them to namespace `Eventum\CRM` under psr-1:
- lib/eventum/crm/* -> src/CRM/

if so, i'd do that in separate PR