### PR TITLE
Prevent users from viewing "removed" notes

### DIFF
--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -63,7 +63,7 @@ class Note
      * Retrieves the details about a given note.
      *
      * @param   int $note_id The note ID
-     * @return  array The note details
+     * @return  false|array The note details
      */
     public static function getDetails($note_id)
     {
@@ -77,13 +77,9 @@ class Note
                  WHERE
                     not_usr_id=usr_id AND
                     not_id=?';
-        try {
-            $res = DB_Helper::getInstance()->getRow($stmt, [$note_id]);
-        } catch (DatabaseException $e) {
-            return '';
-        }
+        $res = DB_Helper::getInstance()->getRow($stmt, [$note_id]);
 
-        if (count($res) > 0) {
+        if ($res) {
             $res['timestamp'] = Date_Helper::getUnixTimestamp($res['not_created_date'], 'GMT');
 
             if ($res['not_is_blocked'] == 1) {
@@ -103,7 +99,7 @@ class Note
             return $res;
         }
 
-        return '';
+        return false;
     }
 
     /**
@@ -446,6 +442,8 @@ class Note
             return -2;
         }
 
+        // Notes are not deleted so a record of the the not_message_id is
+        // preserved to prevent duplicates from being downloaded.
         $stmt = 'UPDATE
                     `note`
                  SET

--- a/src/Controller/ViewNoteController.php
+++ b/src/Controller/ViewNoteController.php
@@ -35,6 +35,11 @@ class ViewNoteController extends BaseController
     private $issue_id;
 
     /**
+     * @var array
+     */
+    private $note_details;
+
+    /**
      * {@inheritdoc}
      */
     protected function configure()
@@ -52,16 +57,13 @@ class ViewNoteController extends BaseController
         Auth::checkAuthentication();
 
         $this->usr_id = Auth::getUserID();
-        $this->issue_id = Note::getIssueID($this->note_id);
-
-        if (!Access::canViewInternalNotes($this->issue_id, $this->usr_id)) {
+        $this->note_details = Note::getDetails($this->note_id);
+        if (!$this->note_details || $this->note_details['not_removed'] == 1) {
             return false;
         }
+        $this->issue_id = $this->note_details['not_iss_id'];
 
-        // FIXME: is this superfluous? Access::canViewInternalNotes does all the checks?
-        $prj_id = Issue::getProjectID($this->issue_id);
-        $role_id = User::getRoleByUser($this->usr_id, $prj_id);
-        if ($role_id < User::ROLE_USER) {
+        if (!Access::canViewInternalNotes($this->issue_id, $this->usr_id)) {
             return false;
         }
 
@@ -80,21 +82,12 @@ class ViewNoteController extends BaseController
      */
     protected function prepareTemplate()
     {
-        $note = Note::getDetails($this->note_id);
-        if (!$note) {
-            $this->tpl->assign('note', '');
-
-            return;
-        }
-
-        $note['message'] = $note['not_note'];
-
         $seq_no = Note::getNoteSequenceNumber($this->issue_id, $this->note_id);
         // TRANSLATORS: %1: note sequence number, %2: note title
-        $extra_title = ev_gettext('Note #%1$s: %2$s', $seq_no, $note['not_title']);
+        $extra_title = ev_gettext('Note #%1$s: %2$s', $seq_no, $this->note_details['not_title']);
         $this->tpl->assign(
             [
-                'note' => $note,
+                'note' => $this->note_details,
                 'issue_id' => $this->issue_id,
                 'extra_title' => $extra_title,
                 'recipients' => Mail_Queue::getMessageRecipients('notes', $this->note_id),

--- a/templates/view_note.tpl.html
+++ b/templates/view_note.tpl.html
@@ -131,7 +131,7 @@ function viewNote(id)
         </tr>
         <tr>
           <td colspan="2" id="email_message">
-            {$note.message|format_email}
+            {$note.not_note|format_email}
           </td>
         </tr>
         <tr class="buttons">


### PR DESCRIPTION
This prevents users from accessing notes marked as removed as well as documenting why we use `not_removed` instead of actually deleting them.

@glensc , do you think it would be better to actually delete the note if it wasn't routed from an email (i.e. `not_message_id` is blank) ? Another option would be for removed notes set the title and body to be null.

While I was updating code I did some general cleanup such as stop hiding errors and removing code flagged in FIXMEs (once I confirmed it was no longer needed)