### PR TITLE
Fix mail submission with PHP7

### DIFF
--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -27,7 +27,7 @@ class Mail_Helper
     // variable to keep the Mail_mime object
     public $mime;
     // variable to keep the headers to be used in the email
-    public $headers = '';
+    public $headers = [];
     // text version of this message
     public $text_body = '';
 


### PR DESCRIPTION
Mail_Helper::$headers is declared as a string but later used as an
array. PHP 5 would silently change its type to array; PHP 7 raises an
'Illegal string offset' warning instead.