### PR TITLE
add extension support for workflows/customfields/partners/crm

### DIFF
--- a/db/migrations/20170512210935_eventum_extension_class.php
+++ b/db/migrations/20170512210935_eventum_extension_class.php
@@ -26,6 +26,8 @@ class EventumExtensionClass extends AbstractMigration
         $this->modifyColumn('custom_field', 'fld_backend', ['null' => true]);
         $this->modifyColumn('project', 'prj_customer_backend', ['null' => true]);
         $this->modifyColumn('project', 'prj_workflow_backend', ['null' => true]);
+        $this->modifyColumn('user', 'usr_par_code', ['null' => true]);
+        $this->modifyColumn('issue_partner', 'ipa_par_code');
     }
 
     private function modifyColumn($table, $column, $options = [])

--- a/db/migrations/20170512210935_eventum_extension_class.php
+++ b/db/migrations/20170512210935_eventum_extension_class.php
@@ -11,27 +11,27 @@
  * that were distributed with this source code.
  */
 
-use Phinx\Migration\AbstractMigration;
+use Eventum\Db\AbstractMigration;
 
 class EventumExtensionClass extends AbstractMigration
 {
     /**
-     * change() doesn't support MODIFY statement
-     * there's no down() because we just increase width here
+     * changeColumn() doesn't support down(),
+     * and we don't implement it ourselves,
+     * because it's just width increase change.
      */
     public function up()
     {
-        $notNullable = 'VARCHAR(255) CHARACTER SET ASCII NOT NULL';
-        $nullable = 'VARCHAR(255) CHARACTER SET ASCII DEFAULT NULL';
-
-        $this->modifyColumn('partner_project', 'pap_par_code', $notNullable);
-        $this->modifyColumn('custom_field', 'fld_backend', $nullable);
-        $this->modifyColumn('project', 'prj_customer_backend', $nullable);
-        $this->modifyColumn('project', 'prj_workflow_backend', $nullable);
+        $this->modifyColumn('partner_project', 'pap_par_code');
+        $this->modifyColumn('custom_field', 'fld_backend', ['null' => true]);
+        $this->modifyColumn('project', 'prj_customer_backend', ['null' => true]);
+        $this->modifyColumn('project', 'prj_workflow_backend', ['null' => true]);
     }
 
-    private function modifyColumn($table, $column, $definition)
+    private function modifyColumn($table, $column, $options = [])
     {
-        return $this->execute("ALTER TABLE `{$table}` MODIFY `{$column}` {$definition}");
+        $options += ['limit' => self::TEXT_TINY, 'encoding' => 'ascii'];
+        $this->table($table)
+            ->changeColumn($column, 'string', $options);
     }
 }

--- a/db/migrations/20170512210935_eventum_extension_class.php
+++ b/db/migrations/20170512210935_eventum_extension_class.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Phinx\Migration\AbstractMigration;
+
+class EventumExtensionClass extends AbstractMigration
+{
+    /**
+     * change() doesn't support MODIFY statement
+     * there's no down() because we just increase width here
+     */
+    public function up()
+    {
+        $notNullable = 'VARCHAR(255) CHARACTER SET ASCII NOT NULL';
+        $nullable = 'VARCHAR(255) CHARACTER SET ASCII DEFAULT NULL';
+
+        $this->modifyColumn('partner_project', 'pap_par_code', $notNullable);
+        $this->modifyColumn('custom_field', 'fld_backend', $nullable);
+        $this->modifyColumn('project', 'prj_customer_backend', $nullable);
+        $this->modifyColumn('project', 'prj_workflow_backend', $nullable);
+    }
+
+    private function modifyColumn($table, $column, $definition)
+    {
+        return $this->execute("ALTER TABLE `{$table}` MODIFY `{$column}` {$definition}");
+    }
+}

--- a/db/migrations/20170512222549_eventum_extension_migrate_db.php
+++ b/db/migrations/20170512222549_eventum_extension_migrate_db.php
@@ -84,7 +84,11 @@ class EventumExtensionMigrateDb extends AbstractMigration
             // lookup filename to class name
             $backend = $callback($value);
             $rc = new ReflectionClass($backend);
-            $class = $rc->getName();
+            $classname = $rc->getName();
+
+            // use deterministic class name
+            $classname = ucwords(str_replace('_', ' ', $classname));
+            $classname = str_replace(' ', '_', $classname);
 
             // there's no placeholders support,
             // method to escape values not exported
@@ -93,7 +97,7 @@ class EventumExtensionMigrateDb extends AbstractMigration
             //
             // last known PR implementing params for execute:
             // https://github.com/robmorgan/phinx/pull/850
-            $stmt = "UPDATE {$table} SET {$column} = '{$class}' WHERE {$column} = '{$value}'";
+            $stmt = "UPDATE {$table} SET {$column} = '{$classname}' WHERE {$column} = '{$value}'";
             $this->execute($stmt);
         }
     }

--- a/db/migrations/20170512222549_eventum_extension_migrate_db.php
+++ b/db/migrations/20170512222549_eventum_extension_migrate_db.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumExtensionMigrateDb extends AbstractMigration
+{
+    public function up()
+    {
+        $this->migratePartners();
+        $this->migrateCustomFields();
+        $this->migrateWorkflows();
+        $this->migrateCustomers();
+    }
+
+    private function migratePartners()
+    {
+        $callback = function ($code) {
+            return Partner::getBackend($code);
+        };
+        $this->migrate('partner_project', 'pap_par_code', $callback);
+    }
+
+    private function migrateCustomFields()
+    {
+        $callback = function ($code) {
+            return Workflow::_getBackend($code);
+        };
+        $this->migrate('custom_field', 'fld_backend', $callback);
+    }
+
+    private function migrateWorkflows()
+    {
+        $callback = function ($code) {
+            return Workflow::_getBackend($code);
+        };
+        $this->migrate('project', 'prj_workflow_backend', $callback);
+    }
+
+    private function migrateCustomers()
+    {
+        $callback = function ($code) {
+            return CRM::_getBackend($code);
+        };
+        $this->migrate('project', 'prj_customer_backend', $callback);
+    }
+
+    private function migrate($table, $field, $callback)
+    {
+        $table = $this->getAdapter()->quoteColumnName($table);
+        $column = $this->getAdapter()->quoteTableName($field);
+
+        $st = $this->query("SELECT {$column} FROM {$table}");
+        foreach ($st as $row) {
+            $value = $row[$field];
+            // nothing to convert for empty values
+            if (!$value) {
+                continue;
+            }
+
+            // lookup filename to class name
+            $backend = $callback($value);
+            $rc = new ReflectionClass($backend);
+            $class = $rc->getName();
+
+            // there's no placeholders support,
+            // method to escape values not exported
+            // but the class names should not need sql escaping
+            // so just go with unescaped variant
+            //
+            // last known PR implementing params for execute:
+            // https://github.com/robmorgan/phinx/pull/850
+            $stmt = "UPDATE {$table} SET {$column} = '{$class}' WHERE {$column} = '{$value}'";
+            $this->execute($stmt);
+        }
+    }
+}

--- a/db/migrations/20170512222549_eventum_extension_migrate_db.php
+++ b/db/migrations/20170512222549_eventum_extension_migrate_db.php
@@ -73,7 +73,7 @@ class EventumExtensionMigrateDb extends AbstractMigration
         $table = $this->getAdapter()->quoteColumnName($table);
         $column = $this->getAdapter()->quoteTableName($field);
 
-        $st = $this->query("SELECT {$column} FROM {$table}");
+        $st = $this->query("SELECT DISTINCT {$column} FROM {$table}");
         foreach ($st as $row) {
             $value = $row[$field];
             // nothing to convert for empty values

--- a/db/migrations/20170512222549_eventum_extension_migrate_db.php
+++ b/db/migrations/20170512222549_eventum_extension_migrate_db.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Db\AbstractMigration;
+use Eventum\Extension\BuiltinLegacyLoaderExtension;
 
 class EventumExtensionMigrateDb extends AbstractMigration
 {
@@ -21,6 +22,18 @@ class EventumExtensionMigrateDb extends AbstractMigration
         $this->migrateCustomFields();
         $this->migrateWorkflows();
         $this->migrateCustomers();
+        $this->setupLegacyLoader();
+    }
+
+    /**
+     * Setup BuiltinLegacyLoaderExtension being loaded by default
+     */
+    private function setupLegacyLoader()
+    {
+        $setup = Setup::get();
+        $rf = new ReflectionClass(BuiltinLegacyLoaderExtension::class);
+        $setup['extensions'][$rf->getName()] = $rf->getFileName();
+        Setup::save();
     }
 
     private function migratePartners()
@@ -34,7 +47,7 @@ class EventumExtensionMigrateDb extends AbstractMigration
     private function migrateCustomFields()
     {
         $callback = function ($code) {
-            return Workflow::_getBackend($code);
+            return Custom_Field::_getBackend($code);
         };
         $this->migrate('custom_field', 'fld_backend', $callback);
     }
@@ -42,7 +55,7 @@ class EventumExtensionMigrateDb extends AbstractMigration
     private function migrateWorkflows()
     {
         $callback = function ($code) {
-            return Workflow::_getBackend($code);
+            return Workflow::getBackend($code);
         };
         $this->migrate('project', 'prj_workflow_backend', $callback);
     }

--- a/db/migrations/20170512222549_eventum_extension_migrate_db.php
+++ b/db/migrations/20170512222549_eventum_extension_migrate_db.php
@@ -41,6 +41,8 @@ class EventumExtensionMigrateDb extends AbstractMigration
     {
         $el = Partner::getExtensionLoader();
         $this->migrate('partner_project', 'pap_par_code', $el);
+        $this->migrate('user', 'usr_par_code', $el);
+        $this->migrate('issue_partner', 'ipa_par_code', $el);
     }
 
     private function migrateCustomFields()

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+/**
+ * Example Eventum Extension.
+ *
+ * To enable this extension, write to config/setup.php:
+ *
+ * 'extensions' => [
+ *   'Eventum\\Extension\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
+ * ],
+ *
+ * Class doc comment will be used to describe purpose or add documentation.
+ */
+class ExampleExtension extends AbstractExtension
+{
+    /**
+     * Method invoked so the extension can setup class loader.
+     *
+     * @param \Composer\Autoload\ClassLoader $loader
+     * @since 3.2.0
+     */
+    public function registerAutoloader($loader)
+    {
+        $phpDir = '/usr/share/php';
+        $baseDir = '/usr/src/eventum-workflow';
+
+        $classmap = [
+            'example_Workflow_Backend' => $baseDir . '/src/Workflow/example_Workflow_Backend.php',
+        ];
+        $psr0 = [
+            'Pimple\\' => $phpDir,
+        ];
+        $psr4 = [
+            'Eventum\\Example\\' => [$baseDir . '/src'],
+        ];
+
+        $loader->addClassMap($classmap);
+
+        foreach ($psr0 as $namespace => $path) {
+            $loader->add($namespace, $path);
+        }
+
+        foreach ($psr4 as $namespace => $path) {
+            $loader->setPsr4($namespace, $path);
+        }
+    }
+
+    /**
+     * Return list of workflow classes.
+     *
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getAvailableWorkflows()
+    {
+        return [
+            'example_Workflow_Backend',
+        ];
+    }
+
+    /**
+     * Return list of custom field classes.
+     *
+     * @return string[]
+     */
+    public function getAvailableCustomFields()
+    {
+        return [
+        ];
+    }
+
+    /**
+     * Return list of partner classes.
+     *
+     * @return string[]
+     */
+    public function getAvailablePartners()
+    {
+        return [
+            'PartnerBackend',
+            'Example\\PartnerX',
+        ];
+    }
+
+    /**
+     * Return list of CRM classes.
+     *
+     * @return string[]
+     */
+    public function getAvailableCRMs()
+    {
+        return [
+            'Example\\CRM',
+        ];
+    }
+}

--- a/globals.php
+++ b/globals.php
@@ -19,3 +19,13 @@ define('APP_PATH', __DIR__);
 define('APP_CONFIG_PATH', APP_PATH . '/config');
 define('APP_INC_PATH', APP_PATH . '/lib/eventum');
 define('APP_SETUP_FILE', APP_CONFIG_PATH . '/setup.php');
+
+// /var path for writable data
+define('APP_VAR_PATH', APP_PATH . '/var');
+
+// define other paths
+define('APP_TPL_PATH', APP_PATH . '/templates');
+define('APP_TPL_COMPILE_PATH', APP_VAR_PATH . '/cache');
+define('APP_LOCKS_PATH', APP_VAR_PATH . '/lock');
+define('APP_LOG_PATH', APP_VAR_PATH . '/log');
+define('APP_ERROR_LOG', APP_LOG_PATH . '/errors.log');

--- a/globals.php
+++ b/globals.php
@@ -17,3 +17,5 @@ define('APP_VERSION', '3.2.0-dev');
 // base path
 define('APP_PATH', __DIR__);
 define('APP_CONFIG_PATH', APP_PATH . '/config');
+define('APP_INC_PATH', APP_PATH . '/lib/eventum');
+define('APP_SETUP_FILE', APP_CONFIG_PATH . '/setup.php');

--- a/init.php
+++ b/init.php
@@ -54,8 +54,6 @@ $define('APP_COOKIE', 'eventum');
 $define('APP_VAR_PATH', APP_PATH . '/var');
 
 // define other paths
-$define('APP_SETUP_FILE', APP_CONFIG_PATH . '/setup.php');
-$define('APP_INC_PATH', APP_PATH . '/lib/eventum');
 $define('APP_TPL_PATH', APP_PATH . '/templates');
 $define('APP_TPL_COMPILE_PATH', APP_VAR_PATH . '/cache');
 $define('APP_LOCKS_PATH', APP_VAR_PATH . '/lock');

--- a/init.php
+++ b/init.php
@@ -50,16 +50,6 @@ require_once APP_CONFIG_PATH . '/config.php';
 $define('APP_LOCAL_PATH', APP_CONFIG_PATH);
 $define('APP_COOKIE', 'eventum');
 
-// /var path for writable data
-$define('APP_VAR_PATH', APP_PATH . '/var');
-
-// define other paths
-$define('APP_TPL_PATH', APP_PATH . '/templates');
-$define('APP_TPL_COMPILE_PATH', APP_VAR_PATH . '/cache');
-$define('APP_LOCKS_PATH', APP_VAR_PATH . '/lock');
-$define('APP_LOG_PATH', APP_VAR_PATH . '/log');
-$define('APP_ERROR_LOG', APP_LOG_PATH . '/errors.log');
-
 // define the user_id of system user
 $define('APP_SYSTEM_USER_ID', 1);
 

--- a/init.php
+++ b/init.php
@@ -136,3 +136,4 @@ $define('APP_EVENTUM_IRC_CATEGORY_DEFAULT', 'default');
 $define('APP_EVENTUM_IRC_CATEGORY_REMINDER', APP_EVENTUM_IRC_CATEGORY_DEFAULT);
 
 Eventum\DebugBar::initialize();
+Eventum\Extension\ExtensionManager::getManager();

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -356,17 +356,32 @@ abstract class CRM
     }
 
     /**
+     * @internal
+     * @param string $backend_class
+     * @return CRM
+     * @deprecated will be removed in 3.3.0
+     */
+    public static function _getBackend($backend_class)
+    {
+        /** @var CRM $crm */
+        $crm = static::getExtensionLoader()->createInstance($backend_class);
+
+        return $crm;
+    }
+
+    /**
      * Returns the backend for the specified class name
      *
+     * @internal
      * @param string $backend_class
      * @param int $prj_id
      * @internal param string $class_name The name of the class
      * @return CRM
+     * @deprecated will be removed in 3.3.0
      */
-    private static function getBackend($backend_class, $prj_id)
+    public static function getBackend($backend_class, $prj_id)
     {
-        /** @var CRM $backend */
-        $backend = static::getExtensionLoader()->createInstance($backend_class);
+        $backend = self::_getBackend($backend_class);
         $backend->setup($prj_id);
         $backend->prj_id = $prj_id;
 

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -296,16 +296,6 @@ abstract class CRM
     }
 
     /**
-     * Returns the list of available customer backends.
-     *
-     * @return array
-     */
-    public static function getBackendList()
-    {
-        return static::getExtensionLoader()->getExtensions();
-    }
-
-    /**
      * Returns the customer backend class file associated with the given
      * project ID.
      *

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -296,14 +296,13 @@ abstract class CRM
     }
 
     /**
-     * Returns the list of available customer backends by listing the class
-     * files in the backend directory.
+     * Returns the list of available customer backends.
      *
-     * @return  array Associative array of filename => name
+     * @return array
      */
     public static function getBackendList()
     {
-        return static::getExtensionLoader()->getFileList();
+        return static::getExtensionLoader()->getExtensions();
     }
 
     /**

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -342,35 +342,8 @@ abstract class CRM
             return false;
         }
 
-        return self::getBackend($backend_class, $prj_id);
-    }
-
-    /**
-     * @internal
-     * @param string $backend_class
-     * @return CRM
-     * @deprecated will be removed in 3.3.0
-     */
-    public static function _getBackend($backend_class)
-    {
-        /** @var CRM $crm */
-        $crm = static::getExtensionLoader()->createInstance($backend_class);
-
-        return $crm;
-    }
-
-    /**
-     * Returns the backend for the specified class name
-     *
-     * @param string $backend_class
-     * @param int $prj_id
-     * @internal param string $class_name The name of the class
-     * @return CRM
-     * @deprecated will be removed in 3.3.0
-     */
-    private static function getBackend($backend_class, $prj_id)
-    {
-        $backend = self::_getBackend($backend_class);
+        /** @var CRM $backend */
+        $backend = static::getExtensionLoader()->createInstance($backend_class);
         $backend->setup($prj_id);
         $backend->prj_id = $prj_id;
 

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -362,14 +362,13 @@ abstract class CRM
     /**
      * Returns the backend for the specified class name
      *
-     * @internal
      * @param string $backend_class
      * @param int $prj_id
      * @internal param string $class_name The name of the class
      * @return CRM
      * @deprecated will be removed in 3.3.0
      */
-    public static function getBackend($backend_class, $prj_id)
+    private static function getBackend($backend_class, $prj_id)
     {
         $backend = self::_getBackend($backend_class);
         $backend->setup($prj_id);

--- a/lib/eventum/class.crm.php
+++ b/lib/eventum/class.crm.php
@@ -776,8 +776,9 @@ abstract class CRM
 
     /**
      * @return ExtensionLoader
+     * @internal
      */
-    private static function getExtensionLoader()
+    public static function getExtensionLoader()
     {
         $dirs = [
             APP_INC_PATH . '/crm',

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1625,14 +1625,14 @@ class Custom_Field
     }
 
     /**
-     * Returns the list of available custom field backends by listing the class
-     * files in the backend directory.
+     * Returns the list of available custom field backends
+     * by listing the class files in the backend directory.
      *
-     * @return  array Associative array of filename => name
+     * @return  array
      */
     public static function getBackendList()
     {
-        return static::getExtensionLoader()->getFileList();
+        return static::getExtensionLoader()->getExtensions();
     }
 
     /**

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1640,10 +1640,13 @@ class Custom_Field
      *
      * @param   string $backend The full backend file name
      * @return  string the pretty name of the backend
+     * @deprecated drop, use ExtensionManager
      */
     public static function getBackendName($backend)
     {
-        preg_match('/^class\.(.*)\.php$/', $backend, $matches);
+        if (!preg_match('/^class\.(.*)\.php$/', $backend, $matches)) {
+            return $backend;
+        }
 
         return ucwords(str_replace('_', ' ', $matches[1]));
     }

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1836,8 +1836,9 @@ class Custom_Field
 
     /**
      * @return ExtensionLoader
+     * @internal
      */
-    private static function getExtensionLoader()
+    public static function getExtensionLoader()
     {
         $dirs = [
             APP_INC_PATH . '/custom_field',

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1643,7 +1643,7 @@ class Custom_Field
 
         if ($res) {
             try {
-                $instance = self::_getBackend($res);
+                $instance = static::getExtensionLoader()->createInstance($res);
             } catch (InvalidArgumentException $e) {
                 Logger::app()->error("Could not load backend $res", ['exception' => $e]);
                 $instance = false;
@@ -1655,17 +1655,6 @@ class Custom_Field
         }
 
         return $returns[$fld_id];
-    }
-
-    /**
-     * @internal
-     * @param string $backend
-     * @return object
-     * @deprecated will be removed in 3.3.0
-     */
-    public static function _getBackend($backend)
-    {
-        return static::getExtensionLoader()->createInstance($backend);
     }
 
     /**

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1047,22 +1047,11 @@ class Custom_Field
                     {{%custom_field}}
                  ORDER BY
                     fld_rank ASC';
-        try {
-            $res = DB_Helper::getInstance()->getAll($stmt);
-        } catch (DatabaseException $e) {
-            return '';
-        }
+
+        $res = DB_Helper::getInstance()->getAll($stmt);
 
         foreach ($res as &$row) {
             $row['projects'] = @implode(', ', array_values(self::getAssociatedProjects($row['fld_id'])));
-            if (in_array($row['fld_type'], self::$option_types)) {
-                if (!empty($row['fld_backend'])) {
-                    $row['field_options'] = implode(', ', array_values(self::getOptions($row['fld_id'])));
-                }
-            }
-            if (!empty($row['fld_backend'])) {
-                $row['field_options'] = 'Backend: ' . self::getBackendName($row['fld_backend']);
-            }
             $row['min_role_name'] = User::getRole($row['fld_min_role']);
             $row['min_role_edit_name'] = User::getRole($row['fld_min_role_edit']);
             $row['has_options'] = in_array($row['fld_type'], self::$option_types);
@@ -1622,22 +1611,6 @@ class Custom_Field
         }
 
         return 1;
-    }
-
-    /**
-     * Returns the 'pretty' name of the backend
-     *
-     * @param   string $backend The full backend file name
-     * @return  string the pretty name of the backend
-     * @deprecated drop, use ExtensionManager
-     */
-    public static function getBackendName($backend)
-    {
-        if (!preg_match('/^class\.(.*)\.php$/', $backend, $matches)) {
-            return $backend;
-        }
-
-        return ucwords(str_replace('_', ' ', $matches[1]));
     }
 
     /**

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1625,17 +1625,6 @@ class Custom_Field
     }
 
     /**
-     * Returns the list of available custom field backends
-     * by listing the class files in the backend directory.
-     *
-     * @return  array
-     */
-    public static function getBackendList()
-    {
-        return static::getExtensionLoader()->getExtensions();
-    }
-
-    /**
      * Returns the 'pretty' name of the backend
      *
      * @param   string $backend The full backend file name

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -1678,7 +1678,7 @@ class Custom_Field
 
         if ($res) {
             try {
-                $instance = static::getExtensionLoader()->createInstance($res);
+                $instance = self::_getBackend($res);
             } catch (InvalidArgumentException $e) {
                 Logger::app()->error("Could not load backend $res", ['exception' => $e]);
                 $instance = false;
@@ -1690,6 +1690,17 @@ class Custom_Field
         }
 
         return $returns[$fld_id];
+    }
+
+    /**
+     * @internal
+     * @param string $backend
+     * @return object
+     * @deprecated will be removed in 3.3.0
+     */
+    public static function _getBackend($backend)
+    {
+        return static::getExtensionLoader()->createInstance($backend);
     }
 
     /**

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -24,10 +24,12 @@ class Partner
      * Return the appropriate partner backend class associated with the
      * given $par_code.
      *
+     * @internal
      * @param   string $par_code The partner code
      * @return  Abstract_Partner_Backend
+     * @deprecated will be removed in 3.3.0
      */
-    private static function getBackend($par_code)
+    public static function getBackend($par_code)
     {
         static $setup_backends;
 

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -13,7 +13,6 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Extension\ExtensionLoader;
-use Eventum\Extension\ExtensionManager;
 
 /**
  * Handles the interactions between Eventum and partner backends.
@@ -209,35 +208,6 @@ class Partner
         return false;
     }
 
-    /**
-     * Return list of available Partner backends.
-     *
-     * @return array
-     */
-    public static function getList()
-    {
-        $partners = [];
-        foreach (self::getBackends() as $par_code => $backend) {
-            $partners[] = [
-                'code' => $par_code,
-                'name' => $backend->getName(),
-                'projects' => self::getProjectsForPartner($par_code),
-            ];
-        }
-
-        return $partners;
-    }
-
-    public static function getAssocList()
-    {
-        $partners = [];
-        foreach (self::getBackends() as $par_code => $backend) {
-            $partners[$par_code] = $backend->getName();
-        }
-
-        return $partners;
-    }
-
     public static function getDetails($par_code)
     {
         return [
@@ -297,23 +267,6 @@ class Partner
         }
 
         return $res;
-    }
-
-    /**
-     * Returns a list of backends available
-     *
-     * @return Abstract_Partner_Backend[]
-     */
-    public static function getBackends()
-    {
-        // load legacy classes
-        $backends = static::getExtensionLoader()->getExtensions();
-
-        // load classes from extension manager
-        $manager = ExtensionManager::getManager();
-        $backends = array_merge($backends, $manager->getPartnerClasses());
-
-        return $backends;
     }
 
     public static function getName($par_code)

--- a/lib/eventum/class.partner.php
+++ b/lib/eventum/class.partner.php
@@ -418,8 +418,9 @@ class Partner
 
     /**
      * @return ExtensionLoader
+     * @internal
      */
-    private static function getExtensionLoader()
+    public static function getExtensionLoader()
     {
         $dirs = [
             APP_INC_PATH . '/partner',

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -19,16 +19,6 @@ use Eventum\Model\Entity;
 class Workflow
 {
     /**
-     * Returns a list of backends available
-     *
-     * @return array
-     */
-    public static function getBackendList()
-    {
-        return static::getExtensionLoader()->getExtensions();
-    }
-
-    /**
      * Returns the name of the workflow backend for the specified project.
      *
      * @param   int $prj_id the id of the project to lookup

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -962,8 +962,9 @@ class Workflow
 
     /**
      * @return ExtensionLoader
+     * @internal
      */
-    private static function getExtensionLoader()
+    public static function getExtensionLoader()
     {
         $dirs = [
             APP_INC_PATH . '/workflow',

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -68,24 +68,13 @@ class Workflow
                 return false;
             }
 
-            $backend = self::getBackend($backendName);
+            $backend = static::getExtensionLoader()->createInstance($backendName);
             $backend->prj_id = $prj_id;
 
             $setup_backends[$prj_id] = $backend;
         }
 
         return $setup_backends[$prj_id];
-    }
-
-    /**
-     * @internal
-     * @param string $backend
-     * @return object
-     * @deprecated will be removed in 3.3.0
-     */
-    public static function getBackend($backend)
-    {
-        return static::getExtensionLoader()->createInstance($backend);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -25,9 +25,7 @@ class Workflow
      */
     public static function getBackendList()
     {
-        $files = static::getExtensionLoader()->getFileList();
-
-        return $files;
+        return static::getExtensionLoader()->getExtensions();
     }
 
     /**
@@ -74,15 +72,15 @@ class Workflow
         static $setup_backends;
 
         if (empty($setup_backends[$prj_id])) {
-            $filename = self::_getBackendNameByProject($prj_id);
-            if (!$filename) {
+            $backendName = self::_getBackendNameByProject($prj_id);
+            if (!$backendName) {
                 return false;
             }
 
-            $instance = static::getExtensionLoader()->createInstance($filename);
-            $instance->prj_id = $prj_id;
+            $backend = static::getExtensionLoader()->createInstance($backendName);
+            $backend->prj_id = $prj_id;
 
-            $setup_backends[$prj_id] = $instance;
+            $setup_backends[$prj_id] = $backend;
         }
 
         return $setup_backends[$prj_id];

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -21,7 +21,7 @@ class Workflow
     /**
      * Returns a list of backends available
      *
-     * @return  array An array of workflow backends
+     * @return array
      */
     public static function getBackendList()
     {

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -66,6 +66,7 @@ class Workflow
      *
      * @param   int $prj_id The project ID
      * @return bool|Abstract_Workflow_Backend
+     * @deprecated will be removed in 3.3.0
      */
     public static function _getBackend($prj_id)
     {

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -78,13 +78,24 @@ class Workflow
                 return false;
             }
 
-            $backend = static::getExtensionLoader()->createInstance($backendName);
+            $backend = self::getBackend($backendName);
             $backend->prj_id = $prj_id;
 
             $setup_backends[$prj_id] = $backend;
         }
 
         return $setup_backends[$prj_id];
+    }
+
+    /**
+     * @internal
+     * @param string $backend
+     * @return object
+     * @deprecated will be removed in 3.3.0
+     */
+    public static function getBackend($backend)
+    {
+        return static::getExtensionLoader()->createInstance($backend);
     }
 
     /**

--- a/phinx.php
+++ b/phinx.php
@@ -30,6 +30,9 @@ $define = function ($name, $value) {
 };
 $define('APP_LOCAL_PATH', APP_CONFIG_PATH);
 
+// workflow may use this in constructor
+Eventum\Monolog\Logger::initialize();
+
 // TODO: use "connection" => $pdo_instance once PEAR DB support is dropped
 // http://docs.phinx.org/en/latest/commands.html#configuration-file-parameter
 

--- a/phinx.php
+++ b/phinx.php
@@ -18,16 +18,22 @@
  */
 
 // init minimal constants needed for some classes to work
-if (!defined('APP_PATH')) {
-    define('APP_PATH', __DIR__);
-    define('APP_CONFIG_PATH', APP_PATH . '/config');
-    define('APP_SETUP_FILE', APP_CONFIG_PATH . '/setup.php');
+require_once __DIR__ . '/globals.php';
+if (file_exists(APP_CONFIG_PATH . '/config.php')) {
+    require_once APP_CONFIG_PATH . '/config.php';
 }
-
-$config = DB_Helper::getConfig();
+$define = function ($name, $value) {
+    if (defined($name)) {
+        return;
+    }
+    define($name, $value);
+};
+$define('APP_LOCAL_PATH', APP_CONFIG_PATH);
 
 // TODO: use "connection" => $pdo_instance once PEAR DB support is dropped
 // http://docs.phinx.org/en/latest/commands.html#configuration-file-parameter
+
+$config = DB_Helper::getConfig();
 
 return [
     'paths' => [

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -132,6 +132,20 @@ class CustomFieldsController extends ManageBaseController
         $manager = ExtensionManager::getManager();
         $backends = array_merge($backends, $manager->getCustomFieldClasses());
 
-        return $backends;
+        return $this->filterValues($backends);
+    }
+
+    /**
+     * Create array with key,value from $values $key,
+     * i.e discarding values.
+     */
+    private function filterValues($values)
+    {
+        $res = [];
+        foreach ($values as $key => $value) {
+            $res[$key] = $key;
+        }
+
+        return $res;
     }
 }

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -17,6 +17,7 @@ use Auth;
 use CRM;
 use Custom_Field;
 use Eventum\Controller\Helper\MessagesHelper;
+use Eventum\Extension\ExtensionManager;
 use Project;
 use User;
 
@@ -116,9 +117,21 @@ class CustomFieldsController extends ManageBaseController
                 'project_list' => Project::getAll(),
                 'list' => Custom_Field::getList(),
                 'user_roles' => $user_roles,
-                'backend_list' => Custom_Field::getBackendList(),
+                'backend_list' => $this->getBackends(),
                 'order_by_list' => Custom_Field::$order_by_choices,
             ]
         );
+    }
+
+    private function getBackends()
+    {
+        // load legacy classes
+        $backends = Custom_Field::getBackendList();
+
+        // load classes from extension manager
+        $manager = ExtensionManager::getManager();
+        $backends = array_merge($backends, $manager->getCustomFieldClasses());
+
+        return $backends;
     }
 }

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -125,12 +125,9 @@ class CustomFieldsController extends ManageBaseController
 
     private function getBackends()
     {
-        // load legacy classes
-        $backends = Custom_Field::getBackendList();
-
         // load classes from extension manager
         $manager = ExtensionManager::getManager();
-        $backends = array_merge($backends, $manager->getCustomFieldClasses());
+        $backends = $manager->getCustomFieldClasses();
 
         return $this->filterValues($backends);
     }

--- a/src/Controller/Manage/PartnersController.php
+++ b/src/Controller/Manage/PartnersController.php
@@ -14,6 +14,7 @@
 namespace Eventum\Controller\Manage;
 
 use Eventum\Controller\Helper\MessagesHelper;
+use Eventum\Extension\ExtensionManager;
 use Partner;
 use Project;
 
@@ -79,9 +80,29 @@ class PartnersController extends ManageBaseController
         $this->tpl->assign(
             [
                 'type' => 'partners',
-                'list' => Partner::getList(),
+                'list' => $this->getPartnersList(),
                 'project_list' => Project::getAll(),
             ]
         );
+    }
+
+    /**
+     * Return list of available Partner backends.
+     *
+     * @return array
+     */
+    private function getPartnersList()
+    {
+        $partners = [];
+        $backends = ExtensionManager::getManager()->getPartnerClasses();
+        foreach ($backends as $par_code => $backend) {
+            $partners[] = [
+                'code' => $par_code,
+                'name' => $backend->getName(),
+                'projects' => Partner::getProjectsForPartner($par_code),
+            ];
+        }
+
+        return $partners;
     }
 }

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -14,13 +14,11 @@
 namespace Eventum\Controller\Manage;
 
 use Auth;
-use CRM;
 use Eventum\Controller\Helper\MessagesHelper;
 use Eventum\Extension\ExtensionManager;
 use Project;
 use Status;
 use User;
-use Workflow;
 
 class ProjectsController extends ManageBaseController
 {
@@ -105,24 +103,18 @@ class ProjectsController extends ManageBaseController
 
     private function getWorkflowBackends()
     {
-        // load legacy classes
-        $backends = Workflow::getBackendList();
-
         // load classes from extension manager
         $manager = ExtensionManager::getManager();
-        $backends = array_merge($backends, $manager->getWorkflowClasses());
+        $backends = $manager->getWorkflowClasses();
 
         return $this->filterValues($backends);
     }
 
     private function getCustomerBackends()
     {
-        // load legacy classes
-        $backends = CRM::getBackendList();
-
         // load classes from extension manager
         $manager = ExtensionManager::getManager();
-        $backends = array_merge($backends, $manager->getCustomerClasses());
+        $backends = $manager->getCustomerClasses();
 
         return $this->filterValues($backends);
     }

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -16,6 +16,7 @@ namespace Eventum\Controller\Manage;
 use Auth;
 use CRM;
 use Eventum\Controller\Helper\MessagesHelper;
+use Eventum\Extension\ExtensionManager;
 use Project;
 use Status;
 use User;
@@ -97,8 +98,20 @@ class ProjectsController extends ManageBaseController
                 'user_options' => User::getActiveAssocList(),
                 'status_options' => Status::getAssocList(),
                 'customer_backends' => CRM::getBackendList(),
-                'workflow_backends' => Workflow::getBackendList(),
+                'workflow_backends' => $this->getWorkflowBackends(),
             ]
         );
+    }
+
+    private function getWorkflowBackends()
+    {
+        // load legacy classes
+        $backends = Workflow::getBackendList();
+
+        // load classes from extension manager
+        $manager = ExtensionManager::getManager();
+        $backends = array_merge($backends, $manager->getWorkflowClasses());
+
+        return $backends;
     }
 }

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -112,7 +112,7 @@ class ProjectsController extends ManageBaseController
         $manager = ExtensionManager::getManager();
         $backends = array_merge($backends, $manager->getWorkflowClasses());
 
-        return $backends;
+        return $this->filterValues($backends);
     }
 
     private function getCustomerBackends()
@@ -124,6 +124,20 @@ class ProjectsController extends ManageBaseController
         $manager = ExtensionManager::getManager();
         $backends = array_merge($backends, $manager->getCustomerClasses());
 
-        return $backends;
+        return $this->filterValues($backends);
+    }
+
+    /**
+     * Create array with key,value from $values $key,
+     * i.e discarding values.
+     */
+    private function filterValues($values)
+    {
+        $res = [];
+        foreach ($values as $key => $value) {
+            $res[$key] = $key;
+        }
+
+        return $res;
     }
 }

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -97,7 +97,7 @@ class ProjectsController extends ManageBaseController
                 'list' => Project::getList(),
                 'user_options' => User::getActiveAssocList(),
                 'status_options' => Status::getAssocList(),
-                'customer_backends' => CRM::getBackendList(),
+                'customer_backends' => $this->getCustomerBackends(),
                 'workflow_backends' => $this->getWorkflowBackends(),
             ]
         );
@@ -111,6 +111,18 @@ class ProjectsController extends ManageBaseController
         // load classes from extension manager
         $manager = ExtensionManager::getManager();
         $backends = array_merge($backends, $manager->getWorkflowClasses());
+
+        return $backends;
+    }
+
+    private function getCustomerBackends()
+    {
+        // load legacy classes
+        $backends = CRM::getBackendList();
+
+        // load classes from extension manager
+        $manager = ExtensionManager::getManager();
+        $backends = array_merge($backends, $manager->getCustomerClasses());
 
         return $backends;
     }

--- a/src/Controller/Manage/UsersController.php
+++ b/src/Controller/Manage/UsersController.php
@@ -15,8 +15,8 @@ namespace Eventum\Controller\Manage;
 
 use Auth;
 use Eventum\Controller\Helper\MessagesHelper;
+use Eventum\Extension\ExtensionManager;
 use Group;
-use Partner;
 use Project;
 use User;
 
@@ -214,8 +214,19 @@ class UsersController extends ManageBaseController
                 'project_list' => $project_list,
                 'project_roles' => $this->getProjectRoles($project_list, $this->user_details),
                 'group_list' => Group::getAssocListAllProjects(),
-                'partners' => Partner::getAssocList(),
+                'partners' => $this->getPartnersList(),
             ]
         );
+    }
+
+    private function getPartnersList()
+    {
+        $partners = [];
+        $backends = ExtensionManager::getManager()->getPartnerClasses();
+        foreach ($backends as $par_code => $backend) {
+            $partners[$par_code] = $backend->getName();
+        }
+
+        return $partners;
     }
 }

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+/**
+ * Class AbstractExtension
+ *
+ * Class doc comment will be used to describe purpose or add documentation.
+ *
+ * $d = new \ReflectionClass('foo');
+ * $d->getDocComment();
+ */
+abstract class AbstractExtension
+{
+    /**
+     * Path to the Eventum Core installation.
+     *
+     * @var string
+     */
+    protected $baseDir;
+
+    /**
+     * Method invoked so the extension can setup class loader.
+     *
+     * @param \Composer\Autoload\ClassLoader $loader
+     * @since 3.2.0
+     */
+    public function registerAutoloader($loader)
+    {
+    }
+
+    /**
+     * Return Workflow Class names your extension provides.
+     *
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getAvailableWorkflows()
+    {
+        return [];
+    }
+
+    /**
+     * Return Custom Field Class names your extension provides.
+     *
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getAvailableCustomFields()
+    {
+        return [];
+    }
+
+    /**
+     * Return Partner Class names your extension provides.
+     *
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getAvailablePartners()
+    {
+        return [];
+    }
+
+    /**
+     * Return CRM Class names your extension provides.
+     *
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getAvailableCRMs()
+    {
+        return [];
+    }
+}

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -24,13 +24,6 @@ namespace Eventum\Extension;
 abstract class AbstractExtension implements ExtensionInterface
 {
     /**
-     * Path to the Eventum Core installation.
-     *
-     * @var string
-     */
-    protected $baseDir;
-
-    /**
      * Method invoked so the extension can setup class loader.
      *
      * @param \Composer\Autoload\ClassLoader $loader

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -13,10 +13,8 @@
 
 namespace Eventum\Extension;
 
-use AppendIterator;
 use CRM;
 use Custom_Field;
-use DirectoryIterator;
 use Partner;
 use Workflow;
 
@@ -56,24 +54,11 @@ class BuiltinLegacyLoaderExtension extends AbstractExtension
     {
         $map = [];
 
-        $di = new AppendIterator();
-        foreach ($loader->getPaths() as $path) {
-            if (!is_dir($path)) {
-                continue;
-            }
-            $di->append(new DirectoryIterator($path));
-        }
-
-        // iterate over dirs, and accept only items that ExtensionLoader provided
+        // iterate over list and fill with absolute path
         $files = $loader->getFileList();
-        foreach ($di as $fi) {
-            $filename = $fi->getFilename();
-            if (!isset($files[$filename])) {
-                continue;
-            }
-
+        foreach ($files as $filename => $description) {
             $classname = $loader->getClassName($filename);
-            $map[$classname] = $fi->getPathname();
+            $map[$classname] = $loader->findClassFilename($filename);
         }
 
         return $map;

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -27,30 +27,60 @@ use Workflow;
  */
 class BuiltinLegacyLoaderExtension extends AbstractExtension
 {
+    /** @var array */
+    private $partners = [];
+    /** @var array */
+    private $workflows = [];
+    /** @var array */
+    private $custom_fields = [];
+    /** @var array */
+    private $customers = [];
+
     public function registerAutoloader($loader)
     {
         $classmap = [];
 
         $el = Partner::getExtensionLoader();
-        $classmap += $this->createMap($el);
+        $classmap += $this->createAutoloadMap($el, $this->partners);
 
         $el = Workflow::getExtensionLoader();
-        $classmap += $this->createMap($el);
+        $classmap += $this->createAutoloadMap($el, $this->workflows);
 
         $el = Custom_Field::getExtensionLoader();
-        $classmap += $this->createMap($el);
+        $classmap += $this->createAutoloadMap($el, $this->custom_fields);
 
         $el = CRM::getExtensionLoader();
-        $classmap += $this->createMap($el);
+        $classmap += $this->createAutoloadMap($el, $this->customers);
 
         $loader->addClassMap($classmap);
     }
 
+    public function getAvailableCustomFields()
+    {
+        return $this->custom_fields;
+    }
+
+    public function getAvailablePartners()
+    {
+        return $this->partners;
+    }
+
+    public function getAvailableWorkflows()
+    {
+        return $this->workflows;
+    }
+
+    public function getAvailableCRMs()
+    {
+        return $this->customers;
+    }
+
     /**
      * @param ExtensionLoader $loader
+     * @param array $classnames array where to append found class names
      * @return array
      */
-    private function createMap($loader)
+    private function createAutoloadMap($loader, &$classnames)
     {
         $map = [];
 
@@ -59,6 +89,7 @@ class BuiltinLegacyLoaderExtension extends AbstractExtension
         foreach ($files as $filename => $description) {
             $classname = $loader->getClassName($filename);
             $map[$classname] = $loader->findClassFilename($filename);
+            $classnames[] = $classname;
         }
 
         return $map;

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use AppendIterator;
+use CRM;
+use Custom_Field;
+use DirectoryIterator;
+use Partner;
+use Workflow;
+
+/**
+ * Extension providing autoloader for legacy backends locations:
+ * - workflow
+ * - partner
+ * - custom_field
+ * - customer
+ */
+class BuiltinLegacyLoaderExtension extends AbstractExtension
+{
+    public function registerAutoloader($loader)
+    {
+        $classmap = [];
+
+        $el = Partner::getExtensionLoader();
+        $classmap += $this->createMap($el);
+
+        $el = Workflow::getExtensionLoader();
+        $classmap += $this->createMap($el);
+
+        $el = Custom_Field::getExtensionLoader();
+        $classmap += $this->createMap($el);
+
+        $el = CRM::getExtensionLoader();
+        $classmap += $this->createMap($el);
+
+        $loader->addClassMap($classmap);
+    }
+
+    /**
+     * @param ExtensionLoader $loader
+     * @return array
+     */
+    private function createMap($loader)
+    {
+        $map = [];
+
+        $di = new AppendIterator();
+        foreach ($loader->getPaths() as $path) {
+            if (!is_dir($path)) {
+                continue;
+            }
+            $di->append(new DirectoryIterator($path));
+        }
+
+        // iterate over dirs, and accept only items that ExtensionLoader provided
+        $files = $loader->getFileList();
+        foreach ($di as $fi) {
+            $filename = $fi->getFilename();
+            if (!isset($files[$filename])) {
+                continue;
+            }
+
+            $classname = $loader->getClassName($filename);
+            $map[$classname] = $fi->getPathname();
+        }
+
+        return $map;
+    }
+}

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -85,17 +85,8 @@ class BuiltinLegacyLoaderExtension extends AbstractExtension
         $map = [];
 
         // iterate over list and fill with absolute path
-        $files = $loader->getFileList();
-        foreach ($files as $filename => $description) {
-            $classname = $loader->getClassName($filename);
-            $filename = $loader->findClassFilename($filename);
-
-            // add alternative capitalization
-            // some places use it inconsistently
-            // can't use reflection here to figure out correct name
-            $classname = ucwords(str_replace('_', ' ', $classname));
-            $classname = str_replace(' ', '_', $classname);
-
+        $classes = $loader->getClassList();
+        foreach ($classes as $classname => $filename) {
             $map[$classname] = $filename;
 
             // use the alternative capitalization

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -88,7 +88,18 @@ class BuiltinLegacyLoaderExtension extends AbstractExtension
         $files = $loader->getFileList();
         foreach ($files as $filename => $description) {
             $classname = $loader->getClassName($filename);
-            $map[$classname] = $loader->findClassFilename($filename);
+            $filename = $loader->findClassFilename($filename);
+
+            // add alternative capitalization
+            // some places use it inconsistently
+            // can't use reflection here to figure out correct name
+            $classname = ucwords(str_replace('_', ' ', $classname));
+            $classname = str_replace(' ', '_', $classname);
+
+            $map[$classname] = $filename;
+
+            // use the alternative capitalization
+            // as it's deterministic regardless of actual name
             $classnames[] = $classname;
         }
 

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -13,32 +13,15 @@
 
 namespace Eventum\Extension;
 
-/**
- * Class AbstractExtension
- *
- * Class doc comment will be used to describe purpose or add documentation.
- *
- * $d = new \ReflectionClass('foo');
- * $d->getDocComment();
- */
-abstract class AbstractExtension implements ExtensionInterface
+interface ExtensionInterface
 {
-    /**
-     * Path to the Eventum Core installation.
-     *
-     * @var string
-     */
-    protected $baseDir;
-
     /**
      * Method invoked so the extension can setup class loader.
      *
      * @param \Composer\Autoload\ClassLoader $loader
      * @since 3.2.0
      */
-    public function registerAutoloader($loader)
-    {
-    }
+    public function registerAutoloader($loader);
 
     /**
      * Return Workflow Class names your extension provides.
@@ -46,10 +29,7 @@ abstract class AbstractExtension implements ExtensionInterface
      * @return string[]
      * @since 3.2.0
      */
-    public function getAvailableWorkflows()
-    {
-        return [];
-    }
+    public function getAvailableWorkflows();
 
     /**
      * Return Custom Field Class names your extension provides.
@@ -57,10 +37,7 @@ abstract class AbstractExtension implements ExtensionInterface
      * @return string[]
      * @since 3.2.0
      */
-    public function getAvailableCustomFields()
-    {
-        return [];
-    }
+    public function getAvailableCustomFields();
 
     /**
      * Return Partner Class names your extension provides.
@@ -68,10 +45,7 @@ abstract class AbstractExtension implements ExtensionInterface
      * @return string[]
      * @since 3.2.0
      */
-    public function getAvailablePartners()
-    {
-        return [];
-    }
+    public function getAvailablePartners();
 
     /**
      * Return CRM Class names your extension provides.
@@ -79,8 +53,5 @@ abstract class AbstractExtension implements ExtensionInterface
      * @return string[]
      * @since 3.2.0
      */
-    public function getAvailableCRMs()
-    {
-        return [];
-    }
+    public function getAvailableCRMs();
 }

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -50,6 +50,12 @@ class ExtensionLoader
      */
     public function createInstance($backend)
     {
+        // see if classname is provided
+        if (class_exists($backend)) {
+            return new $backend();
+        }
+
+        // legacy mode where filename is provided
         $filename = $this->findClassFilename($backend);
         if (!file_exists($filename)) {
             throw new InvalidArgumentException("Filename: $filename does not exist");
@@ -61,6 +67,23 @@ class ExtensionLoader
         $classname = $this->getClassName($backend);
 
         return new $classname();
+    }
+
+    /**
+     * Return list of extensions found
+     *
+     * @return array
+     */
+    public function getExtensions()
+    {
+        $extensions = [];
+        foreach ($this->getFileList() as $filename => $description) {
+            $backend = $this->createInstance($filename);
+            $rc = new ReflectionClass($backend);
+            $extensions[$rc->getName()] = $rc->getName();
+        }
+
+        return $extensions;
     }
 
     /**

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -58,7 +58,7 @@ class ExtensionLoader
         // legacy mode where filename is provided
         $filename = $this->findClassFilename($backend);
         if (!file_exists($filename)) {
-            throw new InvalidArgumentException("Filename: '$filename' does not exist for '$backend");
+            throw new InvalidArgumentException("Filename: '$filename' does not exist for '$backend'");
         }
 
         /** @noinspection PhpIncludeInspection */

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -70,7 +70,9 @@ class ExtensionLoader
     }
 
     /**
-     * Get Classname -> Filename of extensions found
+     * Get Classname -> Filename of extensions found.
+     *
+     * NOTE: this method does require_once to each of the files.
      *
      * @return array
      */
@@ -110,26 +112,26 @@ class ExtensionLoader
      * That is it is an class that can be instantiated.
      *
      * @param string $filename
-     * @param string $className
+     * @param string $classname
      * @return bool
      */
-    private function isExtension($filename, $className)
+    private function isExtension($filename, $classname)
     {
         // skip if filename pattern gave no result
-        if (!$className) {
+        if (!$classname) {
             return false;
         }
 
         // autoload, or load manually
-        if (!class_exists($className)) {
+        if (!class_exists($classname)) {
             require_once $filename;
 
-            if (!class_exists($className)) {
+            if (!class_exists($classname)) {
                 // still not found. skip it
                 return false;
             }
         }
-        $rc = new ReflectionClass($className);
+        $rc = new ReflectionClass($classname);
 
         return $rc->isInstantiable();
     }
@@ -137,13 +139,13 @@ class ExtensionLoader
     /**
      * Get class name from file name.
      *
-     * @param string $fileName
+     * @param string $filename
      * @return string
      * @internal
      */
-    public function getClassName($fileName)
+    public function getClassName($filename)
     {
-        if (!preg_match('/^class\.(.*)\.php$/', $fileName, $matches)) {
+        if (!preg_match('/^class\.(.*)\.php$/', $filename, $matches)) {
             return null;
         }
 

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -50,7 +50,7 @@ class ExtensionLoader
      */
     public function createInstance($backend)
     {
-        $filename = $this->getClassFilename($backend);
+        $filename = $this->findClassFilename($backend);
         if (!file_exists($filename)) {
             throw new InvalidArgumentException("Filename: $filename does not exist");
         }
@@ -154,7 +154,7 @@ class ExtensionLoader
      * @param string $filename
      * @return null|string
      */
-    private function getClassFilename($filename)
+    private function findClassFilename($filename)
     {
         foreach ($this->paths as $path) {
             $class_filename = "$path/$filename";

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -177,8 +177,9 @@ class ExtensionLoader
      *
      * @param string $filename
      * @return null|string
+     * @internal
      */
-    private function findClassFilename($filename)
+    public function findClassFilename($filename)
     {
         foreach ($this->paths as $path) {
             $class_filename = "$path/$filename";
@@ -191,14 +192,5 @@ class ExtensionLoader
         }
 
         return null;
-    }
-
-    /**
-     * @return array
-     * @internal
-     */
-    public function getPaths()
-    {
-        return $this->paths;
     }
 }

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -58,7 +58,7 @@ class ExtensionLoader
         // legacy mode where filename is provided
         $filename = $this->findClassFilename($backend);
         if (!file_exists($filename)) {
-            throw new InvalidArgumentException("Filename: $filename does not exist");
+            throw new InvalidArgumentException("Filename: '$filename' does not exist for '$backend");
         }
 
         /** @noinspection PhpIncludeInspection */
@@ -150,8 +150,9 @@ class ExtensionLoader
      *
      * @param string $fileName
      * @return string
+     * @internal
      */
-    private function getClassName($fileName)
+    public function getClassName($fileName)
     {
         if (!preg_match('/^class\.(.*)\.php$/', $fileName, $matches)) {
             return null;
@@ -190,5 +191,14 @@ class ExtensionLoader
         }
 
         return null;
+    }
+
+    /**
+     * @return array
+     * @internal
+     */
+    public function getPaths()
+    {
+        return $this->paths;
     }
 }

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -80,7 +80,7 @@ class ExtensionLoader
         foreach ($this->getFileList() as $filename => $description) {
             $backend = $this->createInstance($filename);
             $rc = new ReflectionClass($backend);
-            $extensions[$rc->getName()] = $rc->getName();
+            $extensions[$rc->getName()] = $backend;
         }
 
         return $extensions;

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -70,30 +70,36 @@ class ExtensionLoader
     }
 
     /**
-     * Get Filename -> Classname of extensions found
+     * Get Classname -> Filename of extensions found
      *
      * @return array
      */
-    public function getFileList()
+    public function getClassList()
     {
         $list = $files = [];
         foreach ($this->paths as $path) {
             $files = array_merge($files, Misc::getFileList($path));
         }
 
-        foreach ($files as $file) {
-            $fileName = basename($file);
-            $className = $this->getClassName($fileName);
+        foreach ($files as $filename) {
+            $basename = basename($filename);
+            $classname = $this->getClassName($basename);
 
-            if (!$this->isExtension($file, $className)) {
+            if (!$this->isExtension($filename, $classname)) {
                 continue;
             }
 
-            if ($this->parent_class && !is_subclass_of($className, $this->parent_class)) {
+            if ($this->parent_class && !is_subclass_of($classname, $this->parent_class)) {
                 continue;
             }
 
-            $list[$fileName] = $this->getDisplayName($className);
+            // add alternative capitalization
+            // some places use it inconsistently
+            // can't use reflection here to figure out correct name
+            $classname = ucwords(str_replace('_', ' ', $classname));
+            $classname = str_replace(' ', '_', $classname);
+
+            $list[$classname] = $filename;
         }
 
         return $list;
@@ -142,17 +148,6 @@ class ExtensionLoader
         }
 
         return sprintf($this->classFormat, $matches[1]);
-    }
-
-    /**
-     * Returns the 'pretty' name of the backend
-     *
-     * @param string $fileName
-     * @return string
-     */
-    private function getDisplayName($fileName)
-    {
-        return ucwords(str_replace('_', ' ', $fileName));
     }
 
     /**

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -70,23 +70,6 @@ class ExtensionLoader
     }
 
     /**
-     * Return list of extensions found
-     *
-     * @return array
-     */
-    public function getExtensions()
-    {
-        $extensions = [];
-        foreach ($this->getFileList() as $filename => $description) {
-            $backend = $this->createInstance($filename);
-            $rc = new ReflectionClass($backend);
-            $extensions[$rc->getName()] = $backend;
-        }
-
-        return $extensions;
-    }
-
-    /**
      * Get Filename -> Classname of extensions found
      *
      * @return array

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -43,42 +43,53 @@ class ExtensionManager
     }
 
     /**
-     * Return class names of Workflow implementations.
+     * Return instances of Workflow implementations.
      *
      * @return array
      */
     public function getWorkflowClasses()
     {
-        return $this->collectClasses('getAvailableWorkflows');
+        return $this->createInstances('getAvailableWorkflows');
     }
 
     /**
-     * Return class names of Custom Field implementations.
+     * Return instances of Custom Field implementations.
      *
      * @return array
      */
     public function getCustomFieldClasses()
     {
-        return $this->collectClasses('getAvailableCustomFields');
+        return $this->createInstances('getAvailableCustomFields');
     }
 
     /**
-     * Return class names of CRM implementations.
+     * Return instances of CRM implementations.
      *
      * @return array
      */
     public function getCustomerClasses()
     {
-        return $this->collectClasses('getAvailableCRMs');
+        return $this->createInstances('getAvailableCRMs');
     }
 
     /**
-     * Helper to get merged class list from all extensions.
+     * Return instances of Partner implementations.
      *
-     * @param string $methodName
      * @return array
      */
-    protected function collectClasses($methodName)
+    public function getPartnerClasses()
+    {
+        return $this->createInstances('getAvailablePartners');
+    }
+
+    /**
+     * Helper to get merged class list from all extensions
+     * and create instances of them.
+     *
+     * @param string $methodName method name to call on each Extension to obtain class names
+     * @return object[]
+     */
+    protected function createInstances($methodName)
     {
         $classes = [];
         foreach ($this->extensions as $extension) {
@@ -87,10 +98,25 @@ class ExtensionManager
 
         $extensions = [];
         foreach ($classes as $classname) {
-            $extensions[$classname] = $classname;
+            $extensions[$classname] = $this->createInstance($classname);
         }
 
         return $extensions;
+    }
+
+    /**
+     * Create new instance of named class
+     *
+     * @param string $classname
+     * @return object
+     */
+    protected function createInstance($classname)
+    {
+        if (!class_exists($classname)) {
+            throw new InvalidArgumentException("Class '$classname' does not exist");
+        }
+
+        return new $classname();
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -49,12 +49,17 @@ class ExtensionManager
      */
     public function getWorkflowClasses()
     {
-        $res = [];
+        $classes = [];
         foreach ($this->extensions as $extension) {
-            $res = array_merge($res, $extension->getAvailableWorkflows());
+            $classes = array_merge($classes, $extension->getAvailableWorkflows());
         }
 
-        return $res;
+        $extensions = [];
+        foreach ($classes as $classname) {
+            $extensions[$classname] = $classname;
+        }
+
+        return $extensions;
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -75,11 +75,14 @@ class ExtensionManager
     /**
      * Return instances of Partner implementations.
      *
-     * @return array
+     * @return \Abstract_Partner_Backend[]
      */
     public function getPartnerClasses()
     {
-        return $this->createInstances('getAvailablePartners');
+        /** @var \Abstract_Partner_Backend[] $backends */
+        $backends = $this->createInstances('getAvailablePartners');
+
+        return $backends;
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -85,11 +85,19 @@ class ExtensionManager
      */
     protected function loadExtension($classname, $filename)
     {
-        /** @noinspection PhpIncludeInspection */
-        require_once $filename;
-
+        // class may already be loaded
+        // can ignore the filename requirement
         if (!class_exists($classname)) {
-            throw new InvalidArgumentException("Could not load $classname from $filename");
+            if (!file_exists($filename)) {
+                throw new InvalidArgumentException("File does not exist: $filename");
+            }
+
+            /** @noinspection PhpIncludeInspection */
+            require_once $filename;
+
+            if (!class_exists($classname)) {
+                throw new InvalidArgumentException("Could not load $classname from $filename");
+            }
         }
 
         return new $classname();

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -43,15 +43,36 @@ class ExtensionManager
     }
 
     /**
-     * Return class names of Workflow implementations configured in system.
+     * Return class names of Workflow implementations.
      *
      * @return array
      */
     public function getWorkflowClasses()
     {
+        return $this->collectClasses('getAvailableWorkflows');
+    }
+
+    /**
+     * Return class names of Custom Field implementations.
+     *
+     * @return array
+     */
+    public function getCustomFieldClasses()
+    {
+        return $this->collectClasses('getAvailableCustomFields');
+    }
+
+    /**
+     * Helper to get merged class list from all extensions.
+     *
+     * @param string $methodName
+     * @return array
+     */
+    protected function collectClasses($methodName)
+    {
         $classes = [];
         foreach ($this->extensions as $extension) {
-            $classes = array_merge($classes, $extension->getAvailableWorkflows());
+            $classes = array_merge($classes, $extension->$methodName());
         }
 
         $extensions = [];

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -102,7 +102,7 @@ class ExtensionManager
      */
     protected function getExtensionFiles()
     {
-        return Setup::get()['extensions'];
+        return Setup::get()['extensions'] ?: [];
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -63,6 +63,16 @@ class ExtensionManager
     }
 
     /**
+     * Return class names of CRM implementations.
+     *
+     * @return array
+     */
+    public function getCustomerClasses()
+    {
+        return $this->collectClasses('getAvailableCRMs');
+    }
+
+    /**
      * Helper to get merged class list from all extensions.
      *
      * @param string $methodName

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -43,6 +43,21 @@ class ExtensionManager
     }
 
     /**
+     * Return class names of Workflow implementations configured in system.
+     *
+     * @return array
+     */
+    public function getWorkflowClasses()
+    {
+        $res = [];
+        foreach ($this->extensions as $extension) {
+            $res = array_merge($res, $extension->getAvailableWorkflows());
+        }
+
+        return $res;
+    }
+
+    /**
      * Create all extensions, initialize them
      *
      * @return ExtensionInterface[]

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use InvalidArgumentException;
+use Setup;
+use Zend\Config\Config;
+
+class ExtensionManager
+{
+    /** @var ExtensionInterface[] */
+    protected $extensions;
+
+    /**
+     * Singleton Extension Manager
+     *
+     * @return ExtensionManager
+     */
+    public static function getManager()
+    {
+        static $manager;
+        if (!$manager) {
+            $manager = new self();
+        }
+
+        return $manager;
+    }
+
+    public function __construct()
+    {
+        $this->extensions = $this->loadExtensions();
+    }
+
+    /**
+     * Create all extensions, initialize them
+     *
+     * @return ExtensionInterface[]
+     */
+    protected function loadExtensions()
+    {
+        $extensions = [];
+        $loader = $this->getAutoloader();
+
+        foreach ($this->getExtensionFiles() as $classname => $filename) {
+            $extension = $this->loadExtension($classname, $filename);
+            $extension->registerAutoloader($loader);
+            $extensions[$classname] = $extension;
+        }
+
+        return $extensions;
+    }
+
+    /**
+     * Load $filename and create $classname instance
+     *
+     * @param string $classname
+     * @param string $filename
+     * @return ExtensionInterface
+     */
+    protected function loadExtension($classname, $filename)
+    {
+        /** @noinspection PhpIncludeInspection */
+        require_once $filename;
+
+        if (!class_exists($classname)) {
+            throw new InvalidArgumentException("Could not load $classname from $filename");
+        }
+
+        return new $classname();
+    }
+
+    /**
+     * Get configured extensions from setup.php
+     *
+     * @return Config|\Traversable|array
+     */
+    protected function getExtensionFiles()
+    {
+        return Setup::get()['extensions'];
+    }
+
+    /**
+     * Return composer autoloader
+     *
+     * @return \Composer\Autoload\ClassLoader
+     */
+    protected function getAutoloader()
+    {
+        return require APP_PATH . '/vendor/autoload.php';
+    }
+}

--- a/templates/manage/partners.tpl.html
+++ b/templates/manage/partners.tpl.html
@@ -12,7 +12,7 @@
                 {t}Manage Partners{/t}
             </th>
         </tr>
-        {if $smarty.get.cat|default:'' == 'edit'}
+        {if $smarty.get.cat|default:'' == 'edit' && isset($info)}
         <tr>
             <th width="120">
                 {t}Code{/t}

--- a/tests/ExtensionManagerTest.php
+++ b/tests/ExtensionManagerTest.php
@@ -29,6 +29,13 @@ class TestExtension1 extends AbstractExtension implements ExtensionInterface
 
 class TestExtension2 extends AbstractExtension implements ExtensionInterface
 {
+    public function registerAutoloader($loader)
+    {
+        $baseDir = __DIR__ . '/../docs/examples/workflow';
+        $classMap = ['Example_Workflow_Backend' => $baseDir . '/class.example.php'];
+        $loader->addClassMap($classMap);
+    }
+
     public function getAvailableWorkflows()
     {
         return [

--- a/tests/ExtensionManagerTest.php
+++ b/tests/ExtensionManagerTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Test;
+
+use Eventum\Extension\AbstractExtension;
+use Eventum\Extension\ExtensionInterface;
+use Eventum\Extension\ExtensionManager;
+
+class TestExtension1 extends AbstractExtension implements ExtensionInterface
+{
+    public function getAvailableWorkflows()
+    {
+        return [
+            __CLASS__,
+        ];
+    }
+}
+
+class TestExtension2 extends AbstractExtension implements ExtensionInterface
+{
+    public function getAvailableWorkflows()
+    {
+        return [
+            'Example_Workflow_Backend',
+        ];
+    }
+}
+
+class ExtensionManagerTest extends TestCase
+{
+    public function testWorkflowList()
+    {
+        $config = [
+            __NAMESPACE__ . '\\TestExtension1' => __FILE__,
+            __NAMESPACE__ . '\\TestExtension2' => __FILE__,
+        ];
+
+        $manager = $this->getExtensionManager($config);
+        $classes = $manager->getWorkflowClasses();
+        $this->assertCount(2, $classes);
+    }
+
+    /**
+     * Create ExtensionManager with given config
+     *
+     * @return ExtensionManager
+     */
+    private function getExtensionManager($config)
+    {
+        /** @var ExtensionManager $stub */
+        $stub = $this->getMockBuilder(ExtensionManager::class)
+            ->disableOriginalConstructor()
+            ->setMethods(['getExtensionFiles'])
+            ->getMock();
+
+        $stub->method('getExtensionFiles')
+            ->willReturn($config);
+
+        // as ->getMock() calls original constructor before method mocks is setup
+        // we disabled original constructor and call it out now.
+        $stub->__construct();
+
+        return $stub;
+    }
+}


### PR DESCRIPTION
The idea is that in setup.php you define path to your extension project.

- Eventum Core will walk over the list
- create class instances
- call registerAutoloader($autoloader) on those classes

in admin views, or places asking for list of workflow classes
- Eventum Core calls `getAvailableWorkflows` and merges the list

when specific workflow is saved in admin, the implementing class would be stored in database (opposed to currently class filename).

so the change is that Workflow/Custom_Field/Partner/CRM can be implemented any class that can be autoloaded. the classes can be available by composer.json or via the `registerAutoload` method.

----
Add new extension to eventum core, add to `config/setup.php` `extensions` entry and implement `ExtensionInterface` methods. `AbstractExtension` is provided which should be extended.

```php
return [
    'extensions' => [
        'Eventum\Extension\ExtensionExample' => '/path/to/ExtensionExample.php',
    ],
```

Example extension is provided:
- [docs/examples/extension/ExampleExtension.php](https://github.com/eventum/eventum/blob/f1d0a5424f1bb9eb953ce77fe65ace1ea7accc4e/docs/examples/extension/ExampleExtension.php)

The structure how to lay out classes is irrelevant as long as the classes can be autoloaded. autoloader can be configured by `registerAutoload` method.

NOTE: the existing layout and loading by filename is still preserved.