### PR TITLE
require iconv and mbstring extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,10 @@
 
 ## [3.2.1] - 2017-??-??
 
+This release makes `iconv` and `mbstring` extensions required.
+
 - add `$min_role` to base controller (@glensc, #261)
+- require `iconv` and `mbstring` extensions (@glensc, #269)
 
 [3.2.1]: https://github.com/eventum/eventum/compare/v3.2.0...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## [3.2.1] - 2017-??-??
 
-This release makes `iconv` and `mbstring` extensions required.
-
 - add `$min_role` to base controller (@glensc, #261)
 - require `iconv` and `mbstring` extensions (@glensc, #269)
 

--- a/lib/eventum/class.mime_helper.php
+++ b/lib/eventum/class.mime_helper.php
@@ -214,83 +214,25 @@ class Mime_Helper
     /**
      * Encode into a quoted printable encoded string.
      *
-     * @author Elan Ruusamäe <glen@delfi.ee>
-     * @see    Zend_Mime::_encodeQuotedPrintable
      * @param   string $string The string in APP_CHARSET encoding
      * @return  string encoded string
      */
     public static function encodeQuotedPrintable($string)
     {
-        if (function_exists('iconv_mime_encode')) {
-            // avoid any wrapping by specifying line length long enough
-            // "test" -> 4
-            // ": =?ISO-8859-1?B?dGVzdA==?=" -> 27
-            // 3 +2 +10      +3 +7     + 3
-            $line_length = strlen($string) * 4 + strlen(APP_CHARSET) + 11;
+        // avoid any wrapping by specifying line length long enough
+        // "test" -> 4
+        // ": =?ISO-8859-1?B?dGVzdA==?=" -> 27
+        // 3 +2 +10      +3 +7     + 3
+        $line_length = strlen($string) * 4 + strlen(APP_CHARSET) + 11;
 
-            $params = [
-                'input-charset' => APP_CHARSET,
-                'output-charset' => APP_CHARSET,
-                'line-length' => $line_length,
-            ];
-            $string = iconv_mime_encode('', $string, $params);
-
-            return substr($string, 2);
-        }
-
-        // lookup-Tables for QuotedPrintable
-        $qpKeys = [
-            "\x00", "\x01", "\x02", "\x03", "\x04", "\x05", "\x06", "\x07",
-            "\x08", "\x09", "\x0A", "\x0B", "\x0C", "\x0D", "\x0E", "\x0F",
-            "\x10", "\x11", "\x12", "\x13", "\x14", "\x15", "\x16", "\x17",
-            "\x18", "\x19", "\x1A", "\x1B", "\x1C", "\x1D", "\x1E", "\x1F",
-            "\x7F", "\x80", "\x81", "\x82", "\x83", "\x84", "\x85", "\x86",
-            "\x87", "\x88", "\x89", "\x8A", "\x8B", "\x8C", "\x8D", "\x8E",
-            "\x8F", "\x90", "\x91", "\x92", "\x93", "\x94", "\x95", "\x96",
-            "\x97", "\x98", "\x99", "\x9A", "\x9B", "\x9C", "\x9D", "\x9E",
-            "\x9F", "\xA0", "\xA1", "\xA2", "\xA3", "\xA4", "\xA5", "\xA6",
-            "\xA7", "\xA8", "\xA9", "\xAA", "\xAB", "\xAC", "\xAD", "\xAE",
-            "\xAF", "\xB0", "\xB1", "\xB2", "\xB3", "\xB4", "\xB5", "\xB6",
-            "\xB7", "\xB8", "\xB9", "\xBA", "\xBB", "\xBC", "\xBD", "\xBE",
-            "\xBF", "\xC0", "\xC1", "\xC2", "\xC3", "\xC4", "\xC5", "\xC6",
-            "\xC7", "\xC8", "\xC9", "\xCA", "\xCB", "\xCC", "\xCD", "\xCE",
-            "\xCF", "\xD0", "\xD1", "\xD2", "\xD3", "\xD4", "\xD5", "\xD6",
-            "\xD7", "\xD8", "\xD9", "\xDA", "\xDB", "\xDC", "\xDD", "\xDE",
-            "\xDF", "\xE0", "\xE1", "\xE2", "\xE3", "\xE4", "\xE5", "\xE6",
-            "\xE7", "\xE8", "\xE9", "\xEA", "\xEB", "\xEC", "\xED", "\xEE",
-            "\xEF", "\xF0", "\xF1", "\xF2", "\xF3", "\xF4", "\xF5", "\xF6",
-            "\xF7", "\xF8", "\xF9", "\xFA", "\xFB", "\xFC", "\xFD", "\xFE",
-            "\xFF",
+        $params = [
+            'input-charset' => APP_CHARSET,
+            'output-charset' => APP_CHARSET,
+            'line-length' => $line_length,
         ];
+        $string = iconv_mime_encode('', $string, $params);
 
-        $qpReplaceValues = [
-            '=00', '=01', '=02', '=03', '=04', '=05', '=06', '=07',
-            '=08', '=09', '=0A', '=0B', '=0C', '=0D', '=0E', '=0F',
-            '=10', '=11', '=12', '=13', '=14', '=15', '=16', '=17',
-            '=18', '=19', '=1A', '=1B', '=1C', '=1D', '=1E', '=1F',
-            '=7F', '=80', '=81', '=82', '=83', '=84', '=85', '=86',
-            '=87', '=88', '=89', '=8A', '=8B', '=8C', '=8D', '=8E',
-            '=8F', '=90', '=91', '=92', '=93', '=94', '=95', '=96',
-            '=97', '=98', '=99', '=9A', '=9B', '=9C', '=9D', '=9E',
-            '=9F', '=A0', '=A1', '=A2', '=A3', '=A4', '=A5', '=A6',
-            '=A7', '=A8', '=A9', '=AA', '=AB', '=AC', '=AD', '=AE',
-            '=AF', '=B0', '=B1', '=B2', '=B3', '=B4', '=B5', '=B6',
-            '=B7', '=B8', '=B9', '=BA', '=BB', '=BC', '=BD', '=BE',
-            '=BF', '=C0', '=C1', '=C2', '=C3', '=C4', '=C5', '=C6',
-            '=C7', '=C8', '=C9', '=CA', '=CB', '=CC', '=CD', '=CE',
-            '=CF', '=D0', '=D1', '=D2', '=D3', '=D4', '=D5', '=D6',
-            '=D7', '=D8', '=D9', '=DA', '=DB', '=DC', '=DD', '=DE',
-            '=DF', '=E0', '=E1', '=E2', '=E3', '=E4', '=E5', '=E6',
-            '=E7', '=E8', '=E9', '=EA', '=EB', '=EC', '=ED', '=EE',
-            '=EF', '=F0', '=F1', '=F2', '=F3', '=F4', '=F5', '=F6',
-            '=F7', '=F8', '=F9', '=FA', '=FB', '=FC', '=FD', '=FE',
-            '=FF',
-        ];
-
-        $string = str_replace('=', '=3D', $string);
-        $string = str_replace($qpKeys, $qpReplaceValues, $string);
-
-        return rtrim($string);
+        return substr($string, 2);
     }
 
     /**

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -84,11 +84,7 @@ class Misc
      */
     public static function countBytes($data)
     {
-        if (function_exists('mb_strlen')) {
-            return mb_strlen($data, '8bit');
-        }
-
-        return strlen($data);
+        return mb_strlen($data, '8bit');
     }
 
     /**

--- a/src/Controller/Setup/SetupController.php
+++ b/src/Controller/Setup/SetupController.php
@@ -178,11 +178,11 @@ class SetupController extends BaseController
                             'The PDO MySQL extension needs to be enabled in your PHP.INI file in order for Eventum to work properly.', ],
             'json' => [true,
                        'The json extension needs to be enabled in your PHP.INI file in order for Eventum to work properly.', ],
-            'mbstring' => [false,
+            'mbstring' => [true,
                            'The Multibyte String Functions extension is not enabled in your PHP installation. For localization to work properly '
                            .
                            'You need to install this extension. If you do not install this extension localization will be disabled.', ],
-            'iconv' => [false, 'The ICONV extension is not enabled in your PHP installation. ' .
+            'iconv' => [true, 'The ICONV extension is not enabled in your PHP installation. ' .
                         'You need to install this extension for optimal operation. If you do not install this extension some unicode data will be corrupted.', ],
         ];
 


### PR DESCRIPTION
as `zend/mail` and our `mime_helper` require unconditionally `iconv` extension
and `mbstring'` is also used unconditionally in some places in Eventum.

- [x] remove optional iconv/mbstring usages
- [x] update setup to require these extensions instead of being optional
- [x] update documentation in wiki: https://github.com/eventum/eventum/wiki/Prerequisites
