### PR TITLE
mail message: handle multipart/alternative

### DIFF
--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1236,7 +1236,6 @@ class Support
      * @param   MailMessage $mail The Mail object
      * @param   bool $internal_only Whether these files are supposed to be internal only or not
      * @param   int $associated_note_id The note ID that these attachments should be associated with
-     * @status PORTED
      */
     public static function extractAttachments($issue_id, MailMessage $mail, $internal_only = false, $associated_note_id = null)
     {
@@ -1245,7 +1244,7 @@ class Support
         $usr_id = User::getUserIDByEmail($sender_email);
         $prj_id = Issue::getProjectID($issue_id);
         $unknown_user = false;
-        if (empty($usr_id)) {
+        if (!$usr_id) {
             if (CRM::hasCustomerIntegration($prj_id)) {
                 // try checking if a customer technical contact has this email associated with it
                 try {
@@ -1256,7 +1255,7 @@ class Support
                     $usr_id = null;
                 }
             }
-            if (empty($usr_id)) {
+            if (!$usr_id) {
                 // if we couldn't find a real customer by that email, set the usr_id to be the system user id,
                 // and store the actual email address in the unknown_user field.
                 $usr_id = APP_SYSTEM_USER_ID;

--- a/src/Mail/Attachment.php
+++ b/src/Mail/Attachment.php
@@ -93,12 +93,19 @@ class Attachment
         foreach ($this->message as $part) {
             $headers = $part->getHeaders();
 
+            /** @var ContentType $ct */
             $ct = $headers->get('Content-Type');
+            $type = $ct->getType();
+
+            // multipart/alternative should have text/plain and text/html, none of them are "attachments"
+            if ($type === 'multipart/alternative') {
+                continue;
+            }
+
             // attempt to extract filename
             // 1. try Content-Type: name parameter
             // 2. try Content-Disposition: filename parameter
             // 3. as last resort use Untitled with extension from mime-type subpart
-            /** @var ContentType $ct */
             $filename = $ct->getParameter('name');
             if (!$filename) {
                 try {
@@ -107,7 +114,8 @@ class Attachment
                 }
             }
             if (!$filename) {
-                $filename = ev_gettext('Untitled.%s', end(explode('/', $ct->getType())));
+                $parts = explode('/', $type);
+                $filename = ev_gettext('Untitled.%s', end($parts));
             }
 
             $cid = $headers->has('Content-Id') ? $headers->get('Content-Id')->getFieldValue() : null;
@@ -115,11 +123,11 @@ class Attachment
             $attachments[] = [
                 'filename' => $filename,
                 'cid' => $cid,
-                'filetype' => $ct->getType(),
+                'filetype' => $type,
                 'blob' => (new DecodePart($part))->decode(),
             ];
 
-            if ($ct->getType() === 'multipart/related') {
+            if ($type === 'multipart/related') {
                 // get attachments from multipart/related
                 $subpart = new self($part);
 

--- a/src/Mail/Attachment.php
+++ b/src/Mail/Attachment.php
@@ -57,21 +57,21 @@ class Attachment
             if ($part->getHeaders()->has('Content-Disposition')) {
                 $disposition = $part->getHeaderField('Content-Disposition');
                 $filename = $part->getHeaderField('Content-Disposition', 'filename');
-                $is_attachment = $disposition == 'attachment' || $filename;
+                $is_attachment = $disposition === 'attachment' || $filename;
             }
 
             if (in_array($ctype, ['text/plain', 'text/html', 'text/enriched'])) {
                 $has_attachments |= $is_attachment;
-            } elseif ($ctype == 'multipart/related') {
+            } elseif ($ctype === 'multipart/related') {
                 // multipart/related may have subparts (inline html)
                 $attachment = new self($part);
                 $has_attachments |= $attachment->hasAttachments();
             } else {
                 // avoid treating forwarded messages as attachments
-                $is_attachment |= ($disposition == 'inline' && $ctype != 'message/rfc822');
+                $is_attachment |= ($disposition === 'inline' && $ctype !== 'message/rfc822');
                 // handle inline images
                 $type = current(explode('/', $ctype));
-                $is_attachment |= $type == 'image';
+                $is_attachment |= $type === 'image';
 
                 $has_attachments |= $is_attachment;
             }
@@ -119,7 +119,7 @@ class Attachment
                 'blob' => (new DecodePart($part))->decode(),
             ];
 
-            if ($ct->getType() == 'multipart/related') {
+            if ($ct->getType() === 'multipart/related') {
                 // get attachments from multipart/related
                 $subpart = new self($part);
 
@@ -127,7 +127,7 @@ class Attachment
                 // this will resemble previous eventum behavior
                 // whether that's correct is another topic
                 foreach ($subpart->getAttachments() as $attachment) {
-                    if ($attachment['filetype'] == 'text/html') {
+                    if ($attachment['filetype'] === 'text/html') {
                         continue;
                     }
                     $attachments[] = $attachment;

--- a/src/Mail/Helper/DecodePart.php
+++ b/src/Mail/Helper/DecodePart.php
@@ -31,7 +31,7 @@ class DecodePart
      * get body.
      * have to decode ourselves or use something like Mime\Message::createFromMessage
      *
-     * @return bool|string
+     * @return string
      */
     public function decode()
     {

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -1,0 +1,111 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Mail\Helper;
+
+use Eventum\Mail\MailMessage;
+use Mime_Helper;
+
+/**
+ * Creates textual representation of the message body.
+ */
+class TextMessage
+{
+    /** @var MailMessage */
+    private $message;
+
+    public function __construct(MailMessage $message)
+    {
+        $this->message = $message;
+    }
+
+    public function getMessageBody()
+    {
+        $parts = [];
+        foreach ($this->message as $part) {
+            $headers = $part->getHeaders();
+            $ctype = $part->getHeaderField('Content-Type');
+            $hasDisposition = $headers->has('Content-Disposition');
+            $disposition = $hasDisposition ? $part->getHeaderField('Content-Disposition') : null;
+            $filename = $hasDisposition ? $part->getHeaderField('Content-Disposition', 'filename') : null;
+            $is_attachment = $disposition === 'attachment' || $filename;
+
+            $charset = $part->getHeaderField('Content-Type', 'charset');
+
+            switch ($ctype) {
+                case 'text/plain':
+                    if (!$is_attachment) {
+                        $format = $part->getHeaderField('Content-Type', 'format');
+                        $delsp = $part->getHeaderField('Content-Type', 'delsp');
+
+                        $text = Mime_Helper::convertString((new DecodePart($part))->decode(), $charset);
+                        if ($format === 'flowed') {
+                            $text = Mime_Helper::decodeFlowedBodies($text, $delsp);
+                        }
+                        $parts['text'][] = $text;
+                    }
+                    break;
+
+                case 'text/html':
+                    if (!$is_attachment) {
+                        $parts['html'][] = Mime_Helper::convertString($part->getContent(), $charset);
+                    }
+                    break;
+
+                // special case for Apple Mail
+                case 'text/enriched':
+                    if (!$is_attachment) {
+                        $parts['html'][] = Mime_Helper::convertString($part->getContent(), $charset);
+                    }
+                    break;
+
+                default:
+                    // avoid treating forwarded messages as attachments
+                    $is_attachment |= ($disposition === 'inline' && $ctype !== 'message/rfc822');
+                    // handle inline images
+                    $type = current(explode('/', $ctype));
+                    $is_attachment |= $type === 'image';
+
+                    if (!$is_attachment) {
+                        $parts['text'][] = $part->getContent();
+                    }
+            }
+        }
+
+        // now we have $parts with type 'text' and type 'html'
+        if (isset($parts['text'])) {
+            return implode("\n\n", $parts['text']);
+        }
+
+        if (isset($parts['html'])) {
+            $str = implode("\n\n", $parts['html']);
+
+            // hack for inotes to prevent content from being displayed all on one line.
+            $str = str_replace(['</DIV><DIV>', '<br>', '<br />', '<BR>', '<BR />'], "\n", $str);
+            // XXX: do we also need to do something here about base64 encoding?
+            $str = strip_tags($str);
+
+            // convert html entities. this should be done after strip tags
+            $str = html_entity_decode($str, ENT_QUOTES, APP_CHARSET);
+
+            return $str;
+        }
+
+        if (!$this->message->isMultipart()) {
+            // fallback to read just main part
+            return (new DecodePart($this->message))->decode();
+        }
+
+        return '';
+    }
+}

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -15,13 +15,14 @@ namespace Eventum\Mail\Helper;
 
 use Eventum\Mail\MailMessage;
 use Mime_Helper;
+use Zend\Mail\Storage\Part;
 
 /**
  * Creates textual representation of the message body.
  */
 class TextMessage
 {
-    /** @var MailMessage */
+    /** @var MailMessage|Part\PartInterface */
     private $message;
 
     public function __construct(MailMessage $message)
@@ -43,6 +44,10 @@ class TextMessage
             $charset = $part->getHeaderField('Content-Type', 'charset');
 
             switch ($ctype) {
+                case 'multipart/alternative':
+                    $parts['text'][] = (new self($part))->getMessageBody();
+                    break;
+
                 case 'text/plain':
                     if (!$is_attachment) {
                         $format = $part->getHeaderField('Content-Type', 'format');

--- a/src/Mail/Helper/WarningMessage.php
+++ b/src/Mail/Helper/WarningMessage.php
@@ -74,8 +74,7 @@ class WarningMessage
 
         $this->modifyContent(
             function ($content) use ($blocked, $warning) {
-                $content = str_replace($blocked . "\n\n", '', $content);
-                $content = str_replace($warning . "\n\n", '', $content);
+                $content = str_replace([$blocked . "\n\n", $warning . "\n\n"], '', $content);
 
                 return $content;
             }

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -16,8 +16,8 @@ namespace Eventum\Mail;
 use Date_Helper;
 use DateTime;
 use DomainException;
-use Eventum\Mail\Helper\DecodePart;
 use Eventum\Mail\Helper\SanitizeHeaders;
+use Eventum\Mail\Helper\TextMessage;
 use InvalidArgumentException;
 use Mime_Helper;
 use Zend\Mail;
@@ -268,85 +268,11 @@ class MailMessage extends Message
      * Returns the text message body.
      *
      * @return string|null The message body
+     * @deprecated use TextMessage class
      */
     public function getMessageBody()
     {
-        $parts = [];
-        foreach ($this as $part) {
-            $headers = $part->getHeaders();
-            $ctype = $part->getHeaderField('Content-Type');
-            $hasDisposition = $headers->has('Content-Disposition');
-            $disposition = $hasDisposition ? $part->getHeaderField('Content-Disposition') : null;
-            $filename = $hasDisposition ? $part->getHeaderField('Content-Disposition', 'filename') : null;
-            $is_attachment = $disposition === 'attachment' || $filename;
-
-            $charset = $part->getHeaderField('Content-Type', 'charset');
-
-            switch ($ctype) {
-                case 'text/plain':
-                    if (!$is_attachment) {
-                        $format = $part->getHeaderField('Content-Type', 'format');
-                        $delsp = $part->getHeaderField('Content-Type', 'delsp');
-
-                        $text = Mime_Helper::convertString((new DecodePart($part))->decode(), $charset);
-                        if ($format === 'flowed') {
-                            $text = Mime_Helper::decodeFlowedBodies($text, $delsp);
-                        }
-                        $parts['text'][] = $text;
-                    }
-                    break;
-
-                case 'text/html':
-                    if (!$is_attachment) {
-                        $parts['html'][] = Mime_Helper::convertString($part->getContent(), $charset);
-                    }
-                    break;
-
-                // special case for Apple Mail
-                case 'text/enriched':
-                    if (!$is_attachment) {
-                        $parts['html'][] = Mime_Helper::convertString($part->getContent(), $charset);
-                    }
-                    break;
-
-                default:
-                    // avoid treating forwarded messages as attachments
-                    $is_attachment |= ($disposition === 'inline' && $ctype !== 'message/rfc822');
-                    // handle inline images
-                    $type = current(explode('/', $ctype));
-                    $is_attachment |= $type === 'image';
-
-                    if (!$is_attachment) {
-                        $parts['text'][] = $part->getContent();
-                    }
-            }
-        }
-
-        // now we have $parts with type 'text' and type 'html'
-        if (isset($parts['text'])) {
-            return implode("\n\n", $parts['text']);
-        }
-
-        if (isset($parts['html'])) {
-            $str = implode("\n\n", $parts['html']);
-
-            // hack for inotes to prevent content from being displayed all on one line.
-            $str = str_replace(['</DIV><DIV>', '<br>', '<br />', '<BR>', '<BR />'], "\n", $str);
-            // XXX: do we also need to do something here about base64 encoding?
-            $str = strip_tags($str);
-
-            // convert html entities. this should be done after strip tags
-            $str = html_entity_decode($str, ENT_QUOTES, APP_CHARSET);
-
-            return $str;
-        }
-
-        if (!$this->isMultipart()) {
-            // fallback to read just main part
-            return (new DecodePart($this))->decode();
-        }
-
-        return '';
+        return (new TextMessage($this))->getMessageBody();
     }
 
     /**

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -104,4 +104,18 @@ class AttachmentTest extends TestCase
         $content = $mail->getMessageBody();
         $this->assertContains('i cannot get any cursed header', $content);
     }
+
+    /**
+     * it should not account multipart/alternative as an attachment
+     */
+    public function testMultipartAlternative()
+    {
+        $content = $this->readDataFile('multipart-mixed-alternative-attachment.eml');
+        $mail = MailMessage::createFromString($content);
+        $attachment = $mail->getAttachment();
+
+        $this->assertTrue($attachment->hasAttachments());
+        $attachments = $attachment->getAttachments();
+        $this->assertCount(1, $attachments);
+    }
 }

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Test\Mail;
+
+use Eventum\Mail\MailMessage;
+use Eventum\Test\TestCase;
+
+class AttachmentTest extends TestCase
+{
+    public function testHasAttachments()
+    {
+        $raw = "Message-ID: <33@JON>X-foo: 1\r\n\r\nada";
+        $message = MailMessage::createFromString($raw);
+        $has_attachments = $message->countParts();
+        $multipart = $message->isMultipart();
+        $this->assertFalse($multipart);
+        $this->assertEquals(0, $has_attachments);
+        $this->assertFalse($message->getAttachment()->hasAttachments());
+
+        $datafile = $this->getDataFile('bug684922.txt');
+        $message = MailMessage::createFromFile($datafile);
+        $multipart = $message->isMultipart();
+        $this->assertTrue($multipart);
+        $has_attachments = $message->countParts();
+        $this->assertEquals(2, $has_attachments);
+        $this->assertTrue($message->getAttachment()->hasAttachments());
+
+        // this one does not have "Attachments" even it is multipart
+        $datafile = $this->getDataFile('multipart-text-html.txt');
+        $message = MailMessage::createFromFile($datafile);
+        $this->assertFalse($message->getAttachment()->hasAttachments());
+    }
+
+    /**
+     * Ensure email with text/plain attachment does not throw InvalidArgumentException
+     *
+     * Uncaught Exception Zend\Mail\Storage\Exception\InvalidArgumentException:
+     * "Header with Name Content-Disposition or content-disposition not found"
+     */
+    public function testHasAttachmentPlain()
+    {
+        $content = $this->readDataFile('attachment-bug.txt');
+        $message = MailMessage::createFromString($content);
+        $this->assertTrue($message->getAttachment()->hasAttachments());
+    }
+
+    public function testGetAttachments()
+    {
+        $raw = $this->readDataFile('bug684922.txt');
+
+        $mail = MailMessage::createFromString($raw);
+        $attachment = $mail->getAttachment();
+        $this->assertTrue($attachment->hasAttachments());
+        $att2 = $attachment->getAttachments();
+
+        $this->assertCount(2, $att2);
+        $att = $att2[0];
+        $this->assertArrayHasKey('filename', $att);
+        $this->assertArrayHasKey('cid', $att);
+        $this->assertArrayHasKey('filetype', $att);
+        $this->assertArrayHasKey('blob', $att);
+    }
+
+    /**
+     * Multipart/related contains attachment.
+     * Current implementation sees 2 attachments, should see 3.
+     */
+    public function testMultipartRelatedAttachments()
+    {
+        $content = $this->readDataFile('102232.txt');
+
+        $mail = MailMessage::createFromString($content);
+        $attachment = $mail->getAttachment();
+
+        $this->assertTrue($attachment->hasAttachments());
+        $attachments = $attachment->getAttachments();
+        $this->assertCount(3, $attachments);
+    }
+
+    /**
+     * Test that $mail->getAttachments can be called if no attachments present
+     *
+     * @see Support::getEmailDetails()
+     */
+    public function testGetAttachmentsWhenNonePresent()
+    {
+        $content = $this->readDataFile('attachment-bug.txt');
+        $mail = MailMessage::createFromString($content);
+        $attachment = $mail->getAttachment();
+        $this->assertTrue($attachment->hasAttachments());
+        $attachments = $attachment->getAttachments();
+        $this->assertContains('i cannot get any cursed header', $attachments[0]['blob']);
+        $content = $mail->getMessageBody();
+        $this->assertContains('i cannot get any cursed header', $content);
+    }
+}

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -510,18 +510,6 @@ class MailMessageTest extends TestCase
     }
 
     /**
-     * @test $structure->body getting textual mail body from multipart message
-     */
-    public function testGetMailBody()
-    {
-        $filename = __DIR__ . '/../data/multipart-text-html.txt';
-
-        $mail = MailMessage::createFromFile($filename);
-        $body2 = $mail->getMessageBody();
-        $this->assertEquals("Commit in MAIN\n", $body2);
-    }
-
-    /**
      * test different access modes or X-Priority header.
      */
     public function testXPriority()

--- a/tests/Mail/MimeDecodeTest.php
+++ b/tests/Mail/MimeDecodeTest.php
@@ -62,23 +62,6 @@ class MimeDecodeTest extends TestCase
     }
 
     /**
-     * Test that $mail->getAttachments can be called if no attachments present
-     *
-     * @see Support::getEmailDetails()
-     */
-    public function testGetAttachments()
-    {
-        $content = $this->readDataFile('attachment-bug.txt');
-        $mail = MailMessage::createFromString($content);
-        $attachment = $mail->getAttachment();
-        $this->assertTrue($attachment->hasAttachments());
-        $attachments = $attachment->getAttachments();
-        $this->assertContains('i cannot get any cursed header', $attachments[0]['blob']);
-        $content = $mail->getMessageBody();
-        $this->assertContains('i cannot get any cursed header', $content);
-    }
-
-    /**
      * Mime_Helper::decode()->body extracts main message body if no parts present
      */
     public function testBuildMail()

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -19,47 +19,34 @@ use Eventum\Test\TestCase;
 class TextMessageTest extends TestCase
 {
     /**
-     * Test that HTML entities used in text/html part get decoded
+     * @dataProvider testCases
      */
-    public function testParseHtmlEntities()
+    public function testTextMessage($dataFile, $expectedText)
     {
-        $full_message = $this->readDataFile('encoding.txt');
-
-        $mail = MailMessage::createFromString($full_message);
-        $text = $mail->getMessageBody();
-        $this->assertEquals(
-            "\npöördumise töötaja.\n<b>Võtame</b> töösse võimalusel.\npöördumisele süsteemis\n\n", $text
-        );
+        $mail = MailMessage::createFromFile($this->getDataFile($dataFile));
+        $this->assertEquals($expectedText, $mail->getMessageBody());
     }
 
-    public function testBug684922()
+    public function testCases()
     {
-        $message = $this->readDataFile('bug684922.txt');
-        $mail = MailMessage::createFromString($message);
+        return [
+            'Test that HTML entities used in text/html part get decoded' => [
+                'encoding.txt',
+                "\npöördumise töötaja.\n<b>Võtame</b> töösse võimalusel.\npöördumisele süsteemis\n\n",
+            ],
+            'testBug684922' => [
+                'bug684922.txt',
+                '',
+            ],
+            'test $structure->body getting textual mail body from multipart message' => [
+                'multipart-text-html.txt',
+                "Commit in MAIN\n",
+            ],
 
-        $this->assertEquals('', $mail->getMessageBody());
-    }
-
-    /**
-     * test $structure->body getting textual mail body from multipart message
-     */
-    public function testGetMailBody()
-    {
-        $filename = $this->getDataFile('multipart-text-html.txt');
-        $mail = MailMessage::createFromFile($filename);
-        $body = $mail->getMessageBody();
-        $this->assertEquals("Commit in MAIN\n", $body);
-    }
-
-    /**
-     * root mail: multipart/mixed
-     * first part: multipart/alternative
-     */
-    public function testMultiPartAlternativeAttachment()
-    {
-        $filename = $this->getDataFile('multipart-mixed-alternative.eml');
-        $mail = MailMessage::createFromFile($filename);
-        $body = $mail->getMessageBody();
-        $this->assertEquals("No one has ever seen God.\n", $body);
+            'test with multipart/mixed mail with multipart/alternative attachment' => [
+                'multipart-mixed-alternative.eml',
+                "No one has ever seen God.\n",
+            ],
+        ];
     }
 }

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -16,10 +16,7 @@ namespace Eventum\Test\Mail;
 use Eventum\Mail\MailMessage;
 use Eventum\Test\TestCase;
 
-/**
- * @group mail
- */
-class MailParseTest extends TestCase
+class TextMessageTest extends TestCase
 {
     /**
      * Test that HTML entities used in text/html part get decoded
@@ -41,5 +38,16 @@ class MailParseTest extends TestCase
         $mail = MailMessage::createFromString($message);
 
         $this->assertEquals('', $mail->getMessageBody());
+    }
+
+    /**
+     * test $structure->body getting textual mail body from multipart message
+     */
+    public function testGetMailBody()
+    {
+        $filename = $this->getDataFile('multipart-text-html.txt');
+        $mail = MailMessage::createFromFile($filename);
+        $body2 = $mail->getMessageBody();
+        $this->assertEquals("Commit in MAIN\n", $body2);
     }
 }

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -47,7 +47,19 @@ class TextMessageTest extends TestCase
     {
         $filename = $this->getDataFile('multipart-text-html.txt');
         $mail = MailMessage::createFromFile($filename);
-        $body2 = $mail->getMessageBody();
-        $this->assertEquals("Commit in MAIN\n", $body2);
+        $body = $mail->getMessageBody();
+        $this->assertEquals("Commit in MAIN\n", $body);
+    }
+
+    /**
+     * root mail: multipart/mixed
+     * first part: multipart/alternative
+     */
+    public function testMultiPartAlternativeAttachment()
+    {
+        $filename = $this->getDataFile('multipart-mixed-alternative.eml');
+        $mail = MailMessage::createFromFile($filename);
+        $body = $mail->getMessageBody();
+        $this->assertEquals("No one has ever seen God.\n", $body);
     }
 }

--- a/tests/data/multipart-mixed-alternative-attachment.eml
+++ b/tests/data/multipart-mixed-alternative-attachment.eml
@@ -1,0 +1,42 @@
+From: A Happy User <us.er@example.net>
+To: "support@example.net" <support@example.net>
+Date: Wed, 20 Dec 2017 07:50:23 +0000
+Message-ID: <4B9DEC0C-9C0C-426E-9C0C-327FA351468E@example.org>
+Content-Type: multipart/mixed;
+	boundary="_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_"
+MIME-Version: 1.0
+
+--_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: multipart/alternative;
+	boundary="_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_"
+
+--_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+Tm8gb25lIGhhcyBldmVyIHNlZW4gR29kLgo=
+
+--_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <027DA73F56180F47BFAC8D33C76A8893@vendor.example.org>
+Content-Transfer-Encoding: base64
+
+SWYgSSB0ZXN0aWZ5IGFib3V0IG15c2VsZiwgbXkgdGVzdGltb255IGlzIG5vdCB2YWxpZC4KRXZl
+biBpZiBJIHRlc3RpZnkgb24gbXkgb3duIGJlaGFsZiwgbXkgdGVzdGltb255IGlzIHZhbGlkLgo=
+
+--_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: image/gif; name="s.gif"
+Content-Description: s[1].gif
+Content-Disposition: attachment; filename="s[3].gif"; size=43;
+	creation-date="Wed, 20 Dec 2017 07:50:23 GMT";
+	modification-date="Wed, 20 Dec 2017 07:50:23 GMT"
+Content-ID: <16B92C28D7717847A5D610CF449E7339@vendor.example.org>
+Content-Transfer-Encoding: base64
+
+R0lGODlhAQABAID/AMDAwAAAACH5BAEAAAAALAAAAAABAAEAAAICRAEAOw==
+
+--_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_--
+
+
+
+

--- a/tests/data/multipart-mixed-alternative.eml
+++ b/tests/data/multipart-mixed-alternative.eml
@@ -1,0 +1,33 @@
+From: A Happy User <us.er@example.net>
+To: "support@example.net" <support@example.net>
+Date: Wed, 20 Dec 2017 07:50:23 +0000
+Message-ID: <4B9DEC0C-9C0C-426E-9C0C-327FA351468E@example.org>
+Content-Type: multipart/mixed;
+	boundary="_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_"
+MIME-Version: 1.0
+
+--_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: multipart/alternative;
+	boundary="_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_"
+
+--_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: text/plain; charset="utf-8"
+Content-Transfer-Encoding: base64
+
+Tm8gb25lIGhhcyBldmVyIHNlZW4gR29kLgo=
+
+--_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_
+Content-Type: text/html; charset="utf-8"
+Content-ID: <027DA73F56180F47BFAC8D33C76A8893@vendor.example.org>
+Content-Transfer-Encoding: base64
+
+SWYgSSB0ZXN0aWZ5IGFib3V0IG15c2VsZiwgbXkgdGVzdGltb255IGlzIG5vdCB2YWxpZC4KRXZl
+biBpZiBJIHRlc3RpZnkgb24gbXkgb3duIGJlaGFsZiwgbXkgdGVzdGltb255IGlzIHZhbGlkLgo=
+
+--_000_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_--
+
+--_006_4B9DEC0C9C0C426E9C0C327FA351468Eexampleorg_--
+
+
+
+


### PR DESCRIPTION
MailMessage::getMessageBody did not handle email with multipart/mixed with multipart/alternative attachment well.

- [x] render multipart/alternative attachment text properly. cddbbf370ee57ce0a8c267f2c5843242cb85b983
- [x]  fix `Untitled.alternative (5.3 KiB)` created as attachment