### PR TITLE
rpc: harden closeIssue access checks/validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Upgrading to 3.3.0 versions requires that you upgrade to 3.2.0 version first.
 - Use mnapoli/silly for cli applications (@glensc, #279)
 - Unify lengths of header fields (@glensc, #266, #295)
 - Add events for user creation/update (@glensc, #289)
+- Harden closeIssue access checks/validation in RPC code (@glensc, #287)
 
 [3.3.0]: https://github.com/eventum/eventum/compare/v3.2.3...master
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1112,7 +1112,7 @@ class Issue
             'user' => User::getFullName($usr_id),
         ]);
 
-        if ($send_notification_to == 'all') {
+        if ($send_notification_to === 'all') {
             $from = User::getFromHeader($usr_id);
             $message_id = Mail_Helper::generateMessageID();
             $full_email = Support::buildFullHeaders($issue_id, $message_id, $from,
@@ -1165,7 +1165,7 @@ class Issue
                 }
             }
             // send notifications for the issue being closed
-            Notification::notify($issue_id, 'closed', $ids, ($send_notification_to != 'all'));
+            Notification::notify($issue_id, 'closed', $ids, ($send_notification_to !== 'all'));
         }
         Workflow::handleIssueClosed($prj_id, $issue_id, $send_notification, $resolution_id, $status_id, $reason, $usr_id);
 

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -615,11 +615,12 @@ class RemoteApi
                 $email['id'] = $i + 1;
                 unset($email['seb_body']);
             }
+            unset($email);
         }
 
         $setup = Setup::get();
 
-        if (isset($setup['description_email_0']) && $setup['description_email_0'] == 'enabled') {
+        if (isset($setup['description_email_0']) && $setup['description_email_0'] === 'enabled') {
             $issue = Issue::getDetails($issue_id);
             $email = [
                 'id' => 0,
@@ -629,7 +630,7 @@ class RemoteApi
                 'sup_cc' => '',
                 'sup_subject' => $issue['iss_summary'],
             ];
-            if ($real_emails != '') {
+            if ($real_emails !== '') {
                 $emails = array_merge([$email], $real_emails);
             } else {
                 $emails[] = $email;

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -975,9 +975,6 @@ class RemoteApi
         $prj_id = Issue::getProjectID($issue_id);
         AuthCookie::setProjectCookie($prj_id);
 
-        // FIXME: $customer_id unused
-        $customer_id = Issue::getCustomerID($issue_id);
-
         if (!CRM::hasCustomerIntegration($prj_id)) {
             // no customer integration
             throw new RemoteApiException("No customer integration for issue #$issue_id");
@@ -1021,8 +1018,6 @@ class RemoteApi
     {
         $prj_id = Issue::getProjectID($issue_id);
         AuthCookie::setProjectCookie($prj_id);
-        // FIXME: $customer_id unused
-        $customer_id = Issue::getCustomerID($issue_id);
 
         if (!CRM::hasCustomerIntegration($prj_id)) {
             // no customer integration

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -549,20 +549,19 @@ class RemoteApi
             throw new RemoteApiException("Issue #$issue_id already closed");
         }
 
-        // FIXME: this doesn't validate that the status belongs to $issue_id's project
         $status_id = Status::getStatusID($new_status);
-        if (!$status_id) {
+        $prj_id = Issue::getProjectID($issue_id);
+        if (!$status_id || !in_array($prj_id, Status::getAssociatedProjects($status_id))) {
             throw new RemoteApiException("Invalid status: $new_status");
         }
 
-        AuthCookie::setProjectCookie(Issue::getProjectID($issue_id));
+        AuthCookie::setProjectCookie($prj_id);
 
         $res = Issue::close($usr_id, $issue_id, $send_notification, $resolution_id, $status_id, $note);
         if ($res == -1) {
             throw new RemoteApiException("Could not close issue #$issue_id");
         }
 
-        $prj_id = Issue::getProjectID($issue_id);
         if (CRM::hasCustomerIntegration($prj_id)) {
             $crm = CRM::getInstance($prj_id);
             try {


### PR DESCRIPTION
similarly to #280, validate parameters at server side.

i didn't bother to think much, just added similar checks as #280 has:
```php
        $this->checkIssuePermissions($issue_id);
        $this->checkIssueAssignment($issue_id);


        if (!Access::canChangeStatus($issue_id, $usr_id)) {
            throw new RemoteApiException("User has no access to update issue #$issue_id");
        }
```

also checks if issue is not already closed:
```php

        if (Issue::isClosed($issue_id)) {
            throw new RemoteApiException("Issue #$issue_id already closed");
        }
```