### PR TITLE
Fix parsing of link references in markdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ This version drops IRC Bot from Eventum Core, see #371
 
 - Fix corrupted note body on blocked multi-part emails (@balsdorf)
 - Drop IRC Bot from eventum core, available as eventum/irc-bot instead (@glensc, #371)
+- Fix parsing of link references in markdown (@glensc, #367)
 
 [3.5.0]: https://github.com/eventum/eventum/compare/v3.4.2...master
 

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -263,7 +263,9 @@ class Link_Filter
             $parser->enableNewlines = true;
         }
 
-        $text = $parser->parseParagraph($text);
+        $text = $parser->parse($text);
+        // strip paragraph, confuses single line areas
+        $text = preg_replace("{^<p>(.+)</p>\n}", '$1', $text);
 
         return $text;
     }

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -265,7 +265,7 @@ class Link_Filter
 
         $text = $parser->parse($text);
         // strip paragraph, confuses single line areas
-        $text = preg_replace("{^<p>(.+)</p>\n}", '$1', $text);
+        $text = preg_replace("{^<p>(.+)</p>\n$}", '$1', $text);
 
         return $text;
     }


### PR DESCRIPTION
Fix parsing of link references in markdown.

https://github.com/cebe/markdown/issues/157
