### PR TITLE
mail-download: fix user_id fetch using email header

### DIFF
--- a/lib/eventum/auth/APIAuthToken.php
+++ b/lib/eventum/auth/APIAuthToken.php
@@ -53,7 +53,7 @@ class APIAuthToken
             $usr_id = User::getUserIDByEmail($email, true);
             $active_tokens = self::getTokensForUser($usr_id);
             foreach ($active_tokens as $row) {
-                if ($row['token'] == $token) {
+                if ($row['token'] === $token) {
                     return true;
                 }
             }

--- a/lib/eventum/class.authorized_replier.php
+++ b/lib/eventum/class.authorized_replier.php
@@ -131,6 +131,8 @@ class Authorized_Replier
      */
     public static function manualInsert($issue_id, $email, $add_history = true)
     {
+        $email = Mail_Helper::getEmailAddress($email);
+
         if (Validation::isWhitespace($email)) {
             return -1;
         }
@@ -138,8 +140,6 @@ class Authorized_Replier
         if (self::isAuthorizedReplier($issue_id, $email)) {
             return -1;
         }
-
-        $email = Mail_Helper::getEmailAddress($email);
 
         $workflow = Workflow::handleAuthorizedReplierAdded(Issue::getProjectID($issue_id), $issue_id, $email);
         if ($workflow === false) {

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1664,7 +1664,7 @@ class Issue
         $exclude_list = [];
         $managers = [];
 
-        $sender_email = Mail_Helper::getEmailAddress($mail->from);
+        $sender_email = $mail->getSender();
         $sender_usr_id = User::getUserIDByEmail($sender_email, true);
         if (!empty($sender_usr_id)) {
             $reporter = $sender_usr_id;

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -222,7 +222,7 @@ class Notification
             if ($flag_location === 'before') {
                 $info['sender_name'] = '"' . $flag . substr($info['sender_name'], 1);
             } else {
-                $info['sender_name'] = substr($info['sender_name'], 0, strlen($info['sender_name']) - 1) . ' ' . trim($flag) . '"';
+                $info['sender_name'] = substr($info['sender_name'], 0, -1) . ' ' . trim($flag) . '"';
             }
         } else {
             if ($flag_location === 'before') {

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -163,7 +163,7 @@ class Notification
     public static function getFixedFromHeader($issue_id, $sender, $type)
     {
         $setup = Setup::get();
-        if ($type == 'issue') {
+        if ($type === 'issue') {
             $routing = 'email_routing';
         } else {
             $routing = 'note_routing';
@@ -195,7 +195,7 @@ class Notification
             $flag = '[' . $setup[$routing]['recipient_type_flag'] . '] ';
             $flag_location = $setup[$routing]['flag_location'];
         }
-        if ($setup[$routing]['status'] != 'enabled') {
+        if ($setup[$routing]['status'] !== 'enabled') {
             // let's use the custom outgoing sender address
             $project_info = Project::getOutgoingSenderAddress($project_id);
             if (empty($project_info['email'])) {
@@ -218,14 +218,14 @@ class Notification
             }
         }
         // also check where we need to append/prepend a special string to the sender name
-        if (substr($info['sender_name'], strlen($info['sender_name']) - 1) == '"') {
-            if ($flag_location == 'before') {
+        if (substr($info['sender_name'], strlen($info['sender_name']) - 1) === '"') {
+            if ($flag_location === 'before') {
                 $info['sender_name'] = '"' . $flag . substr($info['sender_name'], 1);
             } else {
                 $info['sender_name'] = substr($info['sender_name'], 0, strlen($info['sender_name']) - 1) . ' ' . trim($flag) . '"';
             }
         } else {
-            if ($flag_location == 'before') {
+            if ($flag_location === 'before') {
                 $info['sender_name'] = '"' . $flag . $info['sender_name'] . '"';
             } else {
                 $info['sender_name'] = '"' . $info['sender_name'] . ' ' . trim($flag) . '"';

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -1052,7 +1052,7 @@ class Notification
                 // show the title of the note, not the issue summary
                 $extra_subject = $data['note']['not_title'];
                 // don't add the "[#3333] Note: " prefix to messages that already have that in the subject line
-                if (strstr($extra_subject, "[#$issue_id] $subject: ")) {
+                if (strpos($extra_subject, "[#$issue_id] $subject: ") !== false) {
                     $pos = strpos($extra_subject, "[#$issue_id] $subject: ");
                     $full_subject = substr($extra_subject, $pos);
                 } else {

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -412,14 +412,14 @@ class Routing
         $sender_email = $mail->getSender();
 
         $sender_usr_id = User::getUserIDByEmail($sender_email, true);
-        if (!empty($sender_usr_id)) {
+        if ($sender_usr_id) {
             $sender_role = User::getRoleByUser($sender_usr_id, $prj_id);
             if ($sender_role < User::ROLE_USER) {
                 throw RoutingException::noIssuePermission($issue_id);
             }
         }
 
-        AuthCookie::setAuthCookie(User::getUserIDByEmail($sender_email));
+        AuthCookie::setAuthCookie($sender_usr_id);
         AuthCookie::setProjectCookie($prj_id);
 
         Draft::saveEmail($issue_id, $mail->to, $mail->cc, $mail->subject, $mail->getMessageBody(), false, false, false);

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -298,7 +298,7 @@ class Routing
             throw RoutingException::noIssuePermission($issue_id);
         }
 
-        if (empty($sender_usr_id)) {
+        if (!$sender_usr_id) {
             $sender_usr_id = APP_SYSTEM_USER_ID;
             $unknown_user = $mail->from;
         } else {

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -913,8 +913,7 @@ class Support
     {
         $closing = isset($email_options['closing']) ? $email_options['closing'] : false;
 
-        // get usr_id from FROM header
-        $usr_id = User::getUserIDByEmail($mail->from);
+        $usr_id = User::getUserIDByEmail($mail->getSender());
 
         if (!empty($usr_id) && empty($email_options['customer_id'])) {
             $email_options['customer_id'] = User::getCustomerID($usr_id);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -556,7 +556,7 @@ class Support
             AuthCookie::setAuthCookie(APP_SYSTEM_USER_ID);
             AuthCookie::setProjectCookie($prj_id);
         }
-        if ($should_create_array['type'] == 'note') {
+        if ($should_create_array['type'] === 'note') {
             // assume that this is not a valid note
             $res = -1;
 

--- a/lib/eventum/irc/BotCommands.php
+++ b/lib/eventum/irc/BotCommands.php
@@ -136,9 +136,9 @@ class BotCommands extends AbstractBotCommands
         $email = $this->bot->getEmailByNickname($data->nick);
         $usr_id = User::getUserIDByEmail($email);
 
-        if ($command == 'in') {
+        if ($command === 'in') {
             $res = User::clockIn($usr_id);
-        } elseif ($command == 'out') {
+        } elseif ($command === 'out') {
             $res = User::clockOut($usr_id);
         } else {
             if (User::isClockedIn($usr_id)) {

--- a/src/RPC/RemoteApi.php
+++ b/src/RPC/RemoteApi.php
@@ -320,7 +320,7 @@ class RemoteApi
 
         // check if the assignee is even allowed to be in the given project
         $projects = self::getRemoteAssocListByUser($assignee);
-        if (!in_array($project_id, array_keys($projects))) {
+        if (!array_key_exists($project_id, $projects)) {
             throw new RemoteApiException(
                 "The selected developer is not permitted in the project associated with issue #$issue_id"
             );
@@ -388,7 +388,7 @@ class RemoteApi
         if (!empty($replier_usr_id)) {
             // check if the assignee is even allowed to be in the given project
             $projects = self::getRemoteAssocListByUser($replier_usr_id);
-            if (!in_array($project_id, array_keys($projects))) {
+            if (!array_key_exists($project_id, $projects)) {
                 throw new RemoteApiException(
                     "The given user is not permitted in the project associated with issue #$issue_id"
                 );


### PR DESCRIPTION
functional changes:
* 8e774d294 - User::getUserIDByEmail takes plain email only as input, not formatted email header
* 4407ba4ad - reuse sender_usr_id
* 1c781881d - authorized_replier: manualInsert should convert mail header to email first

@balsdorf could you check if the second commit 4407ba4ad is safe to do