### PR TITLE
drop formatting for sup_cc, sup_to columns

### DIFF
--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -15,7 +15,6 @@ use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\MailTransport;
 use Eventum\Monolog\Logger;
 use Zend\Mail\Address;
-use Zend\Mail\Header\HeaderInterface;
 
 /**
  * Class to handle the business logic related to sending email to
@@ -132,34 +131,6 @@ class Mail_Helper
         }
 
         return $address->toString();
-    }
-
-    /**
-     * Parses a one or more email addresses (could be QP encoded)
-     * and returns them encoded in utf-8.
-     *
-     * Method should be used when displaying header values to user.
-     *
-     * @param Address|string $address The email address value
-     * @throws \Zend\Mail\Header\Exception\InvalidArgumentException
-     * @return string
-     */
-    public static function formatEmailAddresses($address)
-    {
-        if (!$address) {
-            return '';
-        }
-        if (!$address instanceof Address) {
-            try {
-                $address = AddressHeader::fromString($address);
-            } catch (\Zend\Mail\Exception\InvalidArgumentException $e) {
-                Logger::app()->error($e->getMessage(), ['address' => $address, 'exception' => $e]);
-
-                return AddressHeader::INVALID_ADDRESS;
-            }
-        }
-
-        return $address->toString(HeaderInterface::FORMAT_RAW);
     }
 
     /**

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1203,7 +1203,7 @@ class Support
         foreach ($res as &$row) {
             $row['sup_from'] = implode(', ', Mail_Helper::getName($row['sup_from'], true));
             if ((empty($row['sup_to'])) && (!empty($row['sup_iss_id']))) {
-                $row['sup_to'] = 'Notification List';
+                $row['sup_to'] = ev_gettext('Notification List');
             } else {
                 try {
                     $row['sup_to'] = Mail_Helper::getName($row['sup_to']);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1204,13 +1204,6 @@ class Support
             $row['sup_from'] = implode(', ', Mail_Helper::getName($row['sup_from'], true));
             if ((empty($row['sup_to'])) && (!empty($row['sup_iss_id']))) {
                 $row['sup_to'] = ev_gettext('Notification List');
-            } else {
-                try {
-                    $row['sup_to'] = Mail_Helper::getName($row['sup_to']);
-                } catch (\Zend\Mail\Header\Exception\InvalidArgumentException $e) {
-                    // Ignore unformattable headers
-                    Logger::app()->error($e->getMessage(), ['exception' => $e]);
-                }
             }
             if (CRM::hasCustomerIntegration($prj_id)) {
                 // FIXME: $company_titles maybe used uninitialied
@@ -1506,8 +1499,6 @@ class Support
         $res['timestamp'] = Date_Helper::getUnixTimestamp($res['sup_date'], 'GMT');
         // TRANSLATORS: %1 = email subject
         $res['reply_subject'] = Mail_Helper::removeExcessRe(ev_gettext('Re: %1$s', $res['sup_subject']), true);
-        $res['sup_to'] = Mail_Helper::formatEmailAddresses($res['sup_to']);
-        $res['sup_cc'] = Mail_Helper::formatEmailAddresses($res['sup_cc']);
 
         if (!empty($res['sup_iss_id'])) {
             $res['reply_subject'] = Mail_Helper::formatSubject($res['sup_iss_id'], $res['reply_subject']);
@@ -1663,11 +1654,6 @@ class Support
 
         if (count($res) == 0) {
             return [];
-        }
-
-        foreach ($res as &$row) {
-            $row['sup_to'] = Mail_Helper::formatEmailAddresses($row['sup_to']);
-            $row['sup_cc'] = Mail_Helper::formatEmailAddresses($row['sup_cc']);
         }
 
         return $res;

--- a/tests/Mail/MailHelperTest.php
+++ b/tests/Mail/MailHelperTest.php
@@ -16,6 +16,7 @@ namespace Eventum\Test\Mail;
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Test\TestCase;
 use Mail_Helper;
+use Zend\Mail\Header\HeaderInterface;
 
 /**
  * Test class for Mail_Helper.
@@ -286,7 +287,7 @@ class MailHelperTest extends TestCase
      */
     public function testFormatEmailAddresses($input, $exp)
     {
-        $res = Mail_Helper::formatEmailAddresses($input);
+        $res = AddressHeader::fromString($input)->toString(HeaderInterface::FORMAT_RAW);
         // spaces are irrelevant
         $res = preg_replace("/\s+/", ' ', $res);
         $this->assertEquals($exp, $res);


### PR DESCRIPTION
drop formatting for sup_cc, sup_to columns, they are already encoded properly in database.

- [upgrade/patches/62_fixencoding.php](https://github.com/eventum/eventum/blob/v3.2.0/upgrade/patches/62_fixencoding.php)

to my knowledge those fields are used only for display purposes, no need to validate and parse for valid email again