### PR TITLE
Support multiple selections in search fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Upgrading to 3.4.x versions requires that you upgrade to 3.2.0 version first.
 
 - Use Doctrine as ORM for SCM and IssueAssociation (@glensc, #307)
+- Support multiple selections in search fields (@inguin, #323)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/db/migrations/20171109145542_eventum_custom_filter_multiselect.php
+++ b/db/migrations/20171109145542_eventum_custom_filter_multiselect.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumCustomFilterMultiselect extends AbstractMigration
+{
+    const COLUMNS = [
+        'cst_iss_pri_id' => 'cst_priorities',
+        'cst_iss_sev_id' => 'cst_severities',
+        'cst_reporter'   => 'cst_reporters',
+        'cst_iss_prc_id' => 'cst_categories',
+        'cst_iss_sta_id' => 'cst_statuses',
+        'cst_iss_pre_id' => 'cst_releases',
+        'cst_pro_id'     => 'cst_products',
+    ];
+
+    public function up()
+    {
+        $table = $this->table('custom_filter');
+        foreach (self::COLUMNS as $old_name => $new_name) {
+            $table->changeColumn($old_name, 'string', ['length' => 255, 'null' => true]);
+            $table->renameColumn($old_name, $new_name);
+        }
+        $table->changeColumn('cst_users', 'string', ['length' => 255, 'null' => true]);
+        $table->save();
+    }
+
+    public function down()
+    {
+        $table = $this->table('custom_filter');
+        foreach (self::COLUMNS as $old_name => $new_name) {
+            $table->changeColumn($new_name, 'integer', ['length' => 10, 'null' => true, 'signed' => false]);
+            $table->renameColumn($new_name, $old_name);
+        }
+        $table->changeColumn('cst_users', 'string', ['length' => 64, 'null' => true]);
+        $table->save();
+    }
+}

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -158,15 +158,15 @@ class Filter
             $stmt = 'UPDATE
                         `custom_filter`
                      SET
-                        cst_iss_pri_id=?,
-                        cst_iss_sev_id=?,
+                        cst_priorities=?,
+                        cst_severities=?,
                         cst_keywords=?,
                         cst_users=?,
-                        cst_reporter=?,
-                        cst_iss_sta_id=?,
-                        cst_iss_pre_id=?,
-                        cst_iss_prc_id=?,
-                        cst_pro_id=?,
+                        cst_reporters=?,
+                        cst_statuses=?,
+                        cst_releases=?,
+                        cst_categories=?,
+                        cst_products=?,
                         cst_rows=?,
                         cst_sort_by=?,
                         cst_sort_order=?,
@@ -246,15 +246,15 @@ class Filter
                         cst_usr_id,
                         cst_prj_id,
                         cst_title,
-                        cst_iss_pri_id,
-                        cst_iss_sev_id,
+                        cst_priorities,
+                        cst_severities,
                         cst_keywords,
                         cst_users,
-                        cst_reporter,
-                        cst_iss_sta_id,
-                        cst_iss_pre_id,
-                        cst_iss_prc_id,
-                        cst_pro_id,
+                        cst_reporters,
+                        cst_statuses,
+                        cst_releases,
+                        cst_categories,
+                        cst_products,
                         cst_rows,
                         cst_sort_by,
                         cst_sort_order,
@@ -747,12 +747,12 @@ class Filter
         //      "title" => human readable title,
         //      "param" => name that appears in get, post or cookie
         $fields = [
-            'iss_pri_id' => [
+            'priorities' => [
                 'title' => ev_gettext('Priority'),
                 'param' => 'priority',
                 'quickfilter' => true,
             ],
-            'iss_sev_id' => [
+            'severities' => [
                 'title' => ev_gettext('Severity'),
                 'param' => 'severity',
                 'quickfilter' => true,
@@ -767,17 +767,17 @@ class Filter
                 'param' => 'users',
                 'quickfilter' => true,
             ],
-            'iss_prc_id' => [
+            'categories' => [
                 'title' => ev_gettext('Category'),
                 'param' => 'category',
                 'quickfilter' => true,
             ],
-            'iss_sta_id' => [
+            'statuses' => [
                 'title' => ev_gettext('Status'),
                 'param' => 'status',
                 'quickfilter' => true,
             ],
-            'iss_pre_id' => [
+            'releases' => [
                 'title' => ev_gettext('Release'),
                 'param' => 'release',
             ],
@@ -834,7 +834,7 @@ class Filter
                 'title' => ev_gettext('Search Type'),
                 'param' => 'search_type',
             ],
-            'reporter' => [
+            'reporters' => [
                 'title' => ev_gettext('Reporter'),
                 'param' => 'reporter',
             ],
@@ -842,7 +842,7 @@ class Filter
                 'title' => ev_gettext('Customer'),
                 'param' => 'customer_id',
             ],
-            'pro_id' => [
+            'products' => [
                 'title' => ev_gettext('Product'),
                 'param' => 'product',
             ],

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -65,6 +65,9 @@ class Search
     public static function getArrayParam($name, $request_only)
     {
         $value = self::getParam($name, $request_only);
+        if ($value == 'last') {
+            $value = self::getParam('last_' . $name, $request_only);
+        }
         if (!is_array($value)) {
             $value = [$value];
         }

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -56,6 +56,22 @@ class Search
     }
 
     /**
+     * Method used to get a specific array parameter in the issue listing cookie.
+     *
+     * @param string $name The name of the parameter
+     * @param bool $request_only If only $_GET and $_POST should be checked
+     * @return array
+     */
+    public static function getArrayParam($name, $request_only)
+    {
+        $value = self::getParam($name, $request_only);
+        if (!is_array($value)) {
+            $value = [$value];
+        }
+        return $value;
+    }
+
+    /**
      * Method used to save the current search parameters in a cookie.
      * TODO: split to buildSearchParams() and actual saveSearchParams()
      *
@@ -94,19 +110,19 @@ class Search
             'match_mode' => self::getParam('match_mode', $request_only),
             'hide_excerpts' => self::getParam('hide_excerpts', $request_only),
             'search_type' => Misc::stripHTML($search_type),
-            'users' => Misc::escapeString(self::getParam('users', $request_only)),
-            'status' => Misc::escapeInteger(self::getParam('status', $request_only)),
-            'priority' => Misc::escapeInteger(self::getParam('priority', $request_only)),
-            'severity' => Misc::escapeInteger(self::getParam('severity', $request_only)),
-            'category' => Misc::escapeInteger(self::getParam('category', $request_only)),
+            'users' => Misc::escapeInteger(self::getArrayParam('users', $request_only)),
+            'status' => Misc::escapeInteger(self::getArrayParam('status', $request_only)),
+            'priority' => Misc::escapeInteger(self::getArrayParam('priority', $request_only)),
+            'severity' => Misc::escapeInteger(self::getArrayParam('severity', $request_only)),
+            'category' => Misc::escapeInteger(self::getArrayParam('category', $request_only)),
             'customer_email' => Misc::stripHTML(self::getParam('customer_email', $request_only)),
             // advanced search form
             'show_authorized_issues' => Misc::escapeString(self::getParam('show_authorized_issues', $request_only)),
             'show_notification_list_issues' => Misc::escapeString(self::getParam('show_notification_list_issues', $request_only)),
-            'reporter' => Misc::escapeInteger(self::getParam('reporter', $request_only)),
-            'product' => Misc::escapeInteger(self::getParam('product', $request_only)),
+            'reporter' => Misc::escapeInteger(self::getArrayParam('reporter', $request_only)),
+            'product' => Misc::escapeInteger(self::getArrayParam('product', $request_only)),
             // other fields
-            'release' => Misc::escapeInteger(self::getParam('release', $request_only)),
+            'release' => Misc::escapeInteger(self::getArrayParam('release', $request_only)),
             // custom fields
             'custom_field' => Misc::stripHTML($custom_field),
         ];
@@ -491,35 +507,46 @@ class Search
         }
 
         if (!empty($options['users'])) {
-            $stmt .= " AND (\n";
-            if (stripos($options['users'], 'grp') !== false) {
-                $chunks = explode(':', $options['users']);
-                $stmt .= 'iss_grp_id = ' . Misc::escapeInteger($chunks[1]);
-            } else {
-                if ($options['users'] == '-1') {
-                    $stmt .= 'isu_usr_id IS NULL';
-                } elseif ($options['users'] == '-2') {
-                    $stmt .= 'isu_usr_id IS NULL OR isu_usr_id=' . $usr_id;
-                } elseif ($options['users'] == '-3') {
-                    $stmt .= 'isu_usr_id = ' . $usr_id;
-                    $user_groups = User::getGroupIDs($usr_id);
-                    if (count($user_groups) > 0) {
-                        $stmt .= ' OR iss_grp_id IN(' . implode(',', $user_groups) . ')';
+            if (count($options['users']) > 0 && $options['users'][0] != '') {
+                $stmt .= " AND (\n";
+                $first = true;
+                foreach ($options['users'] as $my_user) {
+                    if (!$first) {
+                        $stmt .= ' OR ';
                     }
-                } elseif ($options['users'] == '-4') {
-                    $stmt .= 'isu_usr_id IS NULL OR isu_usr_id = ' . $usr_id;
-                    $user_groups = User::getGroupIDs($usr_id);
-                    if (count($user_groups) > 0) {
-                        $stmt .= ' OR iss_grp_id IN(' . implode(',', $user_groups) . ')';
+                    $first = false;
+                    $stmt .= '(';
+                    if (stripos($my_user, 'grp') !== false) {
+                        $chunks = explode(':', $my_user);
+                        $stmt .= 'iss_grp_id = ' . Misc::escapeInteger($chunks[1]);
+                    } else {
+                        if ($my_user == '-1') {
+                            $stmt .= 'isu_usr_id IS NULL';
+                        } elseif ($my_user == '-2') {
+                            $stmt .= 'isu_usr_id IS NULL OR isu_usr_id=' . $usr_id;
+                        } elseif ($my_user == '-3') {
+                            $stmt .= 'isu_usr_id = ' . $usr_id;
+                            $user_groups = User::getGroupIDs($usr_id);
+                            if (count($user_groups) > 0) {
+                                $stmt .= ' OR iss_grp_id IN(' . implode(',', $user_groups) . ')';
+                            }
+                        } elseif ($my_user == '-4') {
+                            $stmt .= 'isu_usr_id IS NULL OR isu_usr_id = ' . $usr_id;
+                            $user_groups = User::getGroupIDs($usr_id);
+                            if (count($user_groups) > 0) {
+                                $stmt .= ' OR iss_grp_id IN(' . implode(',', $user_groups) . ')';
+                            }
+                        } else {
+                            $stmt .= 'isu_usr_id =' . Misc::escapeInteger($my_user);
+                        }
                     }
-                } else {
-                    $stmt .= 'isu_usr_id =' . Misc::escapeInteger($options['users']);
+                    $stmt .= ')';
                 }
+                $stmt .= ')';
             }
-            $stmt .= ')';
         }
-        if (!empty($options['reporter'])) {
-            $stmt .= ' AND iss_usr_id = ' . Misc::escapeInteger($options['reporter']);
+        if (!empty($options['reporter']) && count($options['reporter']) > 0 && $options['reporter'][0] != '') {
+            $stmt .= ' AND iss_usr_id IN (' . implode(', ', Misc::escapeInteger($options['reporter'])) . ')';
         }
         if (!empty($options['show_authorized_issues'])) {
             $stmt .= " AND (iur_usr_id=$usr_id)";
@@ -550,29 +577,26 @@ class Search
         if (!empty($options['customer_id'])) {
             $stmt .= " AND iss_customer_id='" . Misc::escapeString($options['customer_id']) . "'";
         }
-        if (!empty($options['priority'])) {
-            $stmt .= ' AND iss_pri_id=' . Misc::escapeInteger($options['priority']);
+        if (!empty($options['priority']) && count($options['priority']) > 0 && $options['priority'][0] != '') {
+            $stmt .= ' AND iss_pri_id IN (' . implode(', ', Misc::escapeInteger($options['priority'])) . ')';
         }
-        if (!empty($options['severity'])) {
-            $stmt .= ' AND iss_sev_id=' . Misc::escapeInteger($options['severity']);
+        if (!empty($options['severity']) && count($options['severity']) > 0 && $options['severity'][0] != '') {
+            $stmt .= ' AND iss_sev_id IN (' . implode(', ', Misc::escapeInteger($options['severity'])) . ')';
         }
-        if (!empty($options['status'])) {
-            $stmt .= ' AND iss_sta_id=' . Misc::escapeInteger($options['status']);
+        if (!empty($options['status']) && count($options['status']) > 0 && $options['status'][0] != '') {
+            $stmt .= ' AND iss_sta_id IN (' . implode(', ', Misc::escapeInteger($options['status'])) . ')';
         }
-        if (!empty($options['category'])) {
-            if (!is_array($options['category'])) {
-                $options['category'] = [$options['category']];
-            }
-            $stmt .= ' AND iss_prc_id IN(' . implode(', ', Misc::escapeInteger($options['category'])) . ')';
+        if (!empty($options['category']) && count($options['category']) > 0 && $options['category'][0] != '') {
+            $stmt .= ' AND iss_prc_id IN (' . implode(', ', Misc::escapeInteger($options['category'])) . ')';
         }
         if (!empty($options['hide_closed'])) {
             $stmt .= ' AND sta_is_closed=0';
         }
-        if (!empty($options['release'])) {
-            $stmt .= ' AND iss_pre_id = ' . Misc::escapeInteger($options['release']);
+        if (!empty($options['release']) && count($options['release']) > 0 && $options['release'][0] != '') {
+            $stmt .= ' AND iss_pre_id IN (' . implode(', ', Misc::escapeInteger($options['release'])) . ')';
         }
-        if (!empty($options['product'])) {
-            $stmt .= ' AND ipv_pro_id = ' . Misc::escapeInteger($options['product']);
+        if (!empty($options['product']) && count($options['product']) > 0 && $options['product'][0] != '') {
+            $stmt .= ' AND ipv_pro_id IN (' . implode(', ', Misc::escapeInteger($options['product'])) . ')';
         }
         // now for the date fields
         $date_fields = [

--- a/src/Controller/AdvSearchController.php
+++ b/src/Controller/AdvSearchController.php
@@ -86,8 +86,8 @@ class AdvSearchController extends BaseController
 
         $this->tpl->assign([
             'cats' => Category::getAssocList($this->prj_id),
-            'priorities' => Priority::getList($this->prj_id),
-            'severities' => Severity::getList($this->prj_id),
+            'priorities' => Priority::getAssocList($this->prj_id),
+            'severities' => Severity::getAssocList($this->prj_id),
             'status' => Status::getAssocStatusList($this->prj_id),
             'users' => $assign_options,
             'releases' => Release::getAssocList($this->prj_id, true),

--- a/src/Controller/RssController.php
+++ b/src/Controller/RssController.php
@@ -178,9 +178,9 @@ class RssController extends BaseController
         $options = [
             'users' => $filter['cst_users'],
             'keywords' => $filter['cst_keywords'],
-            'priority' => $filter['cst_iss_pri_id'],
-            'category' => $filter['cst_iss_prc_id'],
-            'status' => $filter['cst_iss_sta_id'],
+            'priority' => $filter['cst_priorities'],
+            'category' => $filter['cst_categories'],
+            'status' => $filter['cst_statuses'],
             'hide_closed' => $filter['cst_hide_closed'],
             'sort_by' => $filter['cst_sort_by'],
             'sort_order' => $filter['cst_sort_order'],

--- a/templates/adv_search.tpl.html
+++ b/templates/adv_search.tpl.html
@@ -63,7 +63,7 @@
         <tr>
           <td valign="top">
             <label>{t}Assigned{/t}<br />
-            <select name="users">
+            <select name="users[]" multiple size="10">
               {html_options options=$users selected=$options.cst_users|default:''}
             </select>
             </label>
@@ -71,11 +71,9 @@
           {if $cats|@count > 0}
           <td>
             <label>{t}Category{/t}<br />
-            <select name="category">
-              <option value="">{t}any{/t}</option>
-              {foreach key=prc_id item=prc_title from=$cats}
-              <option value="{$prc_id}" {if $prc_id == $options.cst_categories|default:''}selected{/if}>{$prc_title}</option>
-              {/foreach}
+            <select name="category[]" multiple size="10">
+              <option value="" {if !isset($options.cst_categories) || $options.cst_categories[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$cats selected=$options.cst_categories|default:''}
             </select>
             </label>
           </td>
@@ -83,33 +81,27 @@
           {if $priorities|@count > 0}
           <td>
             <label>{t}Priority{/t}<br />
-            <select name="priority">
-              <option value="">{t}any{/t}</option>
-              {section name="i" loop=$priorities}
-              <option value="{$priorities[i].pri_id}" {if $priorities[i].pri_id == $options.cst_priorities|default:''}selected{/if}>{$priorities[i].pri_title}</option>
-              {/section}
+            <select name="priority[]" multiple size="10">
+              <option value="" {if !isset($options.cst_priorities) || $options.cst_priorities[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$priorities selected=$options.cst_priorities|default:''}
             </select>
             </label>
           </td>
           {/if}
           {if $severities|@count > 0}
           <td>
-            <span class="default">{t}Severity{/t}:</span><br />
-            <select name="severity" class="default">
-              <option value="">{t}any{/t}</option>
-              {section name="i" loop=$severities}
-              <option value="{$severities[i].sev_id}" {if $severities[i].sev_id == $options.cst_severities|default:''}selected{/if}>{$severities[i].sev_title}</option>
-              {/section}
+            <label>{t}Severity{/t}<br />
+            <select name="severity[]" multiple size="10">
+              <option value="" {if !isset($options.cst_severities) || $options.cst_severities[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$severities selected=$options.cst_severities|default:''}
             </select>
           </td>
           {/if}
           <td valign="top">
             <label>{t}Status{/t}<br />
-            <select name="status">
-              <option value="">{t}any{/t}</option>
-              {foreach key=sta_id item=sta_title from=$status}
-              <option value="{$sta_id}" {if $sta_id == $options.cst_statuses|default:''}selected{/if}>{$sta_title}</option>
-              {/foreach}
+            <select name="status[]" multiple size="10">
+              <option value="" {if !isset($options.cst_statuses) || $options.cst_statuses[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$status selected=$options.cst_statuses|default:''}
             </select>
             </label>
           </td>
@@ -117,8 +109,8 @@
         <tr>
           <td>
             <label>{t}Reporter{/t}<br />
-            <select name="reporter">
-              <option value="">{t}Any{/t}</option>
+            <select name="reporter[]" multiple size="10">
+              <option value="" {if !isset($options.cst_reporters) || $options.cst_reporters[0] == ""}selected{/if}>{t}Any{/t}</option>
               {html_options options=$reporters selected=$options.cst_reporters|default:''}
             </select>
             </label>
@@ -126,23 +118,19 @@
           {if $releases|@count > 0}
           <td>
             <label>{t}Release{/t}<br />
-            <select name="release">
-              <option value="">{t}any{/t}</option>
-              {foreach key=pre_id item=pre_title from=$releases}
-              <option value="{$pre_id}" {if $pre_id == $options.cst_releases|default:''}selected{/if}>{$pre_title}</option>
-              {/foreach}
+            <select name="release[]" multiple size="10">
+              <option value="" {if !isset($options.cst_releases) || $options.cst_releases[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$releases selected=$options.cst_releases|default:''}
             </select>
             </label>
           </td>
           {/if}
           {if $products|@count > 0}
           <td>
-            <span class="default">{t}Product{/t}:</span><br />
-            <select name="product" class="default">
-              <option value="">{t}any{/t}</option>
-              {foreach key=pro_id item=pro_title from=$products}
-              <option value="{$pro_id}" {if $pro_id == $options.cst_products|default:''}selected{/if}>{$pro_title}</option>
-              {/foreach}
+            <label>{t}Product{/t}<br />
+            <select name="product[]" multiple size="10">
+              <option value="" {if !isset($options.cst_products) || $options.cst_products[0] == ""}selected{/if}>{t}any{/t}</option>
+              {html_options options=$products selected=$options.cst_products|default:''}
             </select>
           </td>
           {/if}

--- a/templates/adv_search.tpl.html
+++ b/templates/adv_search.tpl.html
@@ -74,7 +74,7 @@
             <select name="category">
               <option value="">{t}any{/t}</option>
               {foreach key=prc_id item=prc_title from=$cats}
-              <option value="{$prc_id}" {if $prc_id == $options.cst_iss_prc_id|default:''}selected{/if}>{$prc_title}</option>
+              <option value="{$prc_id}" {if $prc_id == $options.cst_categories|default:''}selected{/if}>{$prc_title}</option>
               {/foreach}
             </select>
             </label>
@@ -86,7 +86,7 @@
             <select name="priority">
               <option value="">{t}any{/t}</option>
               {section name="i" loop=$priorities}
-              <option value="{$priorities[i].pri_id}" {if $priorities[i].pri_id == $options.cst_iss_pri_id|default:''}selected{/if}>{$priorities[i].pri_title}</option>
+              <option value="{$priorities[i].pri_id}" {if $priorities[i].pri_id == $options.cst_priorities|default:''}selected{/if}>{$priorities[i].pri_title}</option>
               {/section}
             </select>
             </label>
@@ -98,7 +98,7 @@
             <select name="severity" class="default">
               <option value="">{t}any{/t}</option>
               {section name="i" loop=$severities}
-              <option value="{$severities[i].sev_id}" {if $severities[i].sev_id == $options.cst_iss_sev_id|default:''}selected{/if}>{$severities[i].sev_title}</option>
+              <option value="{$severities[i].sev_id}" {if $severities[i].sev_id == $options.cst_severities|default:''}selected{/if}>{$severities[i].sev_title}</option>
               {/section}
             </select>
           </td>
@@ -108,7 +108,7 @@
             <select name="status">
               <option value="">{t}any{/t}</option>
               {foreach key=sta_id item=sta_title from=$status}
-              <option value="{$sta_id}" {if $sta_id == $options.cst_iss_sta_id|default:''}selected{/if}>{$sta_title}</option>
+              <option value="{$sta_id}" {if $sta_id == $options.cst_statuses|default:''}selected{/if}>{$sta_title}</option>
               {/foreach}
             </select>
             </label>
@@ -119,7 +119,7 @@
             <label>{t}Reporter{/t}<br />
             <select name="reporter">
               <option value="">{t}Any{/t}</option>
-              {html_options options=$reporters selected=$options.cst_reporter|default:''}
+              {html_options options=$reporters selected=$options.cst_reporters|default:''}
             </select>
             </label>
           </td>
@@ -129,7 +129,7 @@
             <select name="release">
               <option value="">{t}any{/t}</option>
               {foreach key=pre_id item=pre_title from=$releases}
-              <option value="{$pre_id}" {if $pre_id == $options.cst_iss_pre_id|default:''}selected{/if}>{$pre_title}</option>
+              <option value="{$pre_id}" {if $pre_id == $options.cst_releases|default:''}selected{/if}>{$pre_title}</option>
               {/foreach}
             </select>
             </label>
@@ -141,7 +141,7 @@
             <select name="product" class="default">
               <option value="">{t}any{/t}</option>
               {foreach key=pro_id item=pro_title from=$products}
-              <option value="{$pro_id}" {if $pro_id == $options.cst_pro_id|default:''}selected{/if}>{$pro_title}</option>
+              <option value="{$pro_id}" {if $pro_id == $options.cst_products|default:''}selected{/if}>{$pro_title}</option>
               {/foreach}
             </select>
           </td>

--- a/templates/quick_filter_form.tpl.html
+++ b/templates/quick_filter_form.tpl.html
@@ -26,11 +26,11 @@
         <input type="hidden" name="show_authorized_issues" value="{$options.show_authorized_issues|default:''}">
         <input type="hidden" name="show_notification_list_issues" value="{$options.show_notification_list_issues|default:''}">
         <input type="hidden" name="custom_field" value="{$options.custom_field|@serialize|urlencode}">
-        {foreach from=$options.reporter item=$reporter}
+        {foreach from=$options.reporter item=reporter}
         <input type="hidden" name="reporter[]" value="{$reporter}">
         {/foreach}
         <input type="hidden" name="customer_id" value="{$options.customer_id|default:''}">
-        {foreach from=$options.product item=$product}
+        {foreach from=$options.product item=product}
         <input type="hidden" name="product[]" value="{$product}">
         {/foreach}
         {if $categories|@count < 1}
@@ -42,12 +42,27 @@
         {if $priorities|@count < 1}
         <input type="hidden" name="priority[]" value="">
         {/if}
-        {foreach from=$options.release item=$release}
+        {foreach from=$options.release item=release}
         <input type="hidden" name="release[]" value="{$release}">
         {/foreach}
         {if $core.current_role == $core.roles.customer}
         <input type="hidden" name="users[]" value="">
         {/if}
+        {foreach from=$options.users item=user}
+        <input type="hidden" name="last_users[]" value="{$user}">
+        {/foreach}
+        {foreach from=$options.category item=category}
+        <input type="hidden" name="last_category[]" value="{$category}">
+        {/foreach}
+        {foreach from=$options.priority item=priority}
+        <input type="hidden" name="last_priority[]" value="{$priority}">
+        {/foreach}
+        {foreach from=$options.severity item=severity}
+        <input type="hidden" name="last_severity[]" value="{$severity}">
+        {/foreach}
+        {foreach from=$options.status item=status}
+        <input type="hidden" name="last_status[]" value="{$status}">
+        {/foreach}
         <tr>
             <td nowrap>
                 <span>{t}Keyword(s){/t}:</span><br />
@@ -94,43 +109,72 @@
             {if $core.current_role != $core.roles.customer}
             <td valign="top">
                 <span>{t}Assigned{/t}:</span><br />
-                <select name="users[]" multiple size="8">
+                <select name="users">
+                    {if $options.users|@count > 1}
+                    <option value="last" selected>{t}multiple selections{/t}</option>
+                    {html_options options=$assign_options}
+                    {else}
                     {html_options options=$assign_options selected=$options.users}
+                    {/if}
                 </select>
             </td>
             {/if}
             {if $categories|@count > 0}
             <td valign="top">
                 <span>{t}Category{/t}:</span><br />
-                <select name="category[]" multiple size="8">
+                <select name="category">
+                    {if $options.category|@count > 1}
+                    <option value="last" selected>{t}multiple selections{/t}</option>
+                    <option value="">{t}any{/t}</option>
+                    {html_options options=$categories}
+                    {else}
                     <option value="" {if $options.category[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$categories selected=$options.category}
+                    {/if}
                 </select>
             </td>
             {/if}
             {if $priorities|@count > 0}
             <td valign="top">
                 <span>{t}Priority{/t}:</span><br />
-                <select name="priority[]" multiple size="8">
+                <select name="priority">
+                    {if $options.priority|@count > 1}
+                    <option value="last" selected>{t}multiple selections{/t}</option>
+                    <option value="">{t}any{/t}</option>
+                    {html_options options=$priorities}
+                    {else}
                     <option value="" {if $options.priority[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$priorities selected=$options.priority}
+                    {/if}
                 </select>
             </td>
             {/if}
             {if $severities|@count > 0}
             <td valign="top">
                 <span>{t}Severity{/t}:</span><br />
-                <select name="severity[]" multiple size="8">
+                <select name="severity">
+                    {if $options.severity|@count > 1}
+                    <option value="last" selected>{t}multiple selections{/t}</option>
+                    <option value="">{t}any{/t}</option>
+                    {html_options options=$severities}
+                    {else}
                     <option value="" {if $options.severity[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$severities selected=$options.severity}
+                    {/if}
                 </select>
             </td>
             {/if}
             <td valign="top">
                 <span>{t}Status{/t}:</span><br />
-                <select name="status[]" multiple size="8">
+                <select name="status">
+                    {if $options.status|@count > 1}
+                    <option value="last" selected>{t}multiple selections{/t}</option>
+                    <option value="">{t}any{/t}</option>
+                    {html_options options=$status}
+                    {else}
                     <option value="" {if $options.status[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$status selected=$options.status}
+                    {/if}
                 </select>
             </td>
         </tr>

--- a/templates/quick_filter_form.tpl.html
+++ b/templates/quick_filter_form.tpl.html
@@ -26,21 +26,27 @@
         <input type="hidden" name="show_authorized_issues" value="{$options.show_authorized_issues|default:''}">
         <input type="hidden" name="show_notification_list_issues" value="{$options.show_notification_list_issues|default:''}">
         <input type="hidden" name="custom_field" value="{$options.custom_field|@serialize|urlencode}">
-        <input type="hidden" name="reporter" value="{$options.reporter|default:''}">
+        {foreach from=$options.reporter item=$reporter}
+        <input type="hidden" name="reporter[]" value="{$reporter}">
+        {/foreach}
         <input type="hidden" name="customer_id" value="{$options.customer_id|default:''}">
-        <input type="hidden" name="product" value="">
+        {foreach from=$options.product item=$product}
+        <input type="hidden" name="product[]" value="{$product}">
+        {/foreach}
         {if $categories|@count < 1}
-        <input type="hidden" name="category" value="">
+        <input type="hidden" name="category[]" value="">
         {/if}
         {if $severities|@count < 1}
-        <input type="hidden" name="severity" value="">
+        <input type="hidden" name="severity[]" value="">
         {/if}
         {if $priorities|@count < 1}
-        <input type="hidden" name="priority" value="">
+        <input type="hidden" name="priority[]" value="">
         {/if}
-        <input type="hidden" name="release" value="{$options.release|default:''}">
+        {foreach from=$options.release item=$release}
+        <input type="hidden" name="release[]" value="{$release}">
+        {/foreach}
         {if $core.current_role == $core.roles.customer}
-        <input type="hidden" name="users" value="" />
+        <input type="hidden" name="users[]" value="">
         {/if}
         <tr>
             <td nowrap>
@@ -88,7 +94,7 @@
             {if $core.current_role != $core.roles.customer}
             <td valign="top">
                 <span>{t}Assigned{/t}:</span><br />
-                <select name="users">
+                <select name="users[]" multiple size="8">
                     {html_options options=$assign_options selected=$options.users}
                 </select>
             </td>
@@ -96,8 +102,8 @@
             {if $categories|@count > 0}
             <td valign="top">
                 <span>{t}Category{/t}:</span><br />
-                <select name="category">
-                    <option value="">{t}any{/t}</option>
+                <select name="category[]" multiple size="8">
+                    <option value="" {if $options.category[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$categories selected=$options.category}
                 </select>
             </td>
@@ -105,28 +111,26 @@
             {if $priorities|@count > 0}
             <td valign="top">
                 <span>{t}Priority{/t}:</span><br />
-                <select name="priority">
-                    <option value="">{t}any{/t}</option>
+                <select name="priority[]" multiple size="8">
+                    <option value="" {if $options.priority[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$priorities selected=$options.priority}
                 </select>
             </td>
             {/if}
             {if $severities|@count > 0}
             <td valign="top">
-                <span class="default">{t}Severity{/t}:</span><br />
-                <select name="severity" class="default">
-                    <option value="">{t}any{/t}</option>
+                <span>{t}Severity{/t}:</span><br />
+                <select name="severity[]" multiple size="8">
+                    <option value="" {if $options.severity[0] == ""}selected{/if}>{t}any{/t}</option>
                     {html_options options=$severities selected=$options.severity}
                 </select>
             </td>
             {/if}
             <td valign="top">
                 <span>{t}Status{/t}:</span><br />
-                <select name="status">
-                    <option value="">{t}any{/t}</option>
-                    {foreach key=sta_id item=sta_title from=$status}
-                    <option value="{$sta_id}" {if $sta_id == $options.status}selected{/if}>{$sta_title}</option>
-                    {/foreach}
+                <select name="status[]" multiple size="8">
+                    <option value="" {if $options.status[0] == ""}selected{/if}>{t}any{/t}</option>
+                    {html_options options=$status selected=$options.status}
                 </select>
             </td>
         </tr>


### PR DESCRIPTION
* Convert the search fields in the quick filter toolbar and advanced
  search to multi-select fields
* For saved searches, store the selection as string of comma-separated
  values
* Add DB migration to change column types in `custom_filter` to string
* List of changed fields:
  - Assigned (cst_users)
  - Category (cst_iss_prc_id)
  - Priority (cst_iss_pri_id)
  - Product  (cst_pro_id)
  - Release  (cst_iss_pre_id)
  - Reporter (cst_reporter)
  - Severity (cst_iss_sev_id)
  - Status   (cst_iss_sta_id)