### PR TITLE
Fix bug adding sender to authorized repliers list when unblocking email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Eventum 3.4.x requires PHP 5.6.
 - Fix bug with project switcher not redirecting to previous page (@balsdorf)
 - Fix bug dumping routed mail to save directory (@balsdorf)
 - Update cebe/markdown to 1.2.1 (@glensc, #365)
+- Fix bug with adding sender to authorized repliers list when unblocking an email (@balsdorf, #364)
 
 [3.4.1]: https://github.com/eventum/eventum/compare/v3.4.0...master
 

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -323,6 +323,10 @@ class Notification
      */
     public static function notifyNewEmail(MailMessage $mail, array $options = [])
     {
+        // create copy of message object to prevent modifications made in this method from
+        // being seen in calling method.
+        $mail = MailMessage::createFromMessage($mail->toMessage());
+
         $internal_only = isset($options['internal_only']) ? $options['internal_only'] : false;
         $assignee_only = isset($options['assignee_only']) ? $options['assignee_only'] : false;
         $type = isset($options['type']) ? $options['type'] : '';


### PR DESCRIPTION
So in [Note::convertNote](https://github.com/eventum/eventum/blob/4e95a61ee6df5c6c8a1fabc5e749e00ea582ab66/lib/eventum/class.note.php#L579) the `$mail` object is passed to `Notification::notifyNewEmail` which changes the sender. Then on [line 588](https://github.com/eventum/eventum/blob/4e95a61ee6df5c6c8a1fabc5e749e00ea582ab66/lib/eventum/class.note.php#L588) `$mail->from` is accessed which now shows the sender from Notification::notifyNewEmail. 

I've now made `notifyNewEmail` create a copy of the mail object before modifying it. 