### PR TITLE
update to defuse/php-encryption 2.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ NOTE: Mail related Workflow methods changed signature, see #263
 - Use filename-normalizer for attachment filenames extracted from emails (@glensc, #356)
 - Fix Open Redirect vulnerability found by NetSparker (https://www.netsparker.com/, @balsdorf)
 - Add experimental markdown rendering (@glensc, #291)
+- Update to defuse/php-encryption 2.1 (@glensc, #358)
 
 [3.4.0]: https://github.com/eventum/eventum/compare/v3.3.5...master
 

--- a/composer.json
+++ b/composer.json
@@ -65,7 +65,7 @@
 		"ext-session": "*",
 		"ext-spl": "*",
 		"cebe/markdown": "~1.1.1",
-		"defuse/php-encryption": "~1.2.1",
+		"defuse/php-encryption": "^2.1",
 		"doctrine/dbal": "^2.5",
 		"doctrine/orm": "^2.5",
 		"enrise/urihelper": "^1.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "19c92800876dca53a9acc362c09bfd97",
+    "content-hash": "0bd2b3b06237c00086d0cda577bbe228",
     "packages": [
         {
             "name": "cebe/markdown",
@@ -99,28 +99,35 @@
         },
         {
             "name": "defuse/php-encryption",
-            "version": "v1.2.1",
+            "version": "v2.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/defuse/php-encryption.git",
-                "reference": "b87737b2eec06b13f025cabea847338fa203d1b4"
+                "reference": "5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/b87737b2eec06b13f025cabea847338fa203d1b4",
-                "reference": "b87737b2eec06b13f025cabea847338fa203d1b4",
+                "url": "https://api.github.com/repos/defuse/php-encryption/zipball/5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689",
+                "reference": "5176f5abb38d3ea8a6e3ac6cd3bbb54d8185a689",
                 "shasum": ""
             },
             "require": {
-                "ext-mcrypt": "*",
                 "ext-openssl": "*",
+                "paragonie/random_compat": "~2.0",
                 "php": ">=5.4.0"
             },
+            "require-dev": {
+                "nikic/php-parser": "^2.0|^3.0",
+                "phpunit/phpunit": "^4|^5"
+            },
+            "bin": [
+                "bin/generate-defuse-key"
+            ],
             "type": "library",
             "autoload": {
-                "files": [
-                    "Crypto.php"
-                ]
+                "psr-4": {
+                    "Defuse\\Crypto\\": "src"
+                }
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -129,18 +136,29 @@
             "authors": [
                 {
                     "name": "Taylor Hornby",
-                    "email": "havoc@defuse.ca"
+                    "email": "taylor@defuse.ca",
+                    "homepage": "https://defuse.ca/"
+                },
+                {
+                    "name": "Scott Arciszewski",
+                    "email": "info@paragonie.com",
+                    "homepage": "https://paragonie.com"
                 }
             ],
             "description": "Secure PHP Encryption Library",
             "keywords": [
                 "aes",
+                "authenticated encryption",
                 "cipher",
+                "crypto",
+                "cryptography",
+                "encrypt",
                 "encryption",
-                "mcrypt",
-                "security"
+                "openssl",
+                "security",
+                "symmetric key cryptography"
             ],
-            "time": "2015-03-14T20:27:45+00:00"
+            "time": "2017-05-18T21:28:48+00:00"
         },
         {
             "name": "doctrine/annotations",

--- a/db/migrations/20180316174428_eventum_crypto2_upgrade.php
+++ b/db/migrations/20180316174428_eventum_crypto2_upgrade.php
@@ -17,14 +17,23 @@ use Eventum\Db\AbstractMigration;
 
 class EventumCrypto2Upgrade extends AbstractMigration
 {
-    /**
-     * There is no downgrade support.
-     */
     public function up()
     {
         if (CryptoManager::encryptionEnabled()) {
             $cm = new CryptoUpgradeManager();
             $cm->regenerateKey();
+        }
+    }
+
+    /**
+     * We can not migrate back to old key format,
+     * so just to keep installation usable, disable encryption.
+     */
+    public function down()
+    {
+        if (CryptoManager::encryptionEnabled()) {
+            $cm = new CryptoUpgradeManager();
+            $cm->disable();
         }
     }
 }

--- a/db/migrations/20180316174428_eventum_crypto2_upgrade.php
+++ b/db/migrations/20180316174428_eventum_crypto2_upgrade.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Crypto\CryptoManager;
+use Eventum\Crypto\CryptoUpgradeManager;
+use Eventum\Db\AbstractMigration;
+
+class EventumCrypto2Upgrade extends AbstractMigration
+{
+    /**
+     * There is no downgrade support.
+     */
+    public function up()
+    {
+        if (CryptoManager::encryptionEnabled()) {
+            $cm = new CryptoUpgradeManager();
+            $cm->regenerateKey();
+        }
+    }
+}

--- a/src/Crypto/CryptoException.php
+++ b/src/Crypto/CryptoException.php
@@ -13,8 +13,8 @@
 
 namespace Eventum\Crypto;
 
-use RuntimeException;
+use Defuse\Crypto\Exception\CryptoException as DefuseCryptoException;
 
-class CryptoException extends RuntimeException
+class CryptoException extends DefuseCryptoException
 {
 }

--- a/src/Crypto/CryptoKeyManager.php
+++ b/src/Crypto/CryptoKeyManager.php
@@ -93,15 +93,21 @@ final class CryptoKeyManager
         if (!is_readable($this->keyfile)) {
             throw new CryptoException("Secret file '{$this->keyfile}' not readable");
         }
+
         // load first to see that it's php script
         // this would avoid printing secret key to output if in old or invalid format
         $key = file_get_contents($this->keyfile);
         if (!$key) {
             throw new CryptoException("Unable to read secret file '{$this->keyfile}");
         }
+
+        // support legacy key format
         if (substr($key, 0, 5) !== '<?php') {
-            throw new CryptoException('Secret key legacy format');
+            $this->key = $key;
+
+            return true;
         }
+
         $key = require $this->keyfile;
         if (!$key) {
             throw new CryptoException("Secret file corrupted: {$this->keyfile}");

--- a/src/Crypto/CryptoKeyManager.php
+++ b/src/Crypto/CryptoKeyManager.php
@@ -13,8 +13,7 @@
 
 namespace Eventum\Crypto;
 
-use Crypto;
-use RandomLib;
+use Defuse\Crypto\Key;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -26,6 +25,7 @@ final class CryptoKeyManager
     /** @var string */
     private $keyfile;
 
+    /** @var Key */
     private $key;
 
     public function __construct()
@@ -40,6 +40,7 @@ final class CryptoKeyManager
 
     /**
      * Checks if key file can be updated
+     * @throws CryptoException
      */
     public function canUpdate()
     {
@@ -51,7 +52,8 @@ final class CryptoKeyManager
     /**
      * Load or generate secret key used for crypt
      *
-     * @return string
+     * @throws CryptoException
+     * @return Key
      */
     public function getKey()
     {
@@ -66,16 +68,23 @@ final class CryptoKeyManager
         return $this->key;
     }
 
+    /**
+     * @throws CryptoException
+     */
     private function generateKey()
     {
-        // use RandomLib to get most compatible implementation
-        // Crypto uses mcrypt *ONLY* without any fallback
-        $factory = new RandomLib\Factory();
-        $generator = $factory->getMediumStrengthGenerator();
-        $this->key = $generator->generate(Crypto::KEY_BYTE_SIZE);
-        $this->storePrivateKey();
+        try {
+            $this->key = Key::createNewRandomKey();
+            $this->storePrivateKey();
+        } catch (CryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        }
     }
 
+    /**
+     * @throws CryptoException
+     * @return bool|null
+     */
     private function loadPrivateKey()
     {
         if (!file_exists($this->keyfile) || !filesize($this->keyfile)) {
@@ -84,22 +93,40 @@ final class CryptoKeyManager
         if (!is_readable($this->keyfile)) {
             throw new CryptoException("Secret file '{$this->keyfile}' not readable");
         }
-        $key = trim(file_get_contents($this->keyfile));
+        // load first to see that it's php script
+        // this would avoid printing secret key to output if in old or invalid format
+        $key = file_get_contents($this->keyfile);
         if (!$key) {
             throw new CryptoException("Unable to read secret file '{$this->keyfile}");
         }
-        $this->key = $key;
+        if (substr($key, 0, 5) !== '<?php') {
+            throw new CryptoException('Secret key legacy format');
+        }
+        $key = require $this->keyfile;
+        if (!$key) {
+            throw new CryptoException("Secret file corrupted: {$this->keyfile}");
+        }
+
+        try {
+            $this->key = Key::loadFromAsciiSafeString($key);
+        } catch (CryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        }
 
         return true;
     }
 
+    /**
+     * @throws CryptoException
+     */
     private function storePrivateKey()
     {
         $this->canUpdate();
 
         try {
             $fs = new Filesystem();
-            $fs->dumpFile($this->keyfile, $this->key);
+            $content = sprintf('<' . '?php return %s;', var_export($this->key->saveToAsciiSafeString(), 1));
+            $fs->dumpFile($this->keyfile, $content);
         } catch (IOException $e) {
             throw new CryptoException("Unable to store secret file '{$this->keyfile}': {$e->getMessage()}");
         }

--- a/src/Crypto/CryptoManager.php
+++ b/src/Crypto/CryptoManager.php
@@ -53,7 +53,7 @@ final class CryptoManager
         }
         try {
             RuntimeTests::runtimeTest();
-        } catch (EnvironmentIsBrokenException $e) {
+        } catch (CryptoException $e) {
             throw new CryptoException($e->getMessage(), $e->getCode(), $e);
         }
 
@@ -73,7 +73,7 @@ final class CryptoManager
     public static function encrypt($plaintext, $key = null)
     {
         if ($plaintext === null || $plaintext === false) {
-            throw new InvalidArgumentException('Refusing to encrypt empty value');
+            throw new CryptoException('Refusing to encrypt empty value');
         }
 
         if (!self::encryptionEnabled()) {
@@ -82,7 +82,7 @@ final class CryptoManager
 
         try {
             return Crypto::encrypt($plaintext, $key ?: self::getKey());
-        } catch (EnvironmentIsBrokenException $e) {
+        } catch (CryptoException $e) {
             throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
         }
     }
@@ -110,7 +110,7 @@ final class CryptoManager
 
             // support legacy decrypt
             return Crypto::legacyDecrypt(base64_decode($ciphertext), $key);
-        } catch (EnvironmentIsBrokenException $e) {
+        } catch (CryptoException $e) {
             throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
         }
     }

--- a/src/Crypto/CryptoManager.php
+++ b/src/Crypto/CryptoManager.php
@@ -15,6 +15,7 @@ namespace Eventum\Crypto;
 
 use Defuse\Crypto\Crypto;
 use Defuse\Crypto\Exception\EnvironmentIsBrokenException;
+use Defuse\Crypto\Key;
 use Defuse\Crypto\RuntimeTests;
 use InvalidArgumentException;
 use Setup;
@@ -101,7 +102,14 @@ final class CryptoManager
         }
 
         try {
-            return Crypto::decrypt($ciphertext, self::getKey());
+            $key = self::getKey();
+
+            if ($key instanceof Key) {
+                return Crypto::decrypt($ciphertext, $key);
+            }
+
+            // support legacy decrypt
+            return Crypto::legacyDecrypt(base64_decode($ciphertext), $key);
         } catch (EnvironmentIsBrokenException $e) {
             throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
         }

--- a/src/Crypto/CryptoUpgradeManager.php
+++ b/src/Crypto/CryptoUpgradeManager.php
@@ -32,11 +32,12 @@ class CryptoUpgradeManager
      * Perform few checks that enable/disable can be performed
      *
      * @param bool $enable TRUE if action is to enable, FALSE if action is to disable
+     * @throws CryptoException
      */
     private function canPerform($enable)
     {
         $enabled = CryptoManager::encryptionEnabled();
-        if ($enabled && $enable || (!$enabled && !$enable)) {
+        if (($enabled && $enable) || (!$enabled && !$enable)) {
             $state = $enabled ? 'enabled' : 'disabled';
             throw new CryptoException("Can not perform, already $state");
         }

--- a/src/Crypto/EncryptedValue.php
+++ b/src/Crypto/EncryptedValue.php
@@ -13,8 +13,6 @@
 
 namespace Eventum\Crypto;
 
-use InvalidArgumentException;
-
 /**
  * Class Encrypted Value
  *
@@ -43,6 +41,7 @@ final class EncryptedValue
      * The encrypted value is stored in object property.
      *
      * @param string $plaintext
+     * @throws CryptoException
      */
     public function setValue($plaintext)
     {
@@ -52,12 +51,13 @@ final class EncryptedValue
     /**
      * Return plain text value
      *
+     * @throws CryptoException
      * @return string
      */
     public function getValue()
     {
         if ($this->ciphertext === null) {
-            throw new InvalidArgumentException('Value not initialized yet');
+            throw new CryptoException('Value not initialized yet');
         }
 
         return CryptoManager::decrypt($this->ciphertext);
@@ -66,12 +66,13 @@ final class EncryptedValue
     /**
      * Get encrypted value, for storing it to Database or Config
      *
+     * @throws CryptoException
      * @return string
      */
     public function getEncrypted()
     {
         if ($this->ciphertext === null) {
-            throw new InvalidArgumentException('Value not initialized yet');
+            throw new CryptoException('Value not initialized yet');
         }
 
         return $this->ciphertext;


### PR DESCRIPTION
[php-encryption/2.0.0](https://github.com/defuse/php-encryption/releases/tag/v2.0.0):
> Release of version 2.0.0 of defuse/php-encryption. This is a significant compatibility-breaking improvement over version 1.2.1. See the README for details.

NOTE: as the encrypted results are hex encoded by defuse/php-encryption, instead of base64, the result db columns may need to be increased. 1 byte encryption resulted 170 bytes encrypted result and 255 byte got exploded to 678 bytes.

so therefore not using defuse encoding, but keeping our own base64 implementation