### PR TITLE
Fix display of quoted lines containing just "0"

### DIFF
--- a/lib/eventum/smarty/modifier.highlight_quoted.php
+++ b/lib/eventum/smarty/modifier.highlight_quoted.php
@@ -66,7 +66,7 @@ function smarty_modifier_highlight_quoted($text, $escape = true, $indenter = '|>
             $match[2] = htmlspecialchars($match[2]);
         }
         $line = trim($match[2]);
-        if ($line) {
+        if ($line !== '') {
             $indent = strlen(preg_replace('/[\s]*/', '', $match[1]));
             $color = $indent % count($colors);
             $ret .= '<font color="' . $colors[$color] . '">';


### PR DESCRIPTION
When highlighting quoted lines in internal notes, lines containing
nothing except the quote marker are displayed as empty. Since the check
evaluates the line contents as boolean it mistakenly identifies the
string "0" as an empty line.