### PR TITLE
add factory method to extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ This version drops IRC Bot from Eventum Core, see #371
 - Fix corrupted note body on blocked multi-part emails (@balsdorf)
 - Drop IRC Bot from eventum core, available as eventum/irc-bot instead (@glensc, #371)
 - Fix parsing of link references in markdown (@glensc, #367)
+- Add Factory support for Extension to construct it's own classes (@glensc, #375)
 
 [3.5.0]: https://github.com/eventum/eventum/compare/v3.4.2...master
 

--- a/src/Extension/ExtensionFactoryInterface.php
+++ b/src/Extension/ExtensionFactoryInterface.php
@@ -19,7 +19,7 @@ interface ExtensionFactoryInterface
      * Create instance of $className
      *
      * @param string $className
-     * @return object
+     * @return object|null
      * @since 3.5.0
      */
     public function factory($className);

--- a/src/Extension/ExtensionFactoryInterface.php
+++ b/src/Extension/ExtensionFactoryInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+interface ExtensionFactoryInterface
+{
+    /**
+     * Create instance of $className
+     *
+     * @param string $className
+     * @return object
+     * @since 3.5.0
+     */
+    public function factory($className);
+}


### PR DESCRIPTION
this allows extensions create class instances themselves.

for example, I might have event subscriber where I want to inject dependencies via constructor:

```php

class IrcSubscriber implements EventSubscriberInterface {
	public function __construct(LoggerInterface $logger) {
		$this->logger = $logger;
	}

	public static function getSubscribedEvents() {
...
```

I'm using myself [Pimple](https://github.com/silexphp/Pimple) [service container](https://pimple.symfony.com/#extending-a-container) to lazy create instances:

```php
		$app[IrcSubscriber::class] = function ($app) {
			return new IrcSubscriber($app['logger']);
		};
```