### PR TITLE
fix expected resolution date being rendered as -1

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -17,6 +17,7 @@ Consult [Upgrade] wiki page how to upgrade from previous versions.
 - use ctrl/cmd enter to submit forms (@glensc, #255)
 - quote custom field names (@glensc, #258)
 - drop Mail_rfc822 PEAR Mail requirement (@glensc, #256)
+- fix expected resolution date being rendered as -1 (@glensc, #260)
 
 [3.2.0]: https://github.com/eventum/eventum/compare/v3.1.10...master
 [PDO MySQL]: http://php.net/manual/en/ref.pdo-mysql.php

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -392,7 +392,7 @@ class Search
         foreach ($res as &$row) {
             $issue_id = $row['iss_id'];
             $row['time_spent'] = Misc::getFormattedTime($row['time_spent']);
-            $row['iss_expected_resolution_date'] = Date_Helper::getSimpleDate($row['iss_expected_resolution_date'], false);
+            $row['expected_resolution_date'] = Date_Helper::getSimpleDate($row['iss_expected_resolution_date'], false);
             $row['excerpts'] = isset($excerpts[$issue_id]) ? $excerpts[$issue_id] : '';
 
             $row['access_level_name'] = Access::getAccessLevelName($row['iss_access_level']);

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -51,7 +51,6 @@
                   {if $core.current_role > $core.roles.developer}[ <span class="js_link" id="toggle_bulk_update"> {t}bulk update tool{/t}</span> ]{/if}
                 </span>
                 {/if}
-              </tr>
           </th>
         </tr>
         <tr>

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -139,7 +139,11 @@
             {elseif $field_name == 'iss_percent_complete'}
               <div class="iss_percent_complete ui-progressbar" data-percent="{$list[i].iss_percent_complete}"><div class="progress-label">&nbsp;{$list[i].iss_percent_complete|escape:"html"} %</div></div>
             {elseif $field_name == 'iss_expected_resolution_date'}
-              <div class="inline_date_pick" id="expected_resolution_date|{$list[i].iss_id}">{$list[i].iss_expected_resolution_date|escape:"html"}&nbsp;</div>
+
+              {if $list[i].iss_expected_resolution_date != 0}
+                <div class="inline_date_pick" id="expected_resolution_date|{$list[i].iss_id}">{$list[i].iss_expected_resolution_date|escape:"html"}&nbsp</div>
+              {/if}
+
             {elseif $field_name == 'iss_summary'}
               <a href="view.php?id={$list[i].iss_id}" title="{t}view issue details{/t}">{$list[i].iss_summary|escape:"html"}</a>
               {if $list[i].redeemed|default:0}


### PR DESCRIPTION
fix issue listing page:
![image](https://cloud.githubusercontent.com/assets/199095/25870602/5ae57f92-350d-11e7-8667-83855cbd6dae.png)

also don't overwrite iss_expected_resolution_date in model
so be able to compare "0000-00-00" with "0" and get "true".

why it works on view issue page, is that template has extra check:
[templates/view_form.tpl.html:119-124](https://github.com/eventum/eventum/blob/v3.1.10/templates/view_form.tpl.html#L119-L124)
    
also, seems div class=inline_date_pick does nothing

