### PR TITLE
drop support for old setup.php formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Upgrading to 3.3.0 versions requires that you upgrade to 3.2.0 version first.
 - Fix fatal error when downloading emails from unknown sender with CRM enabled (@balsdorf)
 - Use league/flysystem to abstract attachments (@balsdorf, @glensc, #254)
 - Drop unused/deprecated methods (@glensc, #284)
+- Drop support for old setup.php formats (@glensc, #288)
 
 [3.3.0]: https://github.com/eventum/eventum/compare/v3.2.3...master
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -109,12 +109,7 @@ class Setup
     private static function initialize()
     {
         $config = new Config(self::getDefaults(), true);
-        $config->merge(new Config(self::loadConfigFile(APP_SETUP_FILE, $migrate)));
-
-        if ($migrate) {
-            // save config in new format
-            self::saveConfig(APP_SETUP_FILE, $config);
-        }
+        $config->merge(new Config(self::loadConfigFile(APP_SETUP_FILE)));
 
         // some subtrees are saved to different files
         $extra_configs = [
@@ -126,12 +121,8 @@ class Setup
                 continue;
             }
 
-            $subconfig = self::loadConfigFile($filename, $migrate);
+            $subconfig = self::loadConfigFile($filename);
             if ($subconfig) {
-                if ($migrate) {
-                    // save config in new format
-                    self::saveConfig($filename, new Config($subconfig));
-                }
                 $config->merge(new Config([$section => $subconfig]));
             }
         }
@@ -146,11 +137,8 @@ class Setup
      * @param string $path
      * @return array
      */
-    private static function loadConfigFile($path, &$migrate)
+    private static function loadConfigFile($path)
     {
-        $eventum_setup_string = $eventum_setup = null;
-        $ldap_setup = null;
-
         // return empty array if the file is empty
         // this is to help eventum installation wizard to proceed
         if (!file_exists($path) || !filesize($path)) {
@@ -159,26 +147,7 @@ class Setup
 
         // config array is supposed to be returned from that path
         /** @noinspection PhpIncludeInspection */
-        $config = require $path;
-        // fall back to old modes:
-        // 1. $eventum_setup string
-        // 2. base64 encoded $eventum_setup_string
-        // 3. $ldap_setup
-        if (isset($eventum_setup)) {
-            $config = $eventum_setup;
-            $migrate = true;
-        } elseif (isset($eventum_setup_string)) {
-            $config = unserialize(base64_decode($eventum_setup_string));
-            $migrate = true;
-        } elseif (isset($ldap_setup)) {
-            $config = $ldap_setup;
-            $migrate = true;
-        } elseif ($config == 1) {
-            // something went wrong, do not return "1", but empty array
-            $config = [];
-        }
-
-        return $config;
+        return require $path;
     }
 
     /**


### PR DESCRIPTION
drop support for old setup.php formats:
1. $eventum_setup string
2. base64 encoded $eventum_setup_string
3. $ldap_setup

currently all setup files return the array:
- base64 encoded setup was dropped in 2.3.4
- config/setup.php uses return array since 3.0.0
- config/ldap.php uses return array since 3.0.6

but upgrade to 3.3.0 requires that you upgrade to 3.2.0 first, so this backward compat is safe to be dropped.