### PR TITLE
mail_queue: fill maq_message_id column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Mail-Download: fix `user_id` fetch using email header (@glensc, #336)
 - Added support for "checkbox" custom fields on advanced search page (@balsdorf, #347)
 - Mail Queue: set message status failed after 20 retries (@glensc, #353)
+- Mail Queue: fill Message-Id column (@glensc, #352)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -48,7 +48,7 @@ class EventumMaqMessageId extends AbstractMigration
                     "skipped maq_id={$maqId}, exception: {$e->getMessage()}"
                 );
 
-                return null;
+                continue;
             }
 
             if (!$messageId) {

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -27,10 +27,12 @@ class EventumMaqMessageId extends AbstractMigration
 
         if (!$total) {
             // nothing to do
+            $this->writeln("Total $total rows, nothing to do");
+
             return;
         }
 
-        $this->output("Total $total rows, this may take time. Please be patient.");
+        $this->writeln("Total $total rows, this may take time. Please be patient.");
         foreach ($maq_ids as $maq_id) {
             $current++;
 
@@ -62,7 +64,7 @@ class EventumMaqMessageId extends AbstractMigration
 
             if ($current % 5000 == 0) {
                 $p = round($current / $total * 100, 2);
-                $this->output("... updated $current rows, $p%");
+                $this->writeln("... updated $current rows, $p%");
             }
         }
 

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -81,9 +81,8 @@ class EventumMaqMessageId extends AbstractMigration
 
         // Message-Id header missing, load whole email, and let SanitizeHeaders build it
         $body = $this->getBody($maqId);
-        $message = MailMessage::createFromHeaderBody($textHeaders, $body);
 
-        return $message->messageId;
+        return MailMessage::createFromHeaderBody($textHeaders, $body)->messageId;
     }
 
     private function getQueueIds()

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+use Eventum\Monolog\Logger;
+use Zend\Mail\Headers;
+
+class EventumMaqMessageId extends AbstractMigration
+{
+    public function up()
+    {
+        $logger = Logger::getInstance('db');
+
+        $maq_ids = $this->getQueueIds();
+        $total = count($maq_ids);
+        $current = $changed = 0;
+
+        if (!$total) {
+            // nothing to do
+            return;
+        }
+
+        $this->output("Total $total rows, this may take time. Please be patient.");
+        foreach ($maq_ids as $maq_id) {
+            $current++;
+
+            $maq_headers = $this->getHeaders($maq_id);
+
+            try {
+                $headers = Headers::fromString($maq_headers);
+            } catch (Exception $e) {
+                $logger->info(
+                    "skipped maq_id={$maq_id}, exception: {$e->getMessage()}"
+                );
+                continue;
+            }
+            $message_id = $headers->get('Message-Id');
+            if (!$message_id) {
+                $logger->info(
+                    "skipped maq_id={$maq_id}, no message-id header"
+                );
+                continue;
+            }
+            $message_id = $message_id->getFieldValue();
+
+            $logger->info(
+                "updated maq_id={$maq_id}", ['maq_id' => $maq_id, 'message_id' => $message_id]
+            );
+
+            $this->setMessageId($maq_id, $message_id);
+            $changed++;
+
+            if ($current % 5000 == 0) {
+                $p = round($current / $total * 100, 2);
+                $this->output("... updated $current rows, $p%");
+            }
+        }
+
+        $logger->info("Updated $changed out of $total entries");
+    }
+
+    private function getQueueIds()
+    {
+        // TODO: process only status pending?
+        $sql = 'SELECT maq_id FROM `mail_queue` WHERE maq_message_id IS NULL';
+
+        return $this->queryColumn($sql, 'maq_id');
+    }
+
+    private function getHeaders($maq_id)
+    {
+        $sql = "SELECT maq_headers FROM `mail_queue` WHERE maq_id=$maq_id";
+
+        $rows = $this->queryColumn($sql, 'maq_headers');
+
+        return $rows[0];
+    }
+
+    private function setMessageId($maq_id, $messageId)
+    {
+        // NOTE: no method to quote from phinx,
+        // but $messageId should be sql safe after it came from Zend\Mail
+        $this->query("UPDATE `mail_queue` SET maq_message_id='{$messageId}' WHERE maq_id={$maq_id}");
+    }
+}

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -73,10 +73,16 @@ class EventumMaqMessageId extends AbstractMigration
     private function getMessageId($maqId)
     {
         $textHeaders = $this->getHeaders($maqId);
-        $headers = Headers::fromString($textHeaders);
-        $messageId = $headers->get('Message-Id');
-        if ($messageId) {
-            return $messageId->getFieldValue();
+
+        try {
+            $headers = Headers::fromString($textHeaders);
+            $messageId = $headers->get('Message-Id');
+            if ($messageId) {
+                return $messageId->getFieldValue();
+            }
+        } catch (Exception $e) {
+            // will fallback and retry with MailMessage
+            $this->logger->debug($e->getMessage());
         }
 
         // Message-Id header missing, load whole email, and let SanitizeHeaders build it

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -112,6 +112,7 @@ class Mail_Queue
             'maq_body' => $mail->getContent(),
             'maq_iss_id' => $issue_id ?: null,
             'maq_subject' => $mail->subject,
+            'maq_message_id' => $mail->messageId,
             'maq_type' => $type,
         ];
 

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -221,7 +221,7 @@ class Misc
      */
     public static function return_bytes($val)
     {
-        $val = trim($val);
+        $val = (int)trim($val);
         $last = strtolower($val[strlen($val) - 1]);
         switch ($last) {
             // The 'G' modifier is available since PHP 5.1.0

--- a/src/Controller/RemoteDataController.php
+++ b/src/Controller/RemoteDataController.php
@@ -240,6 +240,7 @@ class RemoteDataController extends BaseController
         }
 
         $raw = $res['maq_headers'] . "\n" . $res['maq_body'];
+
         return nl2br(htmlspecialchars($raw, ENT_SUBSTITUTE));
     }
 

--- a/src/Db/AbstractMigration.php
+++ b/src/Db/AbstractMigration.php
@@ -17,6 +17,7 @@ use LogicException;
 use Phinx;
 use Phinx\Db\Adapter\MysqlAdapter;
 use Phinx\Migration\AbstractMigration as PhinxAbstractMigration;
+use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class AbstractMigration extends PhinxAbstractMigration
 {
@@ -178,12 +179,13 @@ abstract class AbstractMigration extends PhinxAbstractMigration
     }
 
     /**
-     * output $message to console
+     * Writes a message to the output and adds a newline at the end.
      *
-     * @param string $message
+     * @param string|array $messages The message as an array of lines of a single string
+     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants)
      */
-    protected function output($message)
+    protected function writeln($messages, $options = OutputInterface::OUTPUT_NORMAL | OutputInterface::VERBOSITY_NORMAL)
     {
-        echo "$message\n";
+        $this->output->writeln($messages, $options);
     }
 }

--- a/src/Db/AbstractMigration.php
+++ b/src/Db/AbstractMigration.php
@@ -158,4 +158,32 @@ abstract class AbstractMigration extends PhinxAbstractMigration
         }
         throw new LogicException('primary_key column not found');
     }
+
+    /**
+     * Run SQL Query, return single column.
+     *
+     * @param string $sql
+     * @param string $column
+     * @return array
+     */
+    protected function queryColumn($sql, $column)
+    {
+        $st = $this->query($sql);
+        $rows = [];
+        foreach ($st as $row) {
+            $rows[] = $row[$column];
+        }
+
+        return $rows;
+    }
+
+    /**
+     * output $message to console
+     *
+     * @param string $message
+     */
+    protected function output($message)
+    {
+        echo "$message\n";
+    }
 }

--- a/src/Mail/Helper/MailLoader.php
+++ b/src/Mail/Helper/MailLoader.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Mail\Helper;
+
+use Mime_Helper;
+use Zend\Mail;
+use Zend\Mime;
+
+class MailLoader
+{
+    public static function splitMessage($raw, &$headers, &$content)
+    {
+        // do our own header-body splitting.
+        //
+        // \Zend\Mail\Storage\Message is unable to process mails that contain \n\n in text body
+        // because it has heuristic which headers separator to use
+        // and that gets out of control
+        // https://github.com/zendframework/zend-mail/pull/159
+
+        try {
+            // use RFC compliant "\r\n" EOL
+            Mime\Decode::splitMessage($raw, $headers, $content, "\r\n");
+        } catch (Mail\Exception\InvalidArgumentException $e) {
+            // retry with heuristic
+            try {
+                Mime\Decode::splitMessage($raw, $headers, $content);
+            } catch (Mail\Exception\InvalidArgumentException $e) {
+                static::fallbackMessageSplit($raw, $headers, $content);
+            }
+        } catch (Mail\Exception\RuntimeException $e) {
+            // retry with heuristic
+            try {
+                Mime\Decode::splitMessage($raw, $headers, $content);
+            } catch (Mail\Exception\RuntimeException $e) {
+                static::fallbackMessageSplit($raw, $headers, $content);
+            }
+        }
+    }
+
+    public static function encodeHeaders(array &$headers)
+    {
+        foreach ($headers as $k => $v) {
+            // Zend\Mail does not like empty headers, "Cc:" for example
+            if ($v === '') {
+                unset($headers[$k]);
+            }
+
+            // also it doesn't like 8bit headers
+            if (Mime_Helper::is8bit($v)) {
+                $headers[$k] = Mime_Helper::encode($v);
+            }
+        }
+    }
+
+    private static function fallbackMessageSplit($raw, &$headers, &$content)
+    {
+        // retry with manual \r\n splitting
+        // retry our own splitting
+        // message likely corrupted by Eventum itself
+        list($headers, $content) = explode("\r\n\r\n", $raw, 2);
+
+        // unfold message headers
+        $headers = preg_replace("/\r?\n/", "\r\n", $headers);
+        $headers = preg_replace("/\r\n(\t| )+/", ' ', $headers);
+
+        // split by \r\n, but \r may be optional
+        $headers = preg_split("/\r?\n/", $headers);
+
+        // strip any leftover \r
+        $headers = array_map('trim', $headers);
+
+        static::encodeHeaders($headers);
+    }
+}


### PR DESCRIPTION
#140 added `maq_message_id` column (released as `3.1.1`), but it was never filled by app itself.

this PR will fill the column in mail queue and restore filling it from `maq_headers` column

```
 == 20180306202659 EventumMaqMessageId: migrating
Total 278353 rows, this may take time. Please be patient.
...
 == 20180306202659 EventumMaqMessageId: migrated 4261.0148s

All Done. Took 4261.0750s```

NOTE: it's ok to hit `^C` to abort this patch, it can resume if retried.