### PR TITLE
rpc: setIssueStatus: validate parameters server side

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ Upgrading to 3.2.x versions requires that you upgrade to 3.2.0 version first.
 - Fix bug auto switching project on update issues page (@balsdorf, 6ffecfc)
 - Catch exception if invalid message is added to mail queue (@balsdorf, 0e55ae2)
 - add real 'Status Change Date' column and rename old column to 'Status Action Date' (@balsdorf, #277)
+- rpc: setIssueStatus: validate parameters server side (@glensc, #280)
 
 [3.2.2]: https://github.com/eventum/eventum/compare/v3.2.1...master
 

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -440,31 +440,6 @@ class Command_Line
      */
     public static function setIssueStatus(&$client, $auth, $issue_id, $new_status)
     {
-        $details = self::checkIssuePermissions($client, $auth, $issue_id);
-        self::checkIssueAssignment($client, $auth, $issue_id);
-
-        // check if the issue already is set to the new status
-        if ((strtolower($details['sta_title']) == strtolower($new_status)) ||
-                (strtolower($details['sta_abbreviation']) == strtolower($new_status))) {
-            self::quit("Issue #$issue_id is already set to status '" . $details['sta_title'] . "'");
-        }
-
-        // check if the given status is a valid option
-        $statuses = $client->getAbbreviationAssocList($auth[0], $auth[1], (int) $details['iss_prj_id'], false);
-
-        $titles = Misc::lowercase(array_values($statuses));
-        $abbreviations = Misc::lowercase(array_keys($statuses));
-        if ((!in_array(strtolower($new_status), $titles)) &&
-                (!in_array(strtolower($new_status), $abbreviations))) {
-            self::quit("Status '$new_status' could not be matched against the list of available statuses");
-        }
-
-        // if the user is passing an abbreviation, use the real title instead
-        if (in_array(strtolower($new_status), $abbreviations)) {
-            $index = array_search(strtolower($new_status), $abbreviations);
-            $new_status = $titles[$index];
-        }
-
         $result = $client->setIssueStatus($auth[0], $auth[1], $issue_id, $new_status);
         if ($result == 'OK') {
             echo "OK - Status successfully changed to '$new_status' on issue #$issue_id\n";

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -440,6 +440,31 @@ class Command_Line
      */
     public static function setIssueStatus(&$client, $auth, $issue_id, $new_status)
     {
+        $details = self::checkIssuePermissions($client, $auth, $issue_id);
+        self::checkIssueAssignment($client, $auth, $issue_id);
+
+        // check if the issue already is set to the new status
+        if ((strtolower($details['sta_title']) == strtolower($new_status)) ||
+                (strtolower($details['sta_abbreviation']) == strtolower($new_status))) {
+            self::quit("Issue #$issue_id is already set to status '" . $details['sta_title'] . "'");
+        }
+
+        // check if the given status is a valid option
+        $statuses = $client->getAbbreviationAssocList($auth[0], $auth[1], (int) $details['iss_prj_id'], false);
+
+        $titles = Misc::lowercase(array_values($statuses));
+        $abbreviations = Misc::lowercase(array_keys($statuses));
+        if ((!in_array(strtolower($new_status), $titles)) &&
+                (!in_array(strtolower($new_status), $abbreviations))) {
+            self::quit("Status '$new_status' could not be matched against the list of available statuses");
+        }
+
+        // if the user is passing an abbreviation, use the real title instead
+        if (in_array(strtolower($new_status), $abbreviations)) {
+            $index = array_search(strtolower($new_status), $abbreviations);
+            $new_status = $titles[$index];
+        }
+
         $result = $client->setIssueStatus($auth[0], $auth[1], $issue_id, $new_status);
         if ($result == 'OK') {
             echo "OK - Status successfully changed to '$new_status' on issue #$issue_id\n";

--- a/lib/eventum/class.command_line.php
+++ b/lib/eventum/class.command_line.php
@@ -13,10 +13,10 @@
 
 use Eventum\RPC\RemoteApi;
 
-$_displayed_confirmation = false;
-
 class Command_Line
 {
+    private static $_displayed_confirmation = null;
+
     /**
      * Prompts the user for a resolution option, and returns the ID of the
      * selected one.
@@ -320,7 +320,7 @@ class Command_Line
     public function checkIssueAssignment($client, $auth, $issue_id)
     {
         // check if the confirmation message was already displayed
-        if (isset($GLOBALS['_displayed_confirmation']) && !$GLOBALS['_displayed_confirmation']) {
+        if (isset(self::$_displayed_confirmation) && !self::$_displayed_confirmation) {
             // check if the current user is allowed to change the given issue
             $may_change_issue = $client->mayChangeIssue($auth[0], $auth[1], $issue_id);
 
@@ -1160,7 +1160,7 @@ Account Manager: ' . @$details['customer']['account_manager_name'];
     public static function promptConfirmation($client, $auth, $issue_id, $args)
     {
         // this is needed to prevent multiple confirmations from being shown to the user
-        $GLOBALS['_displayed_confirmation'] = true;
+        self::$_displayed_confirmation = true;
 
         // get summary, customer status and assignment of issue, then show confirmation prompt to user
         $details = $client->getSimpleIssueDetails($auth[0], $auth[1], $issue_id);

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -13,6 +13,7 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Model\Repository\IssueAssociationRepository;
+use Eventum\RPC\RemoteApiException;
 
 /**
  * Class designed to handle all business logic related to the issues in the
@@ -352,7 +353,7 @@ class Issue
      * @param   int $issue_id The issue ID
      * @param   int $status_id The new status ID
      * @param   bool $notify if a notification should be sent about this change
-     * @return  int 1 if the update worked, -1 otherwise
+     * @return  int 1 if the update worked, -2 if no change is made, -1 on error
      */
     public static function setStatus($issue_id, $status_id, $notify = false)
     {
@@ -363,7 +364,7 @@ class Issue
 
         // check if the status is already set to the 'new' one
         if (self::getStatusID($issue_id) == $status_id) {
-            return -1;
+            return -2;
         }
 
         $old_status = self::getStatusID($issue_id);
@@ -415,9 +416,38 @@ class Issue
      */
     public static function setRemoteStatus($issue_id, $usr_id, $new_status)
     {
+        if (!self::canUpdate($issue_id, $usr_id)) {
+            throw new RemoteApiException("User has no access to update issue #$issue_id");
+        }
+
+        // check if the given status is a valid option
+        $prj_id = self::getProjectID($issue_id);
+        $statuses = Status::getAbbreviationAssocList($prj_id, false);
+
+        $titles = Misc::lowercase(array_values($statuses));
+        $abbreviations = Misc::lowercase(array_keys($statuses));
+        if ((!in_array(strtolower($new_status), $titles)) &&
+            (!in_array(strtolower($new_status), $abbreviations))) {
+            $message = "Status '$new_status' could not be matched against the list of available statuses";
+            throw new RemoteApiException($message);
+        }
+
+        // if the user is passing an abbreviation, use the real title instead
+        if (in_array(strtolower($new_status), $abbreviations)) {
+            $index = array_search(strtolower($new_status), $abbreviations);
+            $new_status = $titles[$index];
+        }
+
         $sta_id = Status::getStatusID($new_status);
+        if ($sta_id === null) {
+            // should not really happen as status fetched from above code
+            throw new RemoteApiException("Unable to find status named '$new_status'");
+        }
 
         $res = self::setStatus($issue_id, $sta_id);
+        if ($res == -2) {
+            throw new RemoteApiException("Issue status is already set to '$new_status'");
+        }
         if ($res == 1) {
             // record history entry
             History::add($issue_id, $usr_id, 'remote_status_change', "Status remotely changed to '{status}' by {user}", [

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -3235,7 +3235,7 @@ class Issue
      * @param   int $issue_id the ID of the issue
      * @param   int $usr_id The ID of the user
      * @return  bool If the user can update the issue
-     * @deprecated use Access::canUpdateIssue() directly
+     * @deprecated since 3.2.2 use Access::canUpdateIssue() directly
      */
     public static function canUpdate($issue_id, $usr_id)
     {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -662,69 +662,6 @@ class Issue
     }
 
     /**
-     * Method used to get all issues associated with a status that doesn't have
-     * the 'closed' context.
-     *
-     * @param   int $prj_id The project ID to list issues from
-     * @param   int $usr_id The user ID of the user requesting this information
-     * @param   bool $show_all_issues Whether to show all open issues, or just the ones assigned to the given email address
-     * @param   int $status_id The status ID to be used to restrict results
-     * @return  array The list of open issues
-     */
-    public static function getOpenIssues($prj_id, $usr_id, $show_all_issues, $status_id)
-    {
-        $projects = Project::getRemoteAssocListByUser($usr_id);
-        if (count($projects) == 0) {
-            return '';
-        }
-
-        $stmt = 'SELECT
-                    iss_id,
-                    iss_summary,
-                    sta_title
-                 FROM
-                    (
-                    {{%issue}},
-                    {{%status}}
-                    )
-                 LEFT JOIN
-                    {{%issue_user}}
-                 ON
-                    isu_iss_id=iss_id
-                 WHERE ';
-        $params = [];
-
-        if (!empty($status_id)) {
-            $stmt .= ' sta_id=? AND ';
-            $params[] = $status_id;
-        }
-
-        $stmt .= '
-                    iss_prj_id=? AND
-                    sta_id=iss_sta_id AND
-                    sta_is_closed=0';
-        $params[] = $prj_id;
-        if ($show_all_issues == false) {
-            $stmt .= ' AND
-                    isu_usr_id=?';
-            $params[] = $usr_id;
-        }
-        $stmt .= "\nGROUP BY
-                        iss_id";
-        try {
-            $res = DB_Helper::getInstance()->getAll($stmt, $params);
-        } catch (DatabaseException $e) {
-            return '';
-        }
-
-        if (count($res) > 0) {
-            self::getAssignedUsersByIssues($res);
-        }
-
-        return $res;
-    }
-
-    /**
      * Method used to build the required parameters to simulate an email reply
      * to the user who reported the issue, using the issue details like summary
      * and description as email fields.

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -3298,6 +3298,7 @@ class Issue
      * @param   int $issue_id the ID of the issue
      * @param   int $usr_id The ID of the user
      * @return  bool If the user can update the issue
+     * @deprecated use Access::canUpdateIssue() directly
      */
     public static function canUpdate($issue_id, $usr_id)
     {

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -864,53 +864,6 @@ class Project
     }
 
     /**
-     * Method used to get the list of projects assigned to a given user that
-     * allow remote invocation of issues.
-     *
-     * @param   int $usr_id The user ID
-     * @param   bool $only_customer_projects Whether to only include projects with customer integration or not
-     * @return  array The list of projects
-     */
-    public static function getRemoteAssocListByUser($usr_id, $only_customer_projects = false)
-    {
-        static $returns;
-
-        if ((!$only_customer_projects) && (!empty($returns[$usr_id]))) {
-            return $returns[$usr_id];
-        }
-
-        $stmt = "SELECT
-                    prj_id,
-                    prj_title
-                 FROM
-                    {{%project}},
-                    {{%project_user}}
-                 WHERE
-                    prj_id=pru_prj_id AND
-                    pru_usr_id=? AND
-                    pru_role > ? AND
-                    prj_remote_invocation='enabled'";
-        if ($only_customer_projects) {
-            $stmt .= " AND prj_customer_backend <> '' AND prj_customer_backend IS NOT NULL ";
-        }
-        $stmt .= '
-                 ORDER BY
-                    prj_title';
-        try {
-            $res = DB_Helper::getInstance()->getPair($stmt, [$usr_id, User::ROLE_CUSTOMER]);
-        } catch (DatabaseException $e) {
-            return '';
-        }
-
-        // don't cache the results when the optional argument is used to avoid getting bogus results
-        if (!$only_customer_projects) {
-            $returns[$usr_id] = $res;
-        }
-
-        return $res;
-    }
-
-    /**
      * Method used to get the list of users associated with a given project.
      *
      * @param   int $prj_id The project ID

--- a/lib/eventum/class.status.php
+++ b/lib/eventum/class.status.php
@@ -501,7 +501,7 @@ class Status
     {
         static $returns;
 
-        if (!empty($returns[$sta_title])) {
+        if (isset($returns[$sta_title])) {
             return $returns[$sta_title];
         }
 
@@ -511,11 +511,7 @@ class Status
                     {{%status}}
                  WHERE
                     sta_title=?';
-        try {
-            $res = DB_Helper::getInstance()->getOne($stmt, [$sta_title]);
-        } catch (DatabaseException $e) {
-            return '';
-        }
+        $res = DB_Helper::getInstance()->getOne($stmt, [$sta_title]);
 
         $returns[$sta_title] = $res;
 

--- a/src/Controller/CustomFieldsController.php
+++ b/src/Controller/CustomFieldsController.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Controller;
 
+use Access;
 use Auth;
 use Custom_Field;
 use Issue;
@@ -54,7 +55,7 @@ class CustomFieldsController extends BaseController
 
         $this->usr_id = Auth::getUserID();
 
-        if (!Issue::canUpdate($this->issue_id, $this->usr_id)) {
+        if (!Access::canUpdateIssue($this->issue_id, $this->usr_id)) {
             return false;
         }
 

--- a/src/Controller/PostNoteController.php
+++ b/src/Controller/PostNoteController.php
@@ -217,7 +217,7 @@ class PostNoteController extends BaseController
     private function setIssueStatus($status)
     {
         $res = Issue::setStatus($this->issue_id, $status);
-        if ($res == -1) {
+        if ($res != 1) {
             return;
         }
 

--- a/src/Controller/SendController.php
+++ b/src/Controller/SendController.php
@@ -203,7 +203,7 @@ class SendController extends BaseController
         $new_status = $post->get('new_status');
         if ($new_status && Access::canChangeStatus($this->issue_id, $this->usr_id)) {
             $res = Issue::setStatus($this->issue_id, $new_status);
-            if ($res != -1) {
+            if ($res == 1) {
                 $status_title = Status::getStatusTitle($new_status);
                 History::add(
                     $this->issue_id, $this->usr_id, 'status_changed',

--- a/src/Controller/UpdateController.php
+++ b/src/Controller/UpdateController.php
@@ -98,7 +98,7 @@ class UpdateController extends BaseController
         if (($this->role_id == User::ROLE_CUSTOMER) && (!$details || (User::getCustomerID($this->usr_id) != $details['iss_customer_id']))
             || !Issue::canAccess($this->issue_id, $this->usr_id)
             || !($this->role_id > User::ROLE_REPORTER)
-            || !Issue::canUpdate($this->issue_id, $this->usr_id)
+            || !Access::canUpdateIssue($this->issue_id, $this->usr_id)
         ) {
             $this->error(ev_gettext('Sorry, you do not have the required privileges to update this issue.'));
         }

--- a/src/Controller/ViewController.php
+++ b/src/Controller/ViewController.php
@@ -175,7 +175,7 @@ class ViewController extends BaseController
                 'max_attachment_size' => Attachment::getMaxAttachmentSize(),
                 'quarantine' => Issue::getQuarantineInfo($this->issue_id),
                 'grid' => $this->getColumnsForDisplay(),
-                'can_update' => Issue::canUpdate($this->issue_id, $this->usr_id),
+                'can_update' => Access::canUpdateIssue($this->issue_id, $this->usr_id),
                 'enabled_partners' => Partner::getPartnersByProject($this->prj_id),
                 'partners' => Partner::getPartnersByIssue($this->issue_id),
                 'issue_access' => Access::getIssueAccessArray($this->issue_id, $this->usr_id),

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -281,6 +281,7 @@ class RemoteApi
      * @param string $new_status
      * @return string
      * @access protected
+     * @since 3.2.2 checks access via Issue::canUpdate
      */
     public function setIssueStatus($issue_id, $new_status)
     {

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -24,6 +24,7 @@ use CRMException;
 use Custom_Field;
 use Date_Helper;
 use DateTime;
+use DB_Helper;
 use Draft;
 use Eventum\Monolog\Logger;
 use History;
@@ -112,7 +113,7 @@ class RemoteApi
         $status_id = Status::getStatusID($status);
         $usr_id = Auth::getUserID();
 
-        $results = Issue::getOpenIssues($prj_id, $usr_id, $show_all_issues, $status_id);
+        $results = self::getOpenIssuesList($prj_id, $usr_id, $show_all_issues, $status_id);
 
         if (empty($results)) {
             throw new RemoteApiException('There are currently no open issues');
@@ -191,7 +192,7 @@ class RemoteApi
     {
         $usr_id = Auth::getUserID();
 
-        $res = Project::getRemoteAssocListByUser($usr_id, $only_customer_projects);
+        $res = self::getRemoteAssocListByUser($usr_id, $only_customer_projects);
         if (empty($res)) {
             throw new RemoteApiException(
                 'You are not assigned to any projects at this moment or you lack the proper role'
@@ -317,7 +318,7 @@ class RemoteApi
         }
 
         // check if the assignee is even allowed to be in the given project
-        $projects = Project::getRemoteAssocListByUser($assignee);
+        $projects = self::getRemoteAssocListByUser($assignee);
         if (!in_array($project_id, array_keys($projects))) {
             throw new RemoteApiException(
                 "The selected developer is not permitted in the project associated with issue #$issue_id"
@@ -351,7 +352,7 @@ class RemoteApi
         $usr_id = Auth::getUserID();
 
         // check if the assignee is even allowed to be in the given project
-        $projects = Project::getRemoteAssocListByUser($usr_id);
+        $projects = self::getRemoteAssocListByUser($usr_id);
         if (!in_array($project_id, array_keys($projects))) {
             throw new RemoteApiException(
                 "The selected developer is not permitted in the project associated with issue #$issue_id"
@@ -385,7 +386,7 @@ class RemoteApi
         // if this is an actual user, not just an email address check permissions
         if (!empty($replier_usr_id)) {
             // check if the assignee is even allowed to be in the given project
-            $projects = Project::getRemoteAssocListByUser($replier_usr_id);
+            $projects = self::getRemoteAssocListByUser($replier_usr_id);
             if (!in_array($project_id, array_keys($projects))) {
                 throw new RemoteApiException(
                     "The given user is not permitted in the project associated with issue #$issue_id"
@@ -1088,5 +1089,113 @@ class RemoteApi
             'status' => $new_status,
             'user' => User::getFullName($usr_id),
         ]);
+    }
+
+    /**
+     * Method used to get all issues associated with a status that doesn't have
+     * the 'closed' context.
+     *
+     * @param   int $prj_id The project ID to list issues from
+     * @param   int $usr_id The user ID of the user requesting this information
+     * @param   bool $show_all_issues Whether to show all open issues, or just the ones assigned to the given email address
+     * @param   int $status_id The status ID to be used to restrict results
+     * @return  array The list of open issues
+     */
+    private static function getOpenIssuesList($prj_id, $usr_id, $show_all_issues, $status_id)
+    {
+        $projects = self::getRemoteAssocListByUser($usr_id);
+        if (count($projects) == 0) {
+            return [];
+        }
+
+        $stmt
+            = 'SELECT
+                    iss_id,
+                    iss_summary,
+                    sta_title
+                 FROM
+                    (
+                    {{%issue}},
+                    {{%STATUS}}
+                    )
+                 LEFT JOIN
+                    {{%issue_user}}
+                 ON
+                    isu_iss_id=iss_id
+                 WHERE ';
+        $params = [];
+
+        if (!empty($status_id)) {
+            $stmt .= ' sta_id=? AND ';
+            $params[] = $status_id;
+        }
+
+        $stmt
+            .= '
+                    iss_prj_id=? AND
+                    sta_id=iss_sta_id AND
+                    sta_is_closed=0';
+        $params[] = $prj_id;
+        if ($show_all_issues == false) {
+            $stmt
+                .= ' AND
+                    isu_usr_id=?';
+            $params[] = $usr_id;
+        }
+        $stmt
+            .= "\nGROUP BY
+                        iss_id";
+        $res = DB_Helper::getInstance()->getAll($stmt, $params);
+
+        if (count($res) > 0) {
+            Issue::getAssignedUsersByIssues($res);
+        }
+
+        return $res;
+    }
+
+    /**
+     * Method used to get the list of projects assigned to a given user that
+     * allow remote invocation of issues.
+     *
+     * @param   int $usr_id The user ID
+     * @param   bool $only_customer_projects Whether to only include projects with customer integration or not
+     * @return  array The list of projects
+     */
+    private static function getRemoteAssocListByUser($usr_id, $only_customer_projects = false)
+    {
+        static $returns;
+
+        if (!$only_customer_projects && !empty($returns[$usr_id])) {
+            return $returns[$usr_id];
+        }
+
+        $stmt
+            = "SELECT
+                    prj_id,
+                    prj_title
+                 FROM
+                    {{%project}},
+                    {{%project_user}}
+                 WHERE
+                    prj_id=pru_prj_id AND
+                    pru_usr_id=? AND
+                    pru_role > ? AND
+                    prj_remote_invocation='enabled'";
+        if ($only_customer_projects) {
+            $stmt .= " AND prj_customer_backend <> '' AND prj_customer_backend IS NOT NULL ";
+        }
+        $stmt
+            .= '
+                 ORDER BY
+                    prj_title';
+        $res = DB_Helper::getInstance()->getPair($stmt, [$usr_id, User::ROLE_CUSTOMER]);
+
+        // don't cache the results when the optional argument is used to avoid getting bogus results
+        if (!$only_customer_projects) {
+            $returns[$usr_id] = $res;
+        }
+
+        return $res;
     }
 }

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -285,16 +285,13 @@ class RemoteApi
      * @param string $new_status
      * @return string
      * @access protected
-     * @since 3.2.2 checks access via Issue::canUpdate
+     * @since 3.2.2 checks access via Access::canChangeStatus
      */
     public function setIssueStatus($issue_id, $new_status)
     {
         $usr_id = Auth::getUserID();
 
-        $res = self::updateIssueStatus($issue_id, $usr_id, $new_status);
-        if ($res == -1) {
-            throw new RemoteApiException("Could not set the status to issue #$issue_id");
-        }
+        self::updateIssueStatus($issue_id, $usr_id, $new_status);
 
         return 'OK';
     }

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -267,7 +267,7 @@ class RemoteApi
     public function recordTimeWorked($issue_id, $cat_id, $summary, $time_spent)
     {
         $usr_id = Auth::getUserID();
-        if (!Issue::canUpdate($issue_id, $usr_id)) {
+        if (!Access::canUpdateIssue($issue_id, $usr_id)) {
             throw new RemoteApiException("No access to issue #{$issue_id}");
         }
 

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -289,6 +289,8 @@ class RemoteApi
      */
     public function setIssueStatus($issue_id, $new_status)
     {
+        $this->checkIssuePermissions($issue_id);
+
         $usr_id = Auth::getUserID();
 
         self::updateIssueStatus($issue_id, $usr_id, $new_status);
@@ -1194,5 +1196,27 @@ class RemoteApi
         }
 
         return $res;
+    }
+
+    /**
+     * @see \Command_Line::checkIssuePermissions()
+     * @param int $issue_id
+     */
+    private function checkIssuePermissions($issue_id) {
+        $projects = $this->getUserAssignedProjects(false);
+        $details = $this->getIssueDetails($issue_id);
+        $iss_prj_id = (int)$details['iss_prj_id'];
+
+        // check if the issue the user is trying to change is inside a project viewable to him
+        $found = 0;
+        foreach ($projects as $i => $project) {
+            if ($iss_prj_id == $project['id']) {
+                $found = 1;
+                break;
+            }
+        }
+        if (!$found) {
+            throw new RemoteApiException("The assigned project for issue #$issue_id doesn't match any in the list of projects assigned to you");
+        }
     }
 }

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\RPC;
 
+use Access;
 use APIAuthToken;
 use Attachment;
 use Auth;
@@ -1045,7 +1046,7 @@ class RemoteApi
      */
     private static function updateIssueStatus($issue_id, $usr_id, $new_status)
     {
-        if (!Issue::canUpdate($issue_id, $usr_id)) {
+        if (!Access::canChangeStatus($issue_id, $usr_id)) {
             throw new RemoteApiException("User has no access to update issue #$issue_id");
         }
 


### PR DESCRIPTION
this is how it should had always been done.

needed by https://github.com/eventum/cli/pull/3

i replaced whatever access checks (`checkIssuePermissions`, `checkIssueAssignment`) there was with `Issue::canUpdate`. this should be sufficient right @balsdorf ?