### PR TITLE
add EventDispatcher to console commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Make LDAP user ID attribute configurable, add help page (@inguin, #329)
 - Drop `pear/mime_decode`, `pear/mail_mime` in favor of `Zend\Mail` (@glensc, #263, #333, #334, #335)
 - Use `symfony/filesystem` for file writes (@glensc, #331)
+- Add `EventDispatcher` to console commands (@glensc, #337)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/bin/check_reminders.php
+++ b/bin/check_reminders.php
@@ -13,8 +13,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\ReminderCheckCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\ReminderCheckCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/check_reminders.php
+++ b/bin/check_reminders.php
@@ -14,8 +14,9 @@
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\ReminderCheckCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/download_emails.php
+++ b/bin/download_emails.php
@@ -17,8 +17,8 @@ ini_set('memory_limit', '2047M');
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\MailDownloadCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\MailDownloadCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/download_emails.php
+++ b/bin/download_emails.php
@@ -18,8 +18,9 @@ ini_set('memory_limit', '2047M');
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\MailDownloadCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/extension.php
+++ b/bin/extension.php
@@ -14,8 +14,9 @@
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\ExtensionEnableCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/extension.php
+++ b/bin/extension.php
@@ -13,8 +13,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\ExtensionEnableCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\ExtensionEnableCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/ldapsync.php
+++ b/bin/ldapsync.php
@@ -14,8 +14,9 @@
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\LdapSyncCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/ldapsync.php
+++ b/bin/ldapsync.php
@@ -13,8 +13,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\LdapSyncCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\LdapSyncCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/monitor.php
+++ b/bin/monitor.php
@@ -13,8 +13,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\MonitorCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\MonitorCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/process_all_emails.php
+++ b/bin/process_all_emails.php
@@ -14,8 +14,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\MailRouteCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\MailRouteCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/process_all_emails.php
+++ b/bin/process_all_emails.php
@@ -15,8 +15,9 @@
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\MailRouteCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/process_mail_queue.php
+++ b/bin/process_mail_queue.php
@@ -16,8 +16,9 @@ ini_set('memory_limit', '1024M');
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\MailQueueProcessCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/process_mail_queue.php
+++ b/bin/process_mail_queue.php
@@ -15,8 +15,8 @@ ini_set('memory_limit', '1024M');
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\MailQueueProcessCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\MailQueueProcessCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/bin/truncate_mail_queue.php
+++ b/bin/truncate_mail_queue.php
@@ -14,8 +14,9 @@
 require_once __DIR__ . '/../init.php';
 
 use Eventum\Command\MailQueueTruncateCommand as Command;
+use Eventum\Console\Application;
 
-$app = new Silly\Application();
+$app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/truncate_mail_queue.php
+++ b/bin/truncate_mail_queue.php
@@ -13,8 +13,8 @@
 
 require_once __DIR__ . '/../init.php';
 
-use Eventum\Command\MailQueueTruncateCommand as Command;
 use Eventum\Console\Application;
+use Eventum\Console\Command\MailQueueTruncateCommand as Command;
 
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -18,4 +18,10 @@ use Silly\Application as BaseApplication;
 
 class Application extends BaseApplication
 {
+    public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
+    {
+        $this->setDispatcher(EventManager::getEventDispatcher());
+
+        parent::__construct($name, $version);
+    }
 }

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -1,5 +1,5 @@
-#!/usr/bin/php
 <?php
+
 /*
  * This file is part of the Eventum (Issue Tracking System) package.
  *
@@ -11,12 +11,11 @@
  * that were distributed with this source code.
  */
 
-require_once __DIR__ . '/../init.php';
+namespace Eventum\Console;
 
-use Eventum\Command\MonitorCommand as Command;
-use Eventum\Console\Application;
+use Eventum\EventDispatcher\EventManager;
+use Silly\Application as BaseApplication;
 
-$app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
-$app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
-$app->run();
+class Application extends BaseApplication
+{
+}

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -11,11 +11,11 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Symfony\Component\Console\Output\OutputInterface;
 
-class BaseCommand
+abstract class Command
 {
     // compact constants for writeln
     const DEBUG = OutputInterface::VERBOSITY_DEBUG;

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Eventum\Extension\ExtensionInterface;
 use InvalidArgumentException;

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -11,16 +11,17 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use AuthException;
 use Eventum\Auth\Ldap\UserEntry;
+use Eventum\Console\Command\Command;
 use InvalidArgumentException;
 use LDAP_Auth_Backend;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class LdapSyncCommand extends BaseCommand
+class LdapSyncCommand extends Command
 {
     const DEFAULT_COMMAND = 'ldap:sync';
     const USAGE = self::DEFAULT_COMMAND . ' [--dry-run] [--create-users] [--no-update] [--no-disable]';

--- a/src/Console/Command/MailDownloadCommand.php
+++ b/src/Console/Command/MailDownloadCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Email_Account;
 use Eventum\ConcurrentLock;

--- a/src/Console/Command/MailQueueProcessCommand.php
+++ b/src/Console/Command/MailQueueProcessCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Eventum\ConcurrentLock;
 use Mail_Queue;

--- a/src/Console/Command/MailQueueTruncateCommand.php
+++ b/src/Console/Command/MailQueueTruncateCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Mail_Queue;
 use Symfony\Component\Console\Output\OutputInterface;

--- a/src/Console/Command/MailRouteCommand.php
+++ b/src/Console/Command/MailRouteCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Eventum\Mail\Exception\RoutingException;
 use Eventum\Mail\MailMessage;

--- a/src/Console/Command/MonitorCommand.php
+++ b/src/Console/Command/MonitorCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use DB_Helper;
 use Eventum\Db;

--- a/src/Console/Command/ReminderCheckCommand.php
+++ b/src/Console/Command/ReminderCheckCommand.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Command;
+namespace Eventum\Console\Command;
 
 use Eventum\ConcurrentLock;
 use Reminder;


### PR DESCRIPTION
This allows to add event listeners to console actions:
- [ConsoleEvents::COMMAND Event](https://symfony.com/doc/3.4/components/console/events.html#the-consoleevents-command-event)
- [ConsoleEvents::ERROR Event](https://symfony.com/doc/3.4/components/console/events.html#the-consoleevents-error-event)
- [ConsoleEvents::TERMINATE Event](https://symfony.com/doc/3.4/components/console/events.html#the-consoleevents-terminate-event)

https://symfony.com/doc/3.4/components/console/events.html

example, report memory usage on program shutdown:

```php
$dispatcher->addListener(ConsoleEvents::TERMINATE, function (ConsoleTerminateEvent $event) {
    $memoryUsageProcessor = new MemoryUsageProcessor(true);
    dump($memoryUsageProcessor([]));
});
```