### PR TITLE
use ENT_DISALLOWED for htmlspecialchars when displaying email queue

### DIFF
--- a/src/Controller/RemoteDataController.php
+++ b/src/Controller/RemoteDataController.php
@@ -239,7 +239,8 @@ class RemoteDataController extends BaseController
             return $res['maq_body'];
         }
 
-        return $this->processText(nl2br(htmlspecialchars($res['maq_headers'] . "\n" . $res['maq_body'])));
+        $raw = $res['maq_headers'] . "\n" . $res['maq_body'];
+        return nl2br(htmlspecialchars($raw, ENT_SUBSTITUTE));
     }
 
     private function processText($text)


### PR DESCRIPTION
if email is 8bit encoded and contains raw attachment,
htmlspecialchars returns empty string: ""

cc @slay123 