### PR TITLE
emit history.add events when history entry is added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Upgrading to 3.2.x versions requires that you upgrade to 3.2.0 version first.
 - Catch exception if invalid message is added to mail queue (@balsdorf, 0e55ae2)
 - add real 'Status Change Date' column and rename old column to 'Status Action Date' (@balsdorf, #277)
 - rpc: setIssueStatus: validate parameters server side (@glensc, #280)
+- emit history.add events when history entry is added (@glensc, #278)
 
 [3.2.2]: https://github.com/eventum/eventum/compare/v3.2.1...3.2.2
 

--- a/docs/examples/extension/Event/HistorySubscriber.php
+++ b/docs/examples/extension/Event/HistorySubscriber.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+use Misc;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class HistorySubscriber implements EventSubscriberInterface
+{
+    /**
+     * Returns an array of event names this subscriber wants to listen to.
+     *
+     * @return array The event names to listen to
+     */
+    public static function getSubscribedEvents()
+    {
+        return [
+            SystemEvents::HISTORY_ADD => 'historyAdded',
+        ];
+    }
+
+    /**
+     * @param UnstructuredEvent $event
+     */
+    public function historyAdded(UnstructuredEvent $event)
+    {
+        $his_summary = Misc::processTokens(ev_gettext($event->his_summary), $event->his_context);
+
+        error_log("HISTORY: #{$event->his_id}: $his_summary");
+    }
+}

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -14,6 +14,7 @@
 namespace Eventum\Extension;
 
 use Eventum\Event\CryptoSubscriber;
+use Eventum\Event\HistorySubscriber;
 
 /**
  * Example Eventum Extension.
@@ -36,7 +37,7 @@ class ExampleExtension extends AbstractExtension
     public function registerAutoloader($loader)
     {
         $phpDir = '/usr/share/php';
-        $baseDir = '/usr/src/eventum-workflow';
+        $baseDir = dirname(dirname(dirname(__DIR__)));
 
         $classmap = [
             'example_Workflow_Backend' => $baseDir . '/src/Workflow/example_Workflow_Backend.php',
@@ -45,7 +46,7 @@ class ExampleExtension extends AbstractExtension
             'Pimple\\' => $phpDir,
         ];
         $psr4 = [
-            'Eventum\\Example\\' => [$baseDir . '/src'],
+            'Eventum\\Event\\' => [$baseDir . '/docs/examples/extension/Event'],
         ];
 
         $loader->addClassMap($classmap);
@@ -118,6 +119,7 @@ class ExampleExtension extends AbstractExtension
     {
         return [
             CryptoSubscriber::class,
+            HistorySubscriber::class,
         ];
     }
 }

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -12,6 +12,9 @@
  */
 
 use Eventum\Db\DatabaseException;
+use Eventum\Event\SystemEvents;
+use Eventum\EventDispatcher\EventManager;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class to handle the business logic related to the history information for
@@ -69,10 +72,10 @@ class History
 
         $stmt = 'INSERT INTO {{%issue_history}} SET ' . DB_Helper::buildSet($params);
 
-        try {
-            DB_Helper::getInstance()->query($stmt, $params);
-        } catch (DatabaseException $e) {
-        }
+        DB_Helper::getInstance()->query($stmt, $params);
+
+        $event = new Event();
+        EventManager::dispatch(SystemEvents::HISTORY_ADD, $event);
     }
 
     /**

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -12,9 +12,8 @@
  */
 
 use Eventum\Db\DatabaseException;
-use Eventum\Event\SystemEvents;
+use Eventum\Event;
 use Eventum\EventDispatcher\EventManager;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * Class to handle the business logic related to the history information for
@@ -73,9 +72,10 @@ class History
         $stmt = 'INSERT INTO {{%issue_history}} SET ' . DB_Helper::buildSet($params);
 
         DB_Helper::getInstance()->query($stmt, $params);
+        $params['his_id'] = DB_Helper::get_last_insert_id();
 
-        $event = new Event();
-        EventManager::dispatch(SystemEvents::HISTORY_ADD, $event);
+        $event = new Event\UnstructuredEvent($params);
+        EventManager::dispatch(Event\SystemEvents::HISTORY_ADD, $event);
     }
 
     /**

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -73,6 +73,7 @@ class History
 
         DB_Helper::getInstance()->query($stmt, $params);
         $params['his_id'] = DB_Helper::get_last_insert_id();
+        $params['prj_id'] = Auth::getCurrentProject();
 
         $event = new Event\UnstructuredEvent($params);
         EventManager::dispatch(Event\SystemEvents::HISTORY_ADD, $event);

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+final class SystemEvents
+{
+    /**
+     * Event fired when history entry is added
+     *
+     * @since 3.2.2
+     */
+    const HISTORY_ADD = 'history.add';
+}

--- a/src/Event/UnstructuredEvent.php
+++ b/src/Event/UnstructuredEvent.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+use InvalidArgumentException;
+use Symfony\Component\EventDispatcher\Event;
+
+class UnstructuredEvent extends Event
+{
+    /**
+     * Event parameters.
+     * Access to event parameters is controlled by magic get/set to protect access to wrong parameters.
+     *
+     * @var array
+     */
+    private $params;
+
+    public function __construct($params = [])
+    {
+        $this->params = $params;
+    }
+
+    /**
+     * Get all parameters
+     *
+     * @return array
+     */
+    public function getParams()
+    {
+        return $this->params;
+    }
+
+    /**
+     * @param string $name
+     * @return mixed
+     */
+    public function __get($name)
+    {
+        if (!isset($this->params[$name])) {
+            throw new InvalidArgumentException("Invalid parameter: $name");
+        }
+
+        return $this->params[$name];
+    }
+
+    public function __set($name, $value)
+    {
+        if (!isset($this->params[$name])) {
+            throw new InvalidArgumentException("Invalid parameter: $name");
+        }
+
+        $this->params[$name] = $value;
+    }
+
+    public function __isset($name)
+    {
+        return isset($this->params[$name]);
+    }
+}


### PR DESCRIPTION
just an experiment, is it useful yet, don't know :)

to test, add to `config/setup.php`:
```php

  'extensions' => [
    'Eventum\\Extension\\ExampleExtension' => dirname(__DIR__) . '/docs/examples/extension/ExampleExtension.php',
  ],
```

real usecase could be removing irc related code from eventum-core and move it into extension.
or some kind of activity monitor.