### PR TITLE
tpl: do not use core.current_url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.2.x versions requires that you upgrade to 3.2.0 version first.
 
+- cleanup templates for `core.current_url` (@glensc, #265)
+
 [3.2.2]: https://github.com/eventum/eventum/compare/v3.2.1...master
 
 ## [3.2.1] - 2017-06-09
@@ -40,7 +42,7 @@ This version adds replacement for backend classes with adding Extension support,
 - use font awesome (@glensc, #253)
 - use ctrl/cmd enter to submit forms (@glensc, #255)
 - quote custom field names (@glensc, #258)
-- drop Mail_rfc822 PEAR Mail requirement (@glensc, #256)
+- drop `Mail_rfc822` PEAR Mail requirement (@glensc, #256)
 - add userfile.js, userscript.css support (@glensc, #264)
 - fix expected resolution date being rendered as -1 (@glensc, #260)
 - fix user roles being overridden when updating a project (@balsdorf, 7ae6d2563, #152)

--- a/init.php
+++ b/init.php
@@ -111,7 +111,7 @@ header('Content-Type: text/html; charset=' . APP_CHARSET);
 // display maintenance message if requested.
 if (APP_MAINTENANCE) {
     $is_manage = (strpos($_SERVER['PHP_SELF'], '/manage/') !== false);
-    if (APP_MAINTENANCE && !$is_manage) {
+    if (!$is_manage) {
         $tpl = new Template_Helper();
         $tpl->setTemplate('maintenance.tpl.html');
         $tpl->displayTemplate();

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -151,8 +151,14 @@ class Auth
 
             // auto switch project
             if (isset($_GET['switch_prj_id'])) {
-                AuthCookie::setProjectCookie($_GET['switch_prj_id']);
-                self::redirect($_SERVER['PHP_SELF'] . '?' . str_replace('switch_prj_id=' . $_GET['switch_prj_id'], '', $_SERVER['QUERY_STRING']));
+                $prj_id = $_GET['switch_prj_id'];
+                AuthCookie::setProjectCookie($prj_id);
+                $url = $_SERVER['PHP_SELF'] . '?' .
+                    str_replace(
+                        "switch_prj_id={$prj_id}", '',
+                        $_SERVER['QUERY_STRING']
+                    );
+                self::redirect($url);
             }
 
             // if the current session is still valid, then renew the expiration

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -170,6 +170,8 @@ class Template_Helper
             'app_version' => APP_VERSION,
             'app_setup' => Setup::get(),
             'roles' => User::getAssocRoleIDs(),
+            // @deprecated: do not use 'current_url'
+            // @see https://github.com/eventum/eventum/pull/265
             'current_url' => $_SERVER['PHP_SELF'],
             'template_id' => str_replace(['/', '.tpl.html'], ['_'], $this->tpl_name),
             'handle_clock_in' => $setup['handle_clock_in'] == 'enabled',

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -170,9 +170,6 @@ class Template_Helper
             'app_version' => APP_VERSION,
             'app_setup' => Setup::get(),
             'roles' => User::getAssocRoleIDs(),
-            // @deprecated: do not use 'current_url'
-            // @see https://github.com/eventum/eventum/pull/265
-            'current_url' => $_SERVER['PHP_SELF'],
             'template_id' => str_replace(['/', '.tpl.html'], ['_'], $this->tpl_name),
             'handle_clock_in' => $setup['handle_clock_in'] == 'enabled',
         ];

--- a/src/Controller/EmailsController.php
+++ b/src/Controller/EmailsController.php
@@ -111,6 +111,8 @@ class EmailsController extends BaseController
      */
     private function getSortingInfo($options)
     {
+        $uri = $this->getRequest()->getBaseUrl();
+
         $fields = [
             'sup_from',
             'sup_customer_id',
@@ -136,7 +138,7 @@ class EmailsController extends BaseController
                 }
                 $items['order'][$field] = $sort_order_option;
             }
-            $items['links'][$field] = $_SERVER['PHP_SELF'] . '?sort_by=' . $field . '&sort_order=' . $sort_order;
+            $items['links'][$field] = $uri . '?sort_by=' . $field . '&sort_order=' . $sort_order;
         }
 
         return $items;

--- a/src/Controller/ListController.php
+++ b/src/Controller/ListController.php
@@ -257,6 +257,8 @@ class ListController extends BaseController
      */
     private function getSortingInfo($options)
     {
+        $uri = $this->getRequest()->getBaseUrl();
+
         $custom_fields = Custom_Field::getFieldsToBeListed(Auth::getCurrentProject());
 
         // default order for last action date, priority should be descending
@@ -305,7 +307,7 @@ class ListController extends BaseController
             }
             $options['sort_by'] = $sortfield;
             $options['sort_order'] = $sort_order;
-            $items['links'][$field] = $_SERVER['PHP_SELF'] . '?' . Filter::buildUrl(Filter::getFiltersInfo(), $options, false, true);
+            $items['links'][$field] = $uri . '?' . Filter::buildUrl(Filter::getFiltersInfo(), $options, false, true);
         }
 
         return $items;

--- a/templates/emails.tpl.html
+++ b/templates/emails.tpl.html
@@ -43,7 +43,7 @@
 {include file="email_filter_form.tpl.html"}
 <script type="text/javascript">
     <!--
-    var page_url = '{$core.current_url}';
+    var page_url = '{$core.rel_url}emails.php';
     var current_page = {$list_info.current_page};
     var last_page = {$list_info.last_page};
 

--- a/templates/include/attached_emails.tpl.html
+++ b/templates/include/attached_emails.tpl.html
@@ -2,7 +2,7 @@
 <br />
 <script type="text/javascript">
 <!--
-var url = '{$core.current_url}?cat=associate&';
+var url = '{$core.rel_url}new.php?cat=associate&';
 
 function removeEmails(f)
 {

--- a/templates/include/new_form.tpl.html
+++ b/templates/include/new_form.tpl.html
@@ -329,6 +329,6 @@
 </table>
 
 {if $emails|default:'' != ""}
-    {include file="attached_emails.tpl.html"}
+    {include file="include/attached_emails.tpl.html"}
 {/if}
 </form>

--- a/templates/manage/account_managers.tpl.html
+++ b/templates/manage/account_managers.tpl.html
@@ -3,7 +3,7 @@
 {block "manage_content"}
 <script type="text/javascript">
 <!--
-var url = '{$core.current_url}';
+var url = '{$core.rel_url}manage/account_managers.php';
 var cam_id = {$smarty.get.id|default:''|intval};
 
 function populateCustomerComboBox()
@@ -133,7 +133,7 @@ function checkDelete()
                     &nbsp;{$list[i].customer_title|default:''}
                   </td>
                   <td width="40%">
-                    &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].cam_id}" title="{t}update this entry{/t}">{$list[i].usr_full_name|escape:html}</a>
+                    &nbsp;<a href="{$core.rel_url}manage/account_managers.php?cat=edit&id={$list[i].cam_id}" title="{t}update this entry{/t}">{$list[i].usr_full_name|escape:html}</a>
                   </td>
                   <td width="20%">
                     &nbsp;{$list[i].cam_type}

--- a/templates/manage/categories.tpl.html
+++ b/templates/manage/categories.tpl.html
@@ -90,7 +90,7 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].prc_id}"></td>
             <td width="100%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].prc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].prc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/categories.php?cat=edit&id={$list[i].prc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].prc_title}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/custom_fields.tpl.html
+++ b/templates/manage/custom_fields.tpl.html
@@ -405,12 +405,12 @@
                 <input type="checkbox" name="items[]" value="{$list[i].fld_id}" {if $smarty.section.i.total == 0}disabled{/if}>
               </td>
               <td nowrap>
-                {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].fld_id}&direction=1" direction="down"}
+                {rank_icon href="{$core.rel_url}manage/custom_fields.php?cat=change_rank&id={$list[i].fld_id}&direction=1" direction="down"}
                 {$list[i].fld_rank}
-                {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].fld_id}&direction=-1" direction="up"}
+                {rank_icon href="{$core.rel_url}manage/custom_fields.php?cat=change_rank&id={$list[i].fld_id}&direction=-1" direction="up"}
               </td>
               <td width="15%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].fld_id}" title="{t}update this entry{/t}">{$list[i].fld_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/custom_fields.php?cat=edit&id={$list[i].fld_id}" title="{t}update this entry{/t}">{$list[i].fld_title}</a>
               </td>
               <td width="20%">
                 &nbsp;{$list[i].projects}

--- a/templates/manage/customer_notes.tpl.html
+++ b/templates/manage/customer_notes.tpl.html
@@ -3,7 +3,7 @@
 {block "manage_content"}
 <script type="text/javascript">
 <!--
-var url = '{$core.current_url}';
+var url = '{$core.rel_url}manage/customer_notes.php';
 var cno_id = {$smarty.get.id|intval|default:''};
 
 function populateCustomerComboBox()
@@ -124,7 +124,7 @@ function checkDelete()
         <tr class="{cycle values='odd,even'}">
           <td nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].cno_id}"></td>
           <td>
-            <a href="{$core.current_url}?cat=edit&id={$list[i].cno_id}">{$list[i].customer_title|default:''|escape:"html"}</a>
+            <a href="{$core.rel_url}manage/customer_notes.php?cat=edit&id={$list[i].cno_id}">{$list[i].customer_title|default:''|escape:"html"}</a>
           </td>
           <td>
             {$list[i].cno_note|escape:"html"|nl2br}

--- a/templates/manage/customize_listing.tpl.html
+++ b/templates/manage/customize_listing.tpl.html
@@ -3,7 +3,7 @@
 {block "manage_content"}
 <script type="text/javascript">
   <!--
-  var url = '{$core.current_url}';
+  var url = '{$core.rel_url}manage/customize_listing.php';
   var psd_id = {$smarty.get.id|intval|default:''};
 
   function retrieveStatuses(f)
@@ -133,7 +133,7 @@
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].psd_id}"></td>
       <td width="20%">{$list[i].prj_title}</td>
       <td width="20%">
-        &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].psd_id}" title="{t}update this entry{/t}">{$list[i].sta_title|escape:"html"}</a>
+        &nbsp;<a href="{$core.rel_url}manage/customize_listing.php?cat=edit&id={$list[i].psd_id}" title="{t}update this entry{/t}">{$list[i].sta_title|escape:"html"}</a>
       </td>
       <td width="30%">{$list[i].psd_label|escape:"html"}</td>
       <td width="30%">{$list[i].date_field}</td>

--- a/templates/manage/email_accounts.tpl.html
+++ b/templates/manage/email_accounts.tpl.html
@@ -246,7 +246,7 @@
       <td width="4" align="center" nowrap><input type="checkbox" name="items[]" value="{$list[i].ema_id}"></td>
       <td>&nbsp;{$list[i].prj_title}</td>
       <td width="30%">
-        &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].ema_id}" title="{t}update this entry{/t}">{$list[i].ema_hostname|escape:"html"}</a></td>
+        &nbsp;<a href="{$core.rel_url}manage/email_accounts.php?cat=edit&id={$list[i].ema_id}" title="{t}update this entry{/t}">{$list[i].ema_hostname|escape:"html"}</a></td>
       <td>&nbsp;{$list[i].ema_type}</td>
       <td>&nbsp;{$list[i].ema_port}</td>
       <td>&nbsp;{$list[i].ema_username|escape:"html"}</td>

--- a/templates/manage/email_responses.tpl.html
+++ b/templates/manage/email_responses.tpl.html
@@ -111,7 +111,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].ere_id}"></td>
               <td width="60%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].ere_id}" title="{t}update this entry{/t}">{$list[i].ere_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/email_responses.php?cat=edit&id={$list[i].ere_id}" title="{t}update this entry{/t}">{$list[i].ere_title}</a>
               </td>
               <td width="40%">
                 &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/faq.tpl.html
+++ b/templates/manage/faq.tpl.html
@@ -7,7 +7,7 @@
 {block "manage_content"}
   <script type="text/javascript">
   <!--
-  var url = '{$core.current_url}';
+  var url = '{$core.rel_url}manage/faq.php';
   var id = {$smarty.get.id|intval|default:''};
 
   function populateComboBox()
@@ -178,12 +178,12 @@
         <tr class="{cycle values="odd,even"}">
           <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].faq_id}"></td>
           <td align="center" nowrap>
-            {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].faq_id}&rank=desc" direction="down"}
+            {rank_icon href="{$core.rel_url}manage/faq.php?cat=change_rank&id={$list[i].faq_id}&rank=desc" direction="down"}
             {$list[i].faq_rank}
-            {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].faq_id}&rank=asc" direction="up"}
+            {rank_icon href="{$core.rel_url}manage/faq.php?cat=change_rank&id={$list[i].faq_id}&rank=asc" direction="up"}
           </td>
           <td width="50%">
-            &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].faq_id}" title="{t}update this entry{/t}">{$list[i].faq_title|escape:"html"}</a>
+            &nbsp;<a href="{$core.rel_url}manage/faq.php?cat=edit&id={$list[i].faq_id}" title="{t}update this entry{/t}">{$list[i].faq_title|escape:"html"}</a>
           </td>
           {if $backend_uses_support_levels|default:''}
           <td width="50%">

--- a/templates/manage/field_display.tpl.html
+++ b/templates/manage/field_display.tpl.html
@@ -7,7 +7,7 @@
     <a href="{$core.rel_url}manage/projects.php">{t}Manage Projects{/t}</a>
     </span>
 {else}
-<form name="display_form" method="post" action="{$core.current_url}?prj_id={$prj_id}">
+<form name="display_form" method="post" action="{$core.rel_url}manage/field_display.php?prj_id={$prj_id}">
     <table class="bordered grid">
         <tr class="title">
             <th colspan="2">

--- a/templates/manage/groups.tpl.html
+++ b/templates/manage/groups.tpl.html
@@ -155,7 +155,7 @@ function checkDelete()
             <input type="checkbox" name="items[]" value="{$list[i].grp_id}" {if $smarty.section.i.total == 0}disabled{/if}>
         </td>
         <td width="20%">
-            &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].grp_id}" title="{t}update this entry{/t}">{$list[i].grp_name}</a>
+            &nbsp;<a href="{$core.rel_url}manage/groups.php?cat=edit&id={$list[i].grp_id}" title="{t}update this entry{/t}">{$list[i].grp_name}</a>
         </td>
         <td width="20%">
             &nbsp;{$list[i].grp_description}

--- a/templates/manage/link_filters.tpl.html
+++ b/templates/manage/link_filters.tpl.html
@@ -144,7 +144,7 @@ function checkDelete()
                     <input type="checkbox" name="items[]" value="{$list[i].lfi_id}" {if $smarty.section.i.total == 0}disabled{/if}>
                 </td>
                 <td width="20%">
-                    &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].lfi_id}" title="{t}update this entry{/t}">{$list[i].lfi_pattern|escape:"html"}</a>
+                    &nbsp;<a href="{$core.rel_url}manage/link_filters.php?cat=edit&id={$list[i].lfi_id}" title="{t}update this entry{/t}">{$list[i].lfi_pattern|escape:"html"}</a>
                 </td>
                 <td width="20%">
                     &nbsp;{$list[i].lfi_replacement|escape:"html"}

--- a/templates/manage/news.tpl.html
+++ b/templates/manage/news.tpl.html
@@ -129,7 +129,7 @@ function checkDelete()
     <tr class="{cycle values='odd,even'}">
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].nws_id}"></td>
       <td width="40%">
-        &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].nws_id}" title="{t}update this entry{/t}">{$list[i].nws_title}</a>
+        &nbsp;<a href="{$core.rel_url}manage/news.php?cat=edit&id={$list[i].nws_id}" title="{t}update this entry{/t}">{$list[i].nws_title}</a>
       </td>
       <td width="40%">
         &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/phone_categories.tpl.html
+++ b/templates/manage/phone_categories.tpl.html
@@ -88,7 +88,7 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].phc_id}"></td>
             <td width="100%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].phc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].phc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/phone_categories.php?cat=edit&id={$list[i].phc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].phc_title}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/priorities.tpl.html
+++ b/templates/manage/priorities.tpl.html
@@ -146,15 +146,15 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].pri_id}"></td>
             <td align="center" nowrap>
-              {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].pri_id}&prj_id={$project.prj_id}&rank=desc" direction="down"}
+              {rank_icon href="{$core.rel_url}manage/priorities.php?cat=change_rank&id={$list[i].pri_id}&prj_id={$project.prj_id}&rank=desc" direction="down"}
               {$list[i].pri_rank}
-              {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].pri_id}&prj_id={$project.prj_id}&rank=asc" direction="up"}
+              {rank_icon href="{$core.rel_url}manage/priorities.php?cat=change_rank&id={$list[i].pri_id}&prj_id={$project.prj_id}&rank=asc" direction="up"}
             </td>
             <td align="center" nowrap>
                 {if $list[i].pri_icon > 0}<span class="priority_icon priority-icon-{$list[i].pri_icon}" title="{$list[i].pri_icon}"></span>{/if}
             </td>
             <td width="100%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].pri_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pri_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/priorities.php?cat=edit&id={$list[i].pri_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pri_title}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/products.tpl.html
+++ b/templates/manage/products.tpl.html
@@ -131,7 +131,7 @@
                 <input type="checkbox" name="items[]" value="{$list[i].pro_id}" {if $smarty.section.i.total == 0}disabled{/if}>
             </td>
             <td width="20%">
-                &nbsp;<a class="link" href="{$core.current_url}?cat=edit&id={$list[i].pro_id}" title="{t}update this entry{/t}">{$list[i].pro_title|escape}</a>
+                &nbsp;<a class="link" href="{$core.rel_url}manage/products.php?cat=edit&id={$list[i].pro_id}" title="{t}update this entry{/t}">{$list[i].pro_title|escape}</a>
             </td>
             <td width="20%">
                 &nbsp;{$list[i].pro_version_howto|escape}

--- a/templates/manage/projects.tpl.html
+++ b/templates/manage/projects.tpl.html
@@ -270,7 +270,7 @@ $().ready(function() {
         {section name="i" loop=$list}
         <tr class="{cycle values='odd,even'}">
           <td width="30%" >
-            &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].prj_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
+            &nbsp;<a href="{$core.rel_url}manage/projects.php?cat=edit&id={$list[i].prj_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
           </td>
           <td width="20%" >&nbsp;{$list[i].usr_full_name|escape:html}</td>
           <td >&nbsp;{$list[i].prj_status|capitalize}</td>

--- a/templates/manage/releases.tpl.html
+++ b/templates/manage/releases.tpl.html
@@ -111,7 +111,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].pre_id}"></td>
               <td width="40%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].pre_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pre_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/releases.php?cat=edit&id={$list[i].pre_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pre_title}</a>
               </td>
               <td>&nbsp;{$list[i].pre_scheduled_date}</td>
               <td>&nbsp;{$list[i].pre_status}</td>

--- a/templates/manage/reminder_actions.tpl.html
+++ b/templates/manage/reminder_actions.tpl.html
@@ -225,12 +225,12 @@
                     <tr class="{cycle values='odd,even'}">
                       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].rma_id}"></td>
                       <td align="center" nowrap>
-                        {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].rma_id}&rem_id={$rem_id}&rank=desc" direction="down"}
+                        {rank_icon href="{$core.rel_url}manage/reminder_actions.php?cat=change_rank&id={$list[i].rma_id}&rem_id={$rem_id}&rank=desc" direction="down"}
                         {$list[i].rma_rank}
-                        {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].rma_id}&rem_id={$rem_id}&rank=asc" direction="up"}
+                        {rank_icon href="{$core.rel_url}manage/reminder_actions.php?cat=change_rank&id={$list[i].rma_id}&rem_id={$rem_id}&rank=asc" direction="up"}
                       </td>
                       <td width="20%">
-                        &nbsp;<a href="{$core.current_url}?cat=edit&rem_id={$rem_id}&id={$list[i].rma_id}" title="{t}update this entry{/t}">{$list[i].rma_title|escape:"html"}</a>
+                        &nbsp;<a href="{$core.rel_url}manage/reminder_actions.php?cat=edit&rem_id={$rem_id}&id={$list[i].rma_id}" title="{t}update this entry{/t}">{$list[i].rma_title|escape:"html"}</a>
                       </td>
                       <td width="50%">
                         &nbsp;{$list[i].rmt_title}
@@ -238,7 +238,7 @@
                         {if $list[i].rma_alert_group_leader} [Alert Group Leader]{/if}
                       </td>
                       <td>
-                        &nbsp;<a href="reminder_conditions.php?rem_id={$list[i].rma_rem_id}&rma_id={$list[i].rma_id}">{$list[i].total_conditions} Condition{if $list[i].total_conditions != 1}s{/if}</a><br />
+                        &nbsp;<a href="{$core.rel_url}manage/reminder_conditions.php?rem_id={$list[i].rma_rem_id}&rma_id={$list[i].rma_id}">{$list[i].total_conditions} Condition{if $list[i].total_conditions != 1}s{/if}</a><br />
                         {if $list[i].status|default:'' != ''}&nbsp;Status: {$list[i].status}{/if}
                       </td>
                     </tr>

--- a/templates/manage/reminder_conditions.tpl.html
+++ b/templates/manage/reminder_conditions.tpl.html
@@ -3,7 +3,7 @@
 {block "manage_content"}
   <script type="text/javascript">
   <!--
-  var url = '{$core.current_url}';
+  var url = '{$core.rel_url}manage/reminder_conditions.php';
   var rem_id = '{$rem_id}';
   var rma_id = '{$rma_id}';
   var cat = '{$smarty.request.cat|default:''}';
@@ -188,7 +188,7 @@
                 {section name="i" loop=$list}
                 <tr class="{cycle values='odd,even'}">
                   <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].rlc_id}"></td>
-                  <td width="33%">&nbsp;<a href="{$core.current_url}?cat=edit&rem_id={$rem_id}&rma_id={$rma_id}&id={$list[i].rlc_id}" title="{t}update this entry{/t}">{$list[i].rmf_title|escape:"html"}</a></td>
+                  <td width="33%">&nbsp;<a href="{$core.rel_url}manage/reminder_conditions.php?cat=edit&rem_id={$rem_id}&rma_id={$rma_id}&id={$list[i].rlc_id}" title="{t}update this entry{/t}">{$list[i].rmf_title|escape:"html"}</a></td>
                   <td width="33%">&nbsp;{$list[i].rmo_title|escape:"html"}</td>
                   <td width="33%">&nbsp;{$list[i].rlc_value|escape:"html"}</td>
                 </tr>

--- a/templates/manage/reminders.tpl.html
+++ b/templates/manage/reminders.tpl.html
@@ -7,7 +7,7 @@
 {block "manage_content"}
   <script type="text/javascript">
   <!--
-  var url = '{$core.current_url}';
+  var url = '{$core.rel_url}manage/reminders.php';
   var rem_id = {$smarty.get.id|intval|default:''};
 
   function populateIssueComboBox()
@@ -339,12 +339,12 @@
           <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].rem_id}"></td>
           <td align="center">{$list[i].rem_id}</td>
           <td align="center">
-            {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].rem_id}&rank=desc" direction="down"}
+            {rank_icon href="{$core.rel_url}manage/reminders.php?cat=change_rank&id={$list[i].rem_id}&rank=desc" direction="down"}
             {$list[i].rem_rank}
-            {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].rem_id}&rank=asc" direction="up"}
+            {rank_icon href="{$core.rel_url}manage/reminders.php?cat=change_rank&id={$list[i].rem_id}&rank=asc" direction="up"}
           </td>
           <td>
-            &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].rem_id}" title="{t}update this entry{/t}">{$list[i].rem_title|escape:"html"}</a>
+            &nbsp;<a href="{$core.rel_url}manage/reminders.php?cat=edit&id={$list[i].rem_id}" title="{t}update this entry{/t}">{$list[i].rem_title|escape:"html"}</a>
           </td>
           <td width="25%">
             &nbsp;{$list[i].prj_title|escape:"html"}

--- a/templates/manage/resolution.tpl.html
+++ b/templates/manage/resolution.tpl.html
@@ -101,7 +101,7 @@
           <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].res_id}"></td>
           <td align="center">{$list[i].res_rank}</td>
           <td width="100%">
-            &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].res_id}" title="{t}update this entry{/t}">{$list[i].res_title}</a>
+            &nbsp;<a href="{$core.rel_url}manage/reminders.php?cat=edit&id={$list[i].res_id}" title="{t}update this entry{/t}">{$list[i].res_title}</a>
           </td>
         </tr>
         {sectionelse}

--- a/templates/manage/round_robin.tpl.html
+++ b/templates/manage/round_robin.tpl.html
@@ -3,7 +3,7 @@
 {block "manage_content"}
 <script type="text/javascript">
 <!--
-var url = '{$core.current_url}';
+var url = '{$core.rel_url}manage/round_robin.php';
 
 function populateUserComboBox()
 {
@@ -131,7 +131,7 @@ function checkDelete()
     <tr class="{cycle values="odd,even"}">
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].prr_id}"></td>
       <td width="30%">
-        &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].prr_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
+        &nbsp;<a href="{$core.rel_url}manage/round_robin.php?cat=edit&id={$list[i].prr_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
       </td>
       <td width="70%">
         &nbsp;{$list[i].users|escape:"html"}

--- a/templates/manage/severities.tpl.html
+++ b/templates/manage/severities.tpl.html
@@ -119,12 +119,12 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].sev_id}"></td>
             <td align="center" nowrap>
-              {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].sev_id}&prj_id={$project.prj_id}&rank=desc" direction="down"}
+              {rank_icon href="{$core.rel_url}manage/severities.php?cat=change_rank&id={$list[i].sev_id}&prj_id={$project.prj_id}&rank=desc" direction="down"}
               {$list[i].sev_rank}
-              {rank_icon href="{$core.current_url}?cat=change_rank&id={$list[i].sev_id}&prj_id={$project.prj_id}&rank=asc" direction="up"}
+              {rank_icon href="{$core.rel_url}manage/severities.php?cat=change_rank&id={$list[i].sev_id}&prj_id={$project.prj_id}&rank=asc" direction="up"}
             </td>
             <td width="200" nowrap>
-                &nbsp;<a class="link" href="{$core.current_url}?cat=edit&id={$list[i].sev_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].sev_title}</a>
+                &nbsp;<a class="link" href="{$core.rel_url}manage/severities.php?cat=edit&id={$list[i].sev_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].sev_title}</a>
             </td>
             <td width="100%">
                 &nbsp;{$list[i].sev_description}

--- a/templates/manage/statuses.tpl.html
+++ b/templates/manage/statuses.tpl.html
@@ -166,7 +166,7 @@
               <td align="center">{$list[i].sta_rank}</td>
               <td align="center">{$list[i].sta_abbreviation}</td>
               <td width="40%">
-                &nbsp;<a href="{$core.current_url}?cat=edit&id={$list[i].sta_id}" title="{t}update this entry{/t}">{$list[i].sta_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/statuses.php?cat=edit&id={$list[i].sta_id}" title="{t}update this entry{/t}">{$list[i].sta_title}</a>
               </td>
               <td width="30%">
                 &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/time_tracking.tpl.html
+++ b/templates/manage/time_tracking.tpl.html
@@ -91,7 +91,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].ttc_id}"></td>
               <td width="100%">
-                &nbsp;<a href="{$core.current_url}?prj_id={$project.prj_id}&cat=edit&id={$list[i].ttc_id}" title="{t}update this entry{/t}">{$list[i].ttc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/time_tracking.php?prj_id={$project.prj_id}&cat=edit&id={$list[i].ttc_id}" title="{t}update this entry{/t}">{$list[i].ttc_title}</a>
               </td>
             </tr>
             {sectionelse}

--- a/templates/manage/users_list.tpl.html
+++ b/templates/manage/users_list.tpl.html
@@ -6,7 +6,7 @@
 <script type="text/javascript" src="{$core.rel_url}components/jquery-datatables/media/js/jquery.dataTables.js"></script>
 <script type="text/javascript">
   var active_users_count = {$active_user_count};
-  var page_url = '{$core.current_url}';
+  var page_url = '{$core.rel_url}manage/users.php';
 
   function checkDelete()
   {

--- a/templates/new.tpl.html
+++ b/templates/new.tpl.html
@@ -9,5 +9,5 @@
 {/block}
 
 {block name="content"}
-{include file="new_form.tpl.html"}
+{include file="include/new_form.tpl.html"}
 {/block}

--- a/templates/new.tpl.html
+++ b/templates/new.tpl.html
@@ -9,5 +9,5 @@
 {/block}
 
 {block name="content"}
-{include file="include/new_form.tpl.html"}
+    {include file="include/new_form.tpl.html"}
 {/block}

--- a/templates/notification.tpl.html
+++ b/templates/notification.tpl.html
@@ -119,7 +119,7 @@
           <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap><input type="checkbox" name="items[]" value="{$list[i].sub_id}"></td>
             <td width="60%">
-              <a href="{$core.current_url}?cat=edit&iss_id={$list[i].sub_iss_id}&id={$list[i].sub_id}" title="{t}update this entry{/t}">{$list[i].sub_email|escape:"html"}</a>
+              <a href="{$core.rel_url}notification.php?cat=edit&iss_id={$list[i].sub_iss_id}&id={$list[i].sub_id}" title="{t}update this entry{/t}">{$list[i].sub_email|escape:"html"}</a>
             </td>
             <td width="40%">
               {$list[i].actions}

--- a/templates/post.tpl.html
+++ b/templates/post.tpl.html
@@ -6,7 +6,6 @@
     <a href="{$core.rel_url}">{t}Back to Login Form{/t}</a>
 </div>
 
-
 {if $no_projects|default:''}
 <div class="note_box">
     {t}Sorry, but there are no projects currently setup as allowing anonymous posting.{/t}
@@ -16,7 +15,7 @@
 <div class="note_box">
     {t escape=no 1=$new_issue_id}Thank you, the new issue was created successfully. For your records, the new issue ID is <font color="red">%1</font>{/t}
     <br /><br />
-    {t 1=$core.current_url escape=no}You may <a href="%1">submit another issue</a> if you so wish.{/t}
+    {t 1="{$core.rel_url}new.php" escape=no}You may <a href="%1">submit another issue</a> if you so wish.{/t}
 </div>
 {else}
 {if $smarty.get.post_form|default:'' != 'yes'}


### PR DESCRIPTION
it breaks configurations that are behind proxy
or rewrite rules are being applied

for example i route based on `ab` cookie value users to "production" instance or "dev" instance using the same urls.

and pages that use `current_url` get exposed to the "real" url behind the scenes.

rest of the templates use `rel_url` or `base_url`, so to cleanup `current_url` is good for consistency as well.

the same applies for `$_SERVER['PHP_SELF']`

- [x] `{$core.current_url}`
- [x] `$_SERVER['PHP_SELF']`