### PR TITLE
add Event/EventDispatcher to Eventum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - add `$min_role` to base controller (@glensc, #261)
 - require `iconv` and `mbstring` extensions (@glensc, #269)
+- add Event/EventDispatcher to Eventum (@glensc, #272)
 
 [3.2.1]: https://github.com/eventum/eventum/compare/v3.2.0...master
 

--- a/composer.json
+++ b/composer.json
@@ -86,6 +86,7 @@
 		"smarty-gettext/smarty-gettext": "~1.0",
 		"smarty/smarty": "~3.1.12",
 		"sphinx/php-sphinxapi": "2.0.*",
+		"symfony/event-dispatcher": "~2.7.0",
 		"symfony/filesystem": "~2.7.0",
 		"symfony/http-foundation": "~2.7.0",
 		"theorchard/monolog-cascade": "^0.3.1",

--- a/docs/examples/extension/Event/CryptoSubscriber.php
+++ b/docs/examples/extension/Event/CryptoSubscriber.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+use Eventum\Crypto\CryptoManager;
+use Eventum\Crypto\EncryptedValue;
+use Setup;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class CryptoSubscriber implements EventSubscriberInterface
+{
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            WorkflowEvents::CRYPTO_UPGRADE => 'upgradeConfig',
+            WorkflowEvents::CRYPTO_DOWNGRADE => 'downgradeConfig',
+        ];
+    }
+
+    /**
+     * Upgrade config so that values contain EncryptedValue where some secrecy is wanted
+     *
+     * @see \Eventum\Crypto\CryptoUpgradeManager::upgradeConfig
+     */
+    public function upgradeConfig()
+    {
+        $config = $this->getConfig();
+
+        if (count($config['ftp']) && !$config['ftp']['password'] instanceof EncryptedValue) {
+            $config['ftp']['password'] = new EncryptedValue(
+                CryptoManager::encrypt($config['ftp']['password'])
+            );
+        }
+    }
+
+    /**
+     * Downgrade config: remove all EncryptedValue elements
+     *
+     * @see \Eventum\Crypto\CryptoUpgradeManager::downgradeConfig
+     */
+    public function downgradeConfig()
+    {
+        $config = $this->getConfig();
+
+        if (count($config['ftp']) && $config['ftp']['password'] instanceof EncryptedValue) {
+            /** @var EncryptedValue $value */
+            $value = $config['ftp']['password'];
+            $config['ftp']['password'] = $value->getValue();
+        }
+    }
+
+    /**
+     * @return \Zend\Config\Config
+     */
+    private function getConfig()
+    {
+        return Setup::get();
+    }
+}

--- a/docs/examples/extension/Event/CryptoSubscriber.php
+++ b/docs/examples/extension/Event/CryptoSubscriber.php
@@ -28,8 +28,8 @@ class CryptoSubscriber implements EventSubscriberInterface
     public static function getSubscribedEvents()
     {
         return [
-            WorkflowEvents::CRYPTO_UPGRADE => 'upgradeConfig',
-            WorkflowEvents::CRYPTO_DOWNGRADE => 'downgradeConfig',
+            WorkflowEvents::CONFIG_CRYPTO_UPGRADE => 'upgradeConfig',
+            WorkflowEvents::CONFIG_CRYPTO_DOWNGRADE => 'downgradeConfig',
         ];
     }
 

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -32,7 +32,6 @@ class ExampleExtension extends AbstractExtension
      * Method invoked so the extension can setup class loader.
      *
      * @param \Composer\Autoload\ClassLoader $loader
-     * @since 3.2.0
      */
     public function registerAutoloader($loader)
     {
@@ -64,7 +63,6 @@ class ExampleExtension extends AbstractExtension
      * Return list of workflow classes.
      *
      * @return string[]
-     * @since 3.2.0
      */
     public function getAvailableWorkflows()
     {

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -13,6 +13,8 @@
 
 namespace Eventum\Extension;
 
+use Eventum\Event\CryptoSubscriber;
+
 /**
  * Example Eventum Extension.
  *
@@ -104,6 +106,20 @@ class ExampleExtension extends AbstractExtension
     {
         return [
             'Example\\CRM',
+        ];
+    }
+
+    /**
+     * Get classes implementing EventSubscriberInterface.
+     *
+     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
+     * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
+     * @return string[]
+     */
+    public function getSubscribers()
+    {
+        return [
+            CryptoSubscriber::class,
         ];
     }
 }

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -12,6 +12,8 @@
  */
 
 use Eventum\Db\DatabaseException;
+use Eventum\Event\WorkflowEvents;
+use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionLoader;
 use Eventum\Mail\MailMessage;
 use Eventum\Model\Entity;
@@ -874,10 +876,13 @@ class Workflow
      * Upgrade config so that values contain EncryptedValue where some secrecy is wanted
      * NOTE: this isn't really project specific, therefore it uses hardcoded project id to obtain workflow class
      *
-     * @since 3.1.0
+     * @since 3.1.0 workflow method added
+     * @since 3.2.1 dispatches WorkflowEvents::CRYPTO_DOWNGRADE event
      */
     public static function cryptoUpgradeConfig($prj_id = 1)
     {
+        EventManager::dispatch(WorkflowEvents::CRYPTO_UPGRADE);
+
         if (!self::hasWorkflowIntegration($prj_id)) {
             return;
         }
@@ -888,10 +893,13 @@ class Workflow
      * Downgrade config: remove all EncryptedValue elements.
      * NOTE: this isn't really project specific, therefore it uses hardcoded project id to obtain workflow class
      *
-     * @since 3.1.0
+     * @since 3.1.0 workflow method added
+     * @since 3.2.1 dispatches WorkflowEvents::CRYPTO_DOWNGRADE event
      */
     public static function cryptoDowngradeConfig($prj_id = 1)
     {
+        EventManager::dispatch(WorkflowEvents::CRYPTO_DOWNGRADE);
+
         if (!self::hasWorkflowIntegration($prj_id)) {
             return;
         }

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -881,7 +881,7 @@ class Workflow
      */
     public static function cryptoUpgradeConfig($prj_id = 1)
     {
-        EventManager::dispatch(WorkflowEvents::CRYPTO_UPGRADE);
+        EventManager::dispatch(WorkflowEvents::CONFIG_CRYPTO_UPGRADE);
 
         if (!self::hasWorkflowIntegration($prj_id)) {
             return;
@@ -898,7 +898,7 @@ class Workflow
      */
     public static function cryptoDowngradeConfig($prj_id = 1)
     {
-        EventManager::dispatch(WorkflowEvents::CRYPTO_DOWNGRADE);
+        EventManager::dispatch(WorkflowEvents::CONFIG_CRYPTO_DOWNGRADE);
 
         if (!self::hasWorkflowIntegration($prj_id)) {
             return;

--- a/src/Event/WorkflowEvents.php
+++ b/src/Event/WorkflowEvents.php
@@ -23,12 +23,12 @@ final class WorkflowEvents
      *
      * @since 3.2.1
      */
-    const CRYPTO_UPGRADE = 'crypto.upgrade_config';
+    const CONFIG_CRYPTO_UPGRADE = 'workflow.config.crypto_upgrade';
 
     /**
      * Downgrade config: remove all EncryptedValue elements.
      *
      * @since 3.2.1
      */
-    const CRYPTO_DOWNGRADE = 'crypto.downgrade_config';
+    const CONFIG_CRYPTO_DOWNGRADE = 'workflow.config.crypto_downgrade';
 }

--- a/src/Event/WorkflowEvents.php
+++ b/src/Event/WorkflowEvents.php
@@ -1,0 +1,34 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+/**
+ * Contains all events known in workflow.
+ */
+final class WorkflowEvents
+{
+    /**
+     * Upgrade config so that values contain EncryptedValue where some secrecy is wanted
+     *
+     * @since 3.2.1
+     */
+    const CRYPTO_UPGRADE = 'crypto.upgrade_config';
+
+    /**
+     * Downgrade config: remove all EncryptedValue elements.
+     *
+     * @since 3.2.1
+     */
+    const CRYPTO_DOWNGRADE = 'crypto.downgrade_config';
+}

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\EventDispatcher;
 
+use Eventum\Extension\ExtensionManager;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 
@@ -28,6 +29,13 @@ class EventManager
         static $dispatcher;
         if (!$dispatcher) {
             $dispatcher = new EventDispatcher();
+
+            // register subscribers from extensions
+            $em = ExtensionManager::getManager();
+            $subscribers = $em->getSubscribers();
+            foreach ($subscribers as $subscriber) {
+                $dispatcher->addSubscriber($subscriber);
+            }
         }
 
         return $dispatcher;

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\EventDispatcher;
+
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+
+class EventManager
+{
+    /**
+     * Singleton for Event Dispatcher
+     *
+     * @return EventDispatcher
+     */
+    public static function getEventDispatcher()
+    {
+        static $dispatcher;
+        if (!$dispatcher) {
+            $dispatcher = new EventDispatcher();
+        }
+
+        return $dispatcher;
+    }
+
+    /**
+     * Helper to dispatch events
+     *
+     * @param string $eventName
+     * @param Event $event
+     */
+    public static function dispatch($eventName, Event $event = null)
+    {
+        self::getEventDispatcher()->dispatch($eventName, $event);
+    }
+}

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -46,9 +46,11 @@ class EventManager
      *
      * @param string $eventName
      * @param Event $event
+     * @return Event
+     * @see EventDispatcherInterface::dispatch()
      */
     public static function dispatch($eventName, Event $event = null)
     {
-        self::getEventDispatcher()->dispatch($eventName, $event);
+        return self::getEventDispatcher()->dispatch($eventName, $event);
     }
 }

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -24,22 +24,16 @@ namespace Eventum\Extension;
 abstract class AbstractExtension implements ExtensionInterface
 {
     /**
-     * Method invoked so the extension can setup class loader.
-     *
-     * @param \Composer\Autoload\ClassLoader $loader
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::registerAutoloader()
      */
     public function registerAutoloader($loader)
     {
     }
 
     /**
-     * Get classes implementing EventSubscriberInterface.
-     *
-     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
-     * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
-     * @return string[]
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::getSubscribers()
      */
     public function getSubscribers()
     {
@@ -47,10 +41,8 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     /**
-     * Return Workflow Class names your extension provides.
-     *
-     * @return string[]
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::getAvailableWorkflows()
      */
     public function getAvailableWorkflows()
     {
@@ -58,10 +50,8 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     /**
-     * Return Custom Field Class names your extension provides.
-     *
-     * @return string[]
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::getAvailableCustomFields()
      */
     public function getAvailableCustomFields()
     {
@@ -69,10 +59,8 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     /**
-     * Return Partner Class names your extension provides.
-     *
-     * @return string[]
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::getAvailablePartners()
      */
     public function getAvailablePartners()
     {
@@ -80,10 +68,8 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     /**
-     * Return CRM Class names your extension provides.
-     *
-     * @return string[]
-     * @since 3.2.0
+     * {@inheritdoc}
+     * @see ExtensionInterface::getAvailableCRMs()
      */
     public function getAvailableCRMs()
     {

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -34,6 +34,19 @@ abstract class AbstractExtension implements ExtensionInterface
     }
 
     /**
+     * Get classes implementing EventSubscriberInterface.
+     *
+     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
+     * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getSubscribers()
+    {
+        return [];
+    }
+
+    /**
      * Return Workflow Class names your extension provides.
      *
      * @return string[]

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -29,7 +29,7 @@ interface ExtensionInterface
      * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
      * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
      * @return string[]
-     * @since 3.2.0
+     * @since 3.2.1
      */
     public function getSubscribers();
 
@@ -42,7 +42,7 @@ interface ExtensionInterface
     public function getAvailableWorkflows();
 
     /**
-     * Return Custom Field Class names your extension provides.
+     * Return Custom Field Class names the extension provides.
      *
      * @return string[]
      * @since 3.2.0
@@ -50,7 +50,7 @@ interface ExtensionInterface
     public function getAvailableCustomFields();
 
     /**
-     * Return Partner Class names your extension provides.
+     * Return Partner Class names the extension provides.
      *
      * @return string[]
      * @since 3.2.0
@@ -58,7 +58,7 @@ interface ExtensionInterface
     public function getAvailablePartners();
 
     /**
-     * Return CRM Class names your extension provides.
+     * Return CRM Class names the extension provides.
      *
      * @return string[]
      * @since 3.2.0

--- a/src/Extension/ExtensionInterface.php
+++ b/src/Extension/ExtensionInterface.php
@@ -24,6 +24,16 @@ interface ExtensionInterface
     public function registerAutoloader($loader);
 
     /**
+     * Get classes implementing EventSubscriberInterface.
+     *
+     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
+     * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
+     * @return string[]
+     * @since 3.2.0
+     */
+    public function getSubscribers();
+
+    /**
      * Return Workflow Class names your extension provides.
      *
      * @return string[]

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -15,6 +15,7 @@ namespace Eventum\Extension;
 
 use InvalidArgumentException;
 use Setup;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Zend\Config\Config;
 
 class ExtensionManager
@@ -86,10 +87,23 @@ class ExtensionManager
     }
 
     /**
-     * Helper to get merged class list from all extensions
-     * and create instances of them.
+     * Get classes implementing EventSubscriberInterface.
      *
-     * @param string $methodName method name to call on each Extension to obtain class names
+     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
+     * @return EventSubscriberInterface[]
+     */
+    public function getSubscribers()
+    {
+        /** @var EventSubscriberInterface[] $subscribers */
+        $subscribers = $this->createInstances(__FUNCTION__);
+
+        return $subscribers;
+    }
+
+    /**
+     * Create instances of classes returned from each extension $methodName.
+     *
+     * @param string $methodName
      * @return object[]
      */
     protected function createInstances($methodName)
@@ -99,12 +113,12 @@ class ExtensionManager
             $classes = array_merge($classes, $extension->$methodName());
         }
 
-        $extensions = [];
+        $instances = [];
         foreach ($classes as $classname) {
-            $extensions[$classname] = $this->createInstance($classname);
+            $instances[$classname] = $this->createInstance($classname);
         }
 
-        return $extensions;
+        return $instances;
     }
 
     /**
@@ -123,7 +137,7 @@ class ExtensionManager
     }
 
     /**
-     * Create all extensions, initialize them
+     * Create all extensions, initialize autoloader on them.
      *
      * @return ExtensionInterface[]
      */

--- a/tests/Dispatcher/ExtensionSubscribeTest.php
+++ b/tests/Dispatcher/ExtensionSubscribeTest.php
@@ -1,0 +1,105 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Test\Dispatcher;
+
+use Eventum\Extension\AbstractExtension;
+use Eventum\Test\TestCase;
+use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\EventDispatcher;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class ExtensionSubscribeTest extends TestCase
+{
+    const RESPONSE = 'response';
+    const NAME = 'response';
+
+    public function testExtensionEvents()
+    {
+        $config = [
+            Extension1::class => __FILE__,
+            Extension2::class => __FILE__,
+        ];
+
+        $manager = $this->getExtensionManager($config);
+        $dispatcher = new EventDispatcher();
+        $subscribers = $manager->getSubscribers();
+        foreach ($subscribers as $subscriber) {
+            $dispatcher->addSubscriber($subscriber);
+        }
+
+        $event = new Event();
+        $dispatcher->dispatch('response', $event);
+        $dispatcher->dispatch('name', $event);
+
+        $id = StoreSubscriber::class;
+        $res = $event->{$id};
+        $exp = [
+            'onKernelResponsePre',
+            'onKernelResponsePost',
+            'onStoreOrder',
+        ];
+
+        $this->assertEquals($exp, $res);
+    }
+}
+
+class Extension1 extends AbstractExtension
+{
+}
+
+class Extension2 extends AbstractExtension
+{
+    public function getSubscribers()
+    {
+        return [
+            StoreSubscriber::class,
+        ];
+    }
+}
+
+class StoreSubscriber implements EventSubscriberInterface
+{
+    private $id;
+
+    public function __construct()
+    {
+        $this->id = __CLASS__;
+    }
+
+    public static function getSubscribedEvents()
+    {
+        return [
+            'response' => [
+                ['onKernelResponsePre', 10],
+                ['onKernelResponsePost', -10],
+            ],
+            'name' => 'onStoreOrder',
+        ];
+    }
+
+    public function onKernelResponsePre(Event $event)
+    {
+        $event->{$this->id}[] = __FUNCTION__;
+    }
+
+    public function onKernelResponsePost(Event $event)
+    {
+        $event->{$this->id}[] = __FUNCTION__;
+    }
+
+    public function onStoreOrder(Event $event)
+    {
+        $event->{$this->id}[] = __FUNCTION__;
+    }
+}


### PR DESCRIPTION
Adds Events to Eventum using [Symfony Event Dispatcher](https://symfony.com/doc/current/components/event_dispatcher.html).

First implementation is handling projectless crypto enable/disable events (#165). I am probably the only one using those workflow methods :)

Example Extension updated with the sample that encrypts/disables `$config['ftp']['password']` field when encryption is turned on/off from administration.