### PR TITLE
Prevent alter table in attachment migration

### DIFF
--- a/db/migrations/20170630191008_eventum_attachments.php
+++ b/db/migrations/20170630191008_eventum_attachments.php
@@ -17,11 +17,14 @@ class EventumAttachments extends AbstractMigration
 {
     public function change()
     {
-        $this->table('issue_attachment_file')
-            ->addColumn('iaf_flysystem_path', 'string', ['length' => 255, 'null' => true])
-            ->update();
         $this->table('issue_attachment')
             ->addColumn('iat_min_role', 'integer', ['after' => 'iat_usr_id', 'length' => '1', 'signed' => false, 'null' => false, 'default' => 1])
             ->update();
+
+        $table = $this->table('issue_attachment_file_path', ['id' => false, 'primary_key' => 'iap_iaf_id'])
+            ->addColumn('iap_iaf_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false])
+            ->addColumn('iap_flysystem_path', 'string', ['length' => 255, 'null' => true]);
+        $this->getPrimaryKey($table)->setIdentity(true);
+        $table->create();
     }
 }

--- a/db/migrations/20170630200118_eventum_attachments_migrate.php
+++ b/db/migrations/20170630200118_eventum_attachments_migrate.php
@@ -21,6 +21,10 @@ class EventumAttachmentsMigrate extends AbstractMigration
         $this->execute("INSERT INTO 
                                 issue_attachment_file_path 
                             (
+                                iap_iaf_id,
+                                iap_flysystem_path
+                            )
+                            (
                             SELECT 
                                 iaf_id, 
                                 CONCAT('legacy://', iaf_id)

--- a/db/migrations/20170630200118_eventum_attachments_migrate.php
+++ b/db/migrations/20170630200118_eventum_attachments_migrate.php
@@ -18,6 +18,14 @@ class EventumAttachmentsMigrate extends AbstractMigration
     public function up()
     {
         $this->execute("UPDATE issue_attachment SET iat_min_role = IF(iat_status = 'public', 1, 4)");
-        $this->execute("UPDATE issue_attachment_file SET iaf_flysystem_path = CONCAT('legacy://', iaf_id)");
+        $this->execute("INSERT INTO 
+                                issue_attachment_file_path 
+                            (
+                            SELECT 
+                                iaf_id, 
+                                CONCAT('legacy://', iaf_id)
+                            FROM
+                                issue_attachment_file)
+                            ");
     }
 }

--- a/src/Attachment/Attachment.php
+++ b/src/Attachment/Attachment.php
@@ -285,13 +285,20 @@ class Attachment
         $usr_id = Auth::getUserID();
         $group = $this->getGroup();
         try {
+            $sm = StorageManager::get();
+            $sm->deleteFile($this->flysystem_path);
+
             $sql = 'DELETE FROM
                         `issue_attachment_file`
                     WHERE
                         iaf_id=?';
             DB_Helper::getInstance()->query($sql, [$this->id]);
-            $sm = StorageManager::get();
-            $sm->deleteFile($this->flysystem_path);
+
+            $sql = 'DELETE FROM
+                        `issue_attachment_file_path`
+                    WHERE
+                        iap_iaf_id=?';
+            DB_Helper::getInstance()->query($sql, [$this->id]);
         } catch (DatabaseException $e) {
             return -1;
         }

--- a/src/Attachment/AttachmentGroup.php
+++ b/src/Attachment/AttachmentGroup.php
@@ -150,7 +150,7 @@ class AttachmentGroup
             $attachment = new Attachment($file['iaf_filename'], $file['iaf_filetype']);
             $attachment->id = $file['iaf_id'];
             $attachment->filesize = $file['iaf_filesize'];
-            $attachment->flysystem_path = $file['iaf_flysystem_path'];
+            $attachment->flysystem_path = $file['iap_flysystem_path'];
             $attachment->group_id = $file['iaf_iat_id'];
             $attachments[] = $attachment;
         }

--- a/src/Attachment/AttachmentManager.php
+++ b/src/Attachment/AttachmentManager.php
@@ -182,11 +182,13 @@ class AttachmentManager
                     iaf_filetype,
                     iaf_filesize,
                     iaf_created_date,
-                    iaf_flysystem_path,
+                    iap_flysystem_path,
                     iaf_iat_id
-                FROM
-                    `issue_attachment_file`
-                WHERE
+                 FROM
+                    `issue_attachment_file`,
+                    `issue_attachment_file_path`
+                 WHERE
+                    iap_iaf_id = iaf_id AND
                     iaf_id=?';
         $res = DB_Helper::getInstance()->getRow($sql, [$iaf_id]);
         if (empty($res)) {
@@ -196,7 +198,7 @@ class AttachmentManager
         $attachment = new Attachment($res['iaf_filename'], $res['iaf_filetype']);
         $attachment->id = $iaf_id;
         $attachment->filesize = $res['iaf_filesize'];
-        $attachment->flysystem_path = $res['iaf_flysystem_path'];
+        $attachment->flysystem_path = $res['iap_flysystem_path'];
         $attachment->group_id = $res['iaf_iat_id'];
 
         return $attachment;
@@ -209,10 +211,12 @@ class AttachmentManager
     {
         $sql = "SELECT
                     iaf_id,
-                    iaf_flysystem_path
-                FROM
-                    `issue_attachment_file`
-                WHERE
+                    iap_flysystem_path
+                 FROM
+                    `issue_attachment_file`,
+                    `issue_attachment_file_path`
+                 WHERE
+                    iap_iaf_id = iaf_id AND
                     iaf_iat_id=0 AND
                     iaf_created_date > '0000-00-00 00:00:00' AND
                     iaf_created_date < ?";
@@ -223,9 +227,9 @@ class AttachmentManager
         $sm = StorageManager::get();
         foreach ($res as $row) {
             $iaf_ids[] = $row['iaf_id'];
-            if (!empty($row['iaf_flysystem_path'])) {
+            if (!empty($row['iap_flysystem_path'])) {
                 try {
-                    $sm->deleteFile($row['iaf_flysystem_path']);
+                    $sm->deleteFile($row['iap_flysystem_path']);
                 } catch (FileNotFoundException $e) {
                     // TODO: Should we log this?
                 }
@@ -303,11 +307,13 @@ class AttachmentManager
                     iaf_filetype,
                     iaf_filesize,
                     iaf_created_date,
-                    iaf_flysystem_path,
+                    iap_flysystem_path,
                     iaf_iat_id
                  FROM
-                    `issue_attachment_file`
+                    `issue_attachment_file`,
+                    `issue_attachment_file_path`
                  WHERE
+                    iap_iaf_id = iaf_id AND
                     iaf_iat_id=?';
         try {
             $res = DB_Helper::getInstance()->getAll($stmt, [$group_id]);

--- a/src/Attachment/AttachmentManager.php
+++ b/src/Attachment/AttachmentManager.php
@@ -384,7 +384,8 @@ class AttachmentManager
         $usr_id = Auth::getUserID();
         $group = self::getGroup($iat_id);
         if (!$group->canAccess($usr_id) ||
-            ($usr_id != $group->user_id && User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id) < User::ROLE_MANAGER))
+            ($usr_id != $group->user_id &&
+                User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id)) < User::ROLE_MANAGER)
         ) {
             return -2;
         }

--- a/src/Attachment/EventumLegacyAdapter.php
+++ b/src/Attachment/EventumLegacyAdapter.php
@@ -22,7 +22,7 @@ class EventumLegacyAdapter implements AdapterInterface
 {
     /**
      * @param string $path
-     * @return \Eventum\Attachment\Attachment
+     * @return array
      */
     private function getAttachment($path)
     {
@@ -33,11 +33,13 @@ class EventumLegacyAdapter implements AdapterInterface
                     iaf_filetype,
                     iaf_filesize,
                     iaf_created_date,
-                    iaf_flysystem_path,
+                    iap_flysystem_path,
                     iaf_iat_id
-                FROM
-                    `issue_attachment_file`
-                WHERE
+                 FROM
+                    `issue_attachment_file`,
+                    `issue_attachment_file_path`
+                 WHERE
+                    iap_iaf_id = iaf_id AND
                     iaf_id=?';
         $res = DB_Helper::getInstance()->getRow($sql, [$path]);
 


### PR DESCRIPTION
This changes the new attachment code to use a new table, `issue_attachment_file_path` to store the flysystem path instead of altering the `issue_attachment_file` table. That alter could take significant time and diskspace, depending on how many attachments you had to migrate. 

refs:
- #300 
- #254