### PR TITLE
Added support for "checkbox" custom fields on advanced search page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Use `symfony/filesystem` for file writes (@glensc, #331)
 - Add `EventDispatcher` to console commands (@glensc, #337)
 - Mail-Download: fix `user_id` fetch using email header (@glensc, #336)
+- Added support for "checkbox" custom fields on advanced search page (@balsdorf, #347)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -680,7 +680,7 @@ class Filter
                         default:
                             $display = $filter_details['value'];
                     }
-                } elseif (in_array($filter['fld_type'], ['multiple', 'combo'])) {
+                } elseif (in_array($filter['fld_type'], ['multiple', 'combo', 'checkbox'])) {
                     $display = implode(', ', Custom_Field::getOptions($fld_id, $options['custom_field'][$fld_id]));
                 } else {
                     $display = $options['custom_field'][$fld_id];

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -691,7 +691,7 @@ class Search
                 } else {
                     $stmt .= " AND\n (iss_id = cf" . $fld_id . '.icf_iss_id';
                     $stmt .= " AND\n cf" . $fld_id . ".icf_fld_id = $fld_id";
-                    if ($field['fld_type'] == 'combo') {
+                    if ($field['fld_type'] == 'combo' || $field['fld_type'] == 'checkbox') {
                         $stmt .= ' AND cf' . $fld_id . '.' . $fld_db_name . " IN('" . implode("', '", Misc::escapeString($search_value)) . "')";
                     } else {
                         $stmt .= ' AND cf' . $fld_id . '.' . $fld_db_name . " LIKE '%" . Misc::escapeString($search_value) . "%'";

--- a/templates/adv_search_custom_fields.tpl.html
+++ b/templates/adv_search_custom_fields.tpl.html
@@ -30,7 +30,7 @@
             <option value="lt" {if $cmp == 'lt'}selected{/if}>{t}Less Than{/t}</option>
           </select>
           <input type="text" size="8" name="custom_field[{$field.fld_id}][value]" value="{$options.cst_custom_field[$field.fld_id].value|default:''}" disabled>
-          {elseif $field.fld_type == 'combo' OR $field.fld_type == 'multiple'}
+          {elseif $field.fld_type == 'combo' OR $field.fld_type == 'multiple' OR $field.fld_type == 'checkbox'}
           <select name="custom_field[{$field.fld_id}][]" multiple
             {if $field.field_options|@count > 10}
               size="10"


### PR DESCRIPTION
Not sure why this was never implemented before. It just reuses the code path for multiple select.