### PR TITLE
Don't show inactive users in notification list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Eventum 3.3.x requires PHP 5.6.
 - Fix sending same reminder repeatedly (@phavel, #321)
 - Use symfony/ldap for ldap connection (@glensc, #322)
 - Make `git diff`, `git log` on `*.po`/`*.pot` files less useful (@glensc, #325)
+- Don't show inactive users in notification list (@balsdorf, #324)
 
 [3.3.4]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -539,21 +539,29 @@ class Notification
      */
     public static function getUsersByIssue($issue_id, $type)
     {
+        $prj_id = Issue::getProjectID($issue_id);
         if ($type == 'notes') {
-            $stmt = 'SELECT
+            $stmt = "SELECT
                         DISTINCT sub_usr_id,
                         sub_email
                      FROM
-                        `subscription`
+                        `subscription`,
+                        `user`,
+                        `project_user`
                      WHERE
-                        sub_iss_id=? AND
-                        sub_usr_id IS NOT NULL AND
-                        sub_usr_id <> 0';
+                        usr_id = sub_usr_id AND
+                        pru_usr_id = usr_id AND
+                        pru_prj_id = ? AND
+                        pru_role >= ? AND
+                        usr_status = 'active' AND
+                        sub_iss_id=?";
             $params = [
+                $prj_id,
+                User::ROLE_USER,
                 $issue_id,
             ];
         } else {
-            $stmt = 'SELECT
+            $stmt = "SELECT
                         DISTINCT sub_usr_id,
                         sub_email,
                         pru_role
@@ -567,10 +575,15 @@ class Notification
                           ON
                             sub_usr_id = pru_usr_id AND
                             pru_prj_id = ?
+                        LEFT JOIN
+                          `user`
+                          ON
+                            sub_usr_id = usr_id
                      WHERE
+                        (usr_status = 'active' OR usr_status IS NULL) AND
                         sub_iss_id=? AND
                         sub_id=sbt_sub_id AND
-                        sbt_type=?';
+                        sbt_type=?";
             $params = [
                 Issue::getProjectID($issue_id), $issue_id, $type,
             ];
@@ -1589,7 +1602,7 @@ class Notification
             $stmt .= ',
                      `subscription_type`';
         }
-        $stmt .= '
+        $stmt .= "
                     )
                     LEFT JOIN
                         `project_user`
@@ -1597,7 +1610,8 @@ class Notification
                         (sub_usr_id = pru_usr_id AND pru_prj_id = ?)
                  WHERE
                     sub_usr_id=usr_id AND
-                    sub_iss_id=?';
+                    usr_status = 'active' AND
+                    sub_iss_id=?";
         $params = [
             $prj_id, $issue_id,
         ];


### PR DESCRIPTION
Users with a status of 'inactive' already do not get emails due to the mail queue checking their status before sending. This PR cleans hides them from the NL when viewing an issue. They are still visible if you go to edit the NL.

I've also cleaned up [Notification::getUsersByIssue](https://github.com/eventum/eventum/blob/7ca21595fdaed4f2cbb58b72f3919b5f81f34d72/lib/eventum/class.notification.php#L543) for notes to only return users with a role of Standard User or above. This restriction is already enforced elsewhere in the code but returning all users here is incorrect.