### PR TITLE
use ssl=tls for gmail. fixes #308

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ Eventum 3.3.x requires PHP 5.6.
 
 [3.3.2]: https://github.com/eventum/eventum/compare/v3.3.1...master
 
+- Use `ssl=tls` for GMail (@glensc, #308, #311)
+
 ## [3.3.1] - 2017-10-09
 
 Upgrading to 3.3.x versions requires that you upgrade to 3.2.0 version first.

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -115,7 +115,7 @@ class MailTransport
             $options['host'] = $setup['host'];
         }
         if ($setup['port']) {
-            $options['port'] = $setup['port'];
+            $options['port'] = (int)$setup['port'];
         }
 
         if (file_exists('/etc/mailname')) {
@@ -123,10 +123,14 @@ class MailTransport
         }
 
         if ($setup['auth']) {
+            $ssl = $options['port'] === 587 ? 'tls' : 'ssl';
             $options['connection_class'] = 'login';
             $options['connection_config'] = [
                 'username' => $setup['username'],
                 'password' => $setup['password'],
+                /** @see \Zend\Mail\Protocol\Smtp */
+                // possible values: tls, ssl
+                'ssl' => $setup['ssl'] ?: $ssl,
             ];
         }
 

--- a/tests/Mail/GmailTransportTest.php
+++ b/tests/Mail/GmailTransportTest.php
@@ -50,6 +50,7 @@ class GmailTransportTest extends TestCase
             'from' => 'xyz@domain.cz',
             'host' => 'smtp.gmail.com',
             'port' => '587',
+            'ssl' => 'tls',
             'auth' => true,
             'username' => $smtpSetup['username'],
             'password' => $smtpSetup['password'],

--- a/tests/Mail/GmailTransportTest.php
+++ b/tests/Mail/GmailTransportTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Test\Mail;
+
+use Eventum\Mail\MailTransport;
+use Eventum\Test\TestCase;
+use Setup;
+
+/**
+ * Class GmailTransportTest
+ *
+ * Test that smtp.gmail.com works and doesn't error out with:
+ * "Must issue a STARTTLS command first"
+ *
+ * @group mail
+ * @see https://github.com/eventum/eventum/issues/308
+ */
+class GmailTransportTest extends TestCase
+{
+    public function testGmailTransport()
+    {
+        $this->configureSmtp();
+
+        $mail = new MailTransport();
+        $address = 'glen@delfi.ee';
+        $headers = [];
+        $body = 'test';
+        $mail->send($address, $headers, $body);
+    }
+
+    private function configureSmtp()
+    {
+        $smtpSetup = Setup::get()['tests.smtp'];
+        if (!$smtpSetup) {
+            $this->markTestSkipped('configure tests.smtp for test');
+        }
+
+        $smtp = [
+            'from' => 'xyz@domain.cz',
+            'host' => 'smtp.gmail.com',
+            'port' => '587',
+            'auth' => true,
+            'username' => $smtpSetup['username'],
+            'password' => $smtpSetup['password'],
+            'type' => 'smtp',
+        ];
+
+        Setup::set(['smtp' => $smtp]);
+    }
+}


### PR DESCRIPTION
adds `ssl` option support to `config/setup.php`  with values `tls' or `ssl`. fixes #308

```php
        $smtp = [
            'from' => 'xyz@domain.cz',
            'host' => 'smtp.gmail.com',
            'port' => '587',
            'ssl' => 'tls',
            'auth' => true,
            'username' => ...,
            'password' => ...,
        ];
```

additionally sets `ssl=tls` based on `port` value.