### PR TITLE
mail queue: set message status blocked after 20 retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Add `EventDispatcher` to console commands (@glensc, #337)
 - Mail-Download: fix `user_id` fetch using email header (@glensc, #336)
 - Added support for "checkbox" custom fields on advanced search page (@balsdorf, #347)
-- Mail Queue: set message status blocked after 20 retries (@glensc, #353)
+- Mail Queue: set message status failed after 20 retries (@glensc, #353)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Add `EventDispatcher` to console commands (@glensc, #337)
 - Mail-Download: fix `user_id` fetch using email header (@glensc, #336)
 - Added support for "checkbox" custom fields on advanced search page (@balsdorf, #347)
+- Mail Queue: set message status blocked after 20 retries (@glensc, #353)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.3...master
 

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -11,14 +11,12 @@
  * that were distributed with this source code.
  */
 
-use Eventum\Event\MailQueueListener;
 use Eventum\Event\SystemEvents;
 use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Zend\Mail\Header\To;
 
 class Mail_Queue
 {
@@ -29,6 +27,7 @@ class Mail_Queue
 
     const STATUS_PENDING = 'pending';
     const STATUS_ERROR = 'error';
+    const STATUS_BLOCKED = 'blocked';
     const STATUS_SENT = 'sent';
     const STATUS_TRUNCATED = 'truncated';
 

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -27,7 +27,7 @@ class Mail_Queue
 
     const STATUS_PENDING = 'pending';
     const STATUS_ERROR = 'error';
-    const STATUS_BLOCKED = 'blocked';
+    const STATUS_FAILED = 'failed';
     const STATUS_SENT = 'sent';
     const STATUS_TRUNCATED = 'truncated';
 

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -191,7 +191,7 @@ class Mail_Queue
             // add this backward compat block.
             // drop in 3.5.0 and convert to db migrations to set those as 'blocked'
             $sql = 'select count(*) from `mail_queue_log` where mql_maq_id=? and mql_status=?';
-            $res = DB_Helper::getInstance()->getOne($sql, [$maq_id, Mail_Queue::STATUS_ERROR]);
+            $res = DB_Helper::getInstance()->getOne($sql, [$maq_id, self::STATUS_ERROR]);
             if ((int)$res > self::MAX_RETRIES) {
                 continue;
             }

--- a/src/Console/Command/MailQueueProcessCommand.php
+++ b/src/Console/Command/MailQueueProcessCommand.php
@@ -38,10 +38,10 @@ class MailQueueProcessCommand
     {
         // handle only pending emails
         $limit = 50;
-        Mail_Queue::send('pending', $limit);
+        Mail_Queue::send(Mail_Queue::STATUS_PENDING, $limit);
 
         // handle emails that we tried to send before, but an error happened...
         $limit = 50;
-        Mail_Queue::send('error', $limit);
+        Mail_Queue::send(Mail_Queue::STATUS_ERROR, $limit);
     }
 }

--- a/src/Event/MailQueueListener.php
+++ b/src/Event/MailQueueListener.php
@@ -1,0 +1,123 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+use Date_Helper;
+use DB_Helper;
+use Eventum\Mail\MailMessage;
+use League\Flysystem\Exception;
+use Mail_Helper;
+use Mail_Queue;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class MailQueueListener implements EventSubscriberInterface
+{
+    public static function getSubscribedEvents()
+    {
+        return [
+            SystemEvents::MAIL_QUEUE_SEND => 'send',
+            SystemEvents::MAIL_QUEUE_SENT => 'sent',
+            SystemEvents::MAIL_QUEUE_ERROR => 'error',
+        ];
+    }
+
+    public function send(GenericEvent $event)
+    {
+        /** @var MailMessage $mail */
+        $mail = $event->getSubject();
+
+        // remove any Reply-To:/Return-Path: values from outgoing messages
+        $headers = $mail->getHeaders();
+        $headers->removeHeader('Reply-To');
+        $headers->removeHeader('Return-Path');
+    }
+
+    public function sent(GenericEvent $event)
+    {
+        /** @var MailMessage $mail */
+        $mail = $event->getSubject();
+        $this->addStatusLog($event['id'], Mail_Queue::STATUS_SENT);
+
+        if ($event['save_copy']) {
+            Mail_Helper::saveOutgoingEmailCopy($mail, $event['maq_iss_id'], $event['maq_type']);
+        }
+    }
+
+    public function error(GenericEvent $event)
+    {
+        /** @var Exception $e */
+        $e = $event->getSubject();
+
+        $details = $e->getMessage();
+        $errors = $this->getQueueErrorCount($event['id']);
+        echo "Mail_Queue: issue #{$event['maq_iss_id']}: Can't send mail {$event['id']} (retry $errors): $details\n";
+        self::addStatusLog($event['id'], Mail_Queue::STATUS_ERROR, $details);
+    }
+
+    /**
+     * Saves a log entry about the attempt, successful or otherwise, to send the
+     * queued email message. Also updates maq_status of $maq_id to $status.
+     *
+     * @param   int $maq_id The queued email message ID
+     * @param   string $status The status of the attempt ('sent' or 'error')
+     * @param   string $server_message The full message from the SMTP server, in case of an error
+     * @return  bool
+     */
+    private function addStatusLog($maq_id, $status, $server_message = '')
+    {
+        $stmt = 'INSERT INTO
+                    `mail_queue_log`
+                 (
+                    mql_maq_id,
+                    mql_created_date,
+                    mql_status,
+                    mql_server_message
+                 ) VALUES (
+                    ?, ?, ?, ?
+                 )';
+        $params = [
+            $maq_id,
+            Date_Helper::getCurrentDateGMT(),
+            $status,
+            $server_message,
+        ];
+        DB_Helper::getInstance()->query($stmt, $params);
+
+        $stmt = 'UPDATE
+                    `mail_queue`
+                 SET
+                    maq_status=?
+                 WHERE
+                    maq_id=?';
+
+        DB_Helper::getInstance()->query($stmt, [$status, $maq_id]);
+
+        return true;
+    }
+
+    /**
+     * Return number of errors for this queue item
+     *
+     * @param int $maq_id
+     * @return int
+     */
+    private function getQueueErrorCount($maq_id)
+    {
+        $sql = 'select count(*) from `mail_queue_log` where mql_maq_id=? and mql_status=?';
+        $res = DB_Helper::getInstance()->getOne($sql, [$maq_id, Mail_Queue::STATUS_ERROR]);
+
+        return (int)$res;
+    }
+}

--- a/src/Event/MailQueueListener.php
+++ b/src/Event/MailQueueListener.php
@@ -73,7 +73,7 @@ class MailQueueListener implements EventSubscriberInterface
         $this->addStatusLog($event['id'], $status, $errorMessage);
 
         if ($errorCount >= Mail_Queue::MAX_RETRIES) {
-            $status = Mail_Queue::STATUS_BLOCKED;
+            $status = Mail_Queue::STATUS_FAILED;
         }
         $this->setStatus($event['id'], $status);
     }

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -58,4 +58,13 @@ final class SystemEvents
      * @see ImapMessage::createFromImap
      */
     const MAIL_LOADED_IMAP = 'mail.loaded.imap';
+
+    /**
+     * @since 3.4.0
+     * @see Mail_Queue::send()
+     * @see MailQueueListener
+     */
+    const MAIL_QUEUE_SEND = 'mail.queue.send';
+    const MAIL_QUEUE_SENT = 'mail.queue.sent';
+    const MAIL_QUEUE_ERROR = 'mail.queue.error';
 }

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\EventDispatcher;
 
+use Eventum\Event\MailQueueListener;
 use Eventum\Extension\ExtensionManager;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
@@ -36,6 +37,9 @@ class EventManager
             foreach ($subscribers as $subscriber) {
                 $dispatcher->addSubscriber($subscriber);
             }
+
+            // TODO: figure out how to add builtins
+            $dispatcher->addSubscriber(new MailQueueListener());
         }
 
         return $dispatcher;

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -44,7 +44,6 @@ class MailTransport
         $envelope->setTo(Mail_Helper::getEmailAddress($recipient));
         $transport->setEnvelope($envelope);
 
-        $exception = null;
         try {
             $transport->send($mail->toMessage());
         } catch (Exception $e) {

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -14,6 +14,7 @@
 namespace Eventum\Mail;
 
 use Eventum\Monolog\Logger;
+use Exception;
 use Mail_Helper;
 use Setup;
 use Zend\Mail\Transport;
@@ -32,9 +33,7 @@ class MailTransport
      *              specified in the headers, for Bcc:, resending
      *              messages, etc.
      * @param MailMessage $mail
-     * @return mixed Returns true on success, or a exception class
-     *               containing a descriptive error message on
-     *               failure
+     * @throws Exception
      */
     public function send($recipient, MailMessage $mail)
     {
@@ -45,23 +44,22 @@ class MailTransport
         $envelope->setTo(Mail_Helper::getEmailAddress($recipient));
         $transport->setEnvelope($envelope);
 
+        $exception = null;
         try {
             $transport->send($mail->toMessage());
-            $res = true;
-        } catch (\Exception $e) {
+        } catch (Exception $e) {
             $traceFile = $this->getTraceFile();
             if ($traceFile) {
                 // this is largely useless, as the exception likely happens in toMessage call above
                 file_put_contents($traceFile, json_encode([$recipient, $mail->getHeadersArray(), $mail->getContent()]));
             }
             Logger::app()->error($e->getMessage(), ['traceFile' => $traceFile, 'exception' => $e]);
-            $res = $e;
+
+            throw $e;
         } finally {
             // avoid leaking recipient in case of transport reuse
             $transport->setEnvelope(new Transport\Envelope());
         }
-
-        return $res;
     }
 
     /**


### PR DESCRIPTION
previous version also stopped sending after getting error 21 times.

the previous version kept status=error in database, thus resulting processing only one message at a time if database had any message queue item with status error.