### PR TITLE
Use less global constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,6 @@ Session.vim
 /localization/*/
 /po
 
-/tests/_setup.php
 /tests/_locales.stamp
 !/tests/_bootstrap.php
 /tests/ldap.php

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,6 +62,7 @@ cache:
 
 before_install:
   - bin/ci/configure.sh
+  - cp config/setup.phpunit.php config/setup.php
 
 install:
   - composer install --no-interaction --prefer-dist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ This version drops IRC Bot from Eventum Core, see #371
 - Fix parsing of link references in markdown (@glensc, #367)
 - Add Factory support for Extension to construct it's own classes (@glensc, #375)
 - Deprecate config loading from workflow class (@glensc, #378)
+- Use less global constants (@glensc, #377)
 
 [3.5.0]: https://github.com/eventum/eventum/compare/v3.4.2...master
 

--- a/autoload.php
+++ b/autoload.php
@@ -14,7 +14,13 @@
 // this needs to be setup before autoload itself
 define('APP_PHP_GETTEXT_PATH', APP_PATH . '/vendor/php-gettext/php-gettext');
 
-if (!file_exists($autoload = APP_PATH . '/vendor/autoload.php')) {
+foreach ([APP_PATH . '/vendor/autoload.php', APP_PATH . '/../../../vendor/autoload.php'] as $autoload) {
+    if (file_exists($autoload)) {
+        break;
+    }
+}
+
+if (!file_exists($autoload)) {
     echo <<<EOF
 
     You must set up the project dependencies, run the following commands:

--- a/config/setup.phpunit.php
+++ b/config/setup.phpunit.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+return [
+    'database' => [
+        'hostname' => 'localhost',
+        'database' => 'eventum',
+        'username' => 'mysql',
+        'password' => '',
+        'port' => 3306,
+    ],
+    'admin_user' => 2,
+];

--- a/db/migrations/20180520134959_eventum_db_charset_config.php
+++ b/db/migrations/20180520134959_eventum_db_charset_config.php
@@ -1,0 +1,37 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumDbCharsetConfig extends AbstractMigration
+{
+    public function up()
+    {
+        $config = Setup::get();
+        $config['database']['charset'] = $this->getCharset();
+
+        Setup::save();
+    }
+
+    /**
+     * Get charset suitable for PDO mysql driver
+     *
+     * @return string
+     */
+    protected function getCharset()
+    {
+        // no dash variant listed, blindly reap "UTF-8" to "UTF8"
+        // http://dev.mysql.com/doc/refman/5.0/en/charset-charsets.html
+        return strtolower(str_replace('-', '', APP_CHARSET));
+    }
+}

--- a/globals.php
+++ b/globals.php
@@ -13,8 +13,10 @@
 
 // base path
 define('APP_PATH', __DIR__);
+// @deprecated since 3.5.0
 define('APP_CONFIG_PATH', APP_PATH . '/config');
 define('APP_INC_PATH', APP_PATH . '/lib/eventum');
+// @deprecated since 3.5.0
 define('APP_SETUP_FILE', APP_CONFIG_PATH . '/setup.php');
 
 // /var path for writable data

--- a/htdocs/setup/check_permissions.php
+++ b/htdocs/setup/check_permissions.php
@@ -21,11 +21,12 @@ echo '<html>
 </head>
 <body>';
 
+$setupFile = Setup::getSetupFile();
 echo "<p class=\"default\">This script checks your eventum directory for permission problems. Since different hosts will have
 permissions setup differently this script cannot automatically fix permission problems.</p>
 <p class=\"default\">As a general rule, your webserver should be running as 'nobody' (a user with few permissions)
 and your files should not be writable from the web. Only your logs (" . APP_LOG_PATH . ') and setup (' .
-APP_SETUP_FILE . ') files need to be writable by the web server.</p>
+    $setupFile . ') files need to be writable by the web server.</p>
 
 <p>The commands listed in the comments are only examples and may not work for every installation.';
 
@@ -46,7 +47,7 @@ check_file('Log Directory', APP_LOG_PATH, 'Log directory should be writable by y
     server should <b>NOT</b> be able to read this directory to prevent outsiders from viewing your logs.
                 <em>chmod -R a-r ' . APP_LOG_PATH . '</em>', 'w');
 
-check_file('Setup File', APP_SETUP_FILE, "The setup file should be both readable and writable from your web server.
+check_file('Setup File', $setupFile, "The setup file should be both readable and writable from your web server.
     The setup file is used to store general settings.<br /><b>Note:</b> Once you have eventum configured, you can
     mark this file as 'read only' if you want.", 'rw');
 

--- a/htdocs/setup/index.php
+++ b/htdocs/setup/index.php
@@ -25,7 +25,8 @@ define('APP_CHARSET', 'UTF-8');
 
 header('Content-Type: text/html; charset=' . APP_CHARSET);
 
-$have_config = file_exists(APP_CONFIG_PATH . '/config.php') && filesize(APP_CONFIG_PATH . '/config.php');
+$configPath = Setup::getConfigPath();
+$have_config = file_exists($configPath . '/config.php') && filesize($configPath . '/config.php');
 // get out if already configured
 if ($have_config) {
     header('Location: ../');
@@ -39,7 +40,7 @@ date_default_timezone_set(@date_default_timezone_get());
 
 define('APP_NAME', 'Eventum');
 define('APP_DEFAULT_LOCALE', 'en_US');
-define('APP_LOCAL_PATH', APP_CONFIG_PATH);
+define('APP_LOCAL_PATH', $configPath);
 define('APP_RELATIVE_URL', '../');
 define('APP_SITE_NAME', 'Eventum');
 define('APP_COOKIE', 'eventum');

--- a/init.php
+++ b/init.php
@@ -76,7 +76,7 @@ $define('APP_DEFAULT_TIMEZONE', 'UTC');
 $define('APP_DEFAULT_WEEKDAY', 0);
 
 if (!defined('APP_EMAIL_ENCODING')) {
-    if (APP_CHARSET == 'UTF-8') {
+    if (APP_CHARSET === 'UTF-8') {
         define('APP_EMAIL_ENCODING', '8bit');
     } else {
         define('APP_EMAIL_ENCODING', '7bit');

--- a/lib/eventum/auth/class.cas_auth_backend.php
+++ b/lib/eventum/auth/class.cas_auth_backend.php
@@ -280,7 +280,7 @@ class CAS_Auth_Backend implements Auth_Backend_Interface
         static $setup;
         if (empty($setup) || $force == true) {
             $setup = [];
-            $configfile = APP_CONFIG_PATH . '/cas.php';
+            $configfile = Setup::getConfigPath() . '/cas.php';
 
             if (file_exists($configfile)) {
                 /** @noinspection PhpIncludeInspection */

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -30,7 +30,7 @@ class Auth
     {
         static $private_key;
         if ($private_key === null) {
-            require_once APP_CONFIG_PATH . '/private_key.php';
+            require_once Setup::getConfigPath() . '/private_key.php';
         }
 
         return $private_key;
@@ -43,7 +43,7 @@ class Auth
      */
     public static function generatePrivateKey()
     {
-        $path = APP_CONFIG_PATH . '/private_key.php';
+        $path = Setup::getConfigPath() . '/private_key.php';
         $private_key = md5(Misc::generateRandom(32));
 
         $contents = '<' . "?php\n\$private_key = " . var_export($private_key, 1) . ";\n";

--- a/lib/eventum/class.language.php
+++ b/lib/eventum/class.language.php
@@ -41,7 +41,10 @@ class Language
      */
     public static function setup()
     {
-        self::set(APP_DEFAULT_LOCALE);
+        if (!defined('APP_NO_GETTEXT')) {
+            self::set(APP_DEFAULT_LOCALE);
+        }
+
         self::initEncoding();
     }
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -82,6 +82,9 @@ class Setup
      */
     public static function save($options = [])
     {
+        $configPath = dirname(dirname(__DIR__)) . '/config';
+        $setupFile = $configPath . '/setup.php';
+
         $config = self::set($options);
         try {
             $clone = clone $config;
@@ -89,9 +92,9 @@ class Setup
             $ldap = $clone->ldap;
             unset($clone->ldap);
 
-            self::saveConfig(APP_SETUP_FILE, $clone);
+            self::saveConfig($setupFile, $clone);
             if ($ldap) {
-                self::saveConfig(APP_CONFIG_PATH . '/ldap.php', $ldap);
+                self::saveConfig($configPath . '/ldap.php', $ldap);
             }
         } catch (Exception $e) {
             $code = $e->getCode();
@@ -110,12 +113,15 @@ class Setup
      */
     private static function initialize()
     {
+        $configPath = dirname(dirname(__DIR__)) . '/config';
+        $setupFile = $configPath . '/setup.php';
+
         $config = new Config(self::getDefaults(), true);
-        $config->merge(new Config(self::loadConfigFile(APP_SETUP_FILE)));
+        $config->merge(new Config(self::loadConfigFile($setupFile)));
 
         // some subtrees are saved to different files
         $extra_configs = [
-            'ldap' => APP_CONFIG_PATH . '/ldap.php',
+            'ldap' => $configPath . '/ldap.php',
         ];
 
         foreach ($extra_configs as $section => $filename) {
@@ -188,13 +194,15 @@ class Setup
      */
     private static function getDefaults()
     {
+        $appPath = dirname(dirname(__DIR__));
+
         // at minimum should define top level array elements
         // so that fluent access works without errors and notices
         $defaults = [
             'monitor' => [
                 'diskcheck' => [
                     'status' => 'enabled',
-                    'partition' => APP_PATH,
+                    'partition' => $appPath,
                 ],
                 'paths' => [
                     'status' => 'enabled',

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -82,9 +82,6 @@ class Setup
      */
     public static function save($options = [])
     {
-        $configPath = dirname(dirname(__DIR__)) . '/config';
-        $setupFile = $configPath . '/setup.php';
-
         $config = self::set($options);
         try {
             $clone = clone $config;
@@ -92,9 +89,9 @@ class Setup
             $ldap = $clone->ldap;
             unset($clone->ldap);
 
-            self::saveConfig($setupFile, $clone);
+            self::saveConfig(self::getSetupFile(), $clone);
             if ($ldap) {
-                self::saveConfig($configPath . '/ldap.php', $ldap);
+                self::saveConfig(self::getConfigPath() . '/ldap.php', $ldap);
             }
         } catch (Exception $e) {
             $code = $e->getCode();
@@ -107,21 +104,36 @@ class Setup
     }
 
     /**
+     * @return string
+     * @since 3.5.0
+     */
+    public static function getConfigPath()
+    {
+        return dirname(dirname(__DIR__)) . '/config';
+    }
+
+    /**
+     * @return string
+     * @since 3.5.0
+     */
+    public static function getSetupFile()
+    {
+        return self::getConfigPath() . '/setup.php';
+    }
+
+    /**
      * Initialize config object, load it from setup files, merge defaults.
      *
      * @return Config
      */
     private static function initialize()
     {
-        $configPath = dirname(dirname(__DIR__)) . '/config';
-        $setupFile = $configPath . '/setup.php';
-
         $config = new Config(self::getDefaults(), true);
-        $config->merge(new Config(self::loadConfigFile($setupFile)));
+        $config->merge(new Config(self::loadConfigFile(self::getSetupFile())));
 
         // some subtrees are saved to different files
         $extra_configs = [
-            'ldap' => $configPath . '/ldap.php',
+            'ldap' => self::getConfigPath() . '/ldap.php',
         ];
 
         foreach ($extra_configs as $section => $filename) {

--- a/src/Console/Command/MonitorCommand.php
+++ b/src/Console/Command/MonitorCommand.php
@@ -43,8 +43,9 @@ class MonitorCommand
         $this->output = $output;
 
         // the owner, group and filesize settings should be changed to match the correct permissions on your server.
+        $configPath = Setup::getConfigPath();
         $required_files = [
-            APP_CONFIG_PATH . '/config.php' => [
+            $configPath . '/config.php' => [
                 'check_owner' => true,
                 'owner' => 'apache',
                 'check_group' => true,
@@ -52,7 +53,7 @@ class MonitorCommand
                 'check_permission' => true,
                 'permission' => 640,
             ],
-            APP_CONFIG_PATH . '/setup.php' => [
+            $configPath . '/setup.php' => [
                 'check_owner' => true,
                 'owner' => 'apache',
                 'check_group' => true,

--- a/src/Controller/Manage/GeneralController.php
+++ b/src/Controller/Manage/GeneralController.php
@@ -83,20 +83,20 @@ class GeneralController extends ManageBaseController
         $res = Setup::save($setup);
         $this->tpl->assign('result', $res);
 
+        $setupFile = Setup::getSetupFile();
+        $configPath = Setup::getConfigPath();
         $map = [
             1 => [ev_gettext('Thank you, the setup information was saved successfully.'), MessagesHelper::MSG_INFO],
             -1 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions to create the configuration file in the setup directory (%1\$s). " .
-                            'Please contact your local system administrator and ask for write privileges on the provided path.',
-                            APP_CONFIG_PATH
-                        ),
-                        MessagesHelper::MSG_NOTE_BOX, ],
+                "ERROR: The system doesn't have the appropriate permissions to create the configuration file in the setup directory (%1\$s). " .
+                'Please contact your local system administrator and ask for write privileges on the provided path.',
+                $configPath
+            ), MessagesHelper::MSG_NOTE_BOX],
             -2 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions to update the configuration file in the setup directory (%1\$s). " .
-                            'Please contact your local system administrator and ask for write privileges on the provided filename.',
-                            APP_SETUP_FILE
-                        ),
-                   MessagesHelper::MSG_NOTE_BOX, ],
+                "ERROR: The system doesn't have the appropriate permissions to update the configuration file in the setup directory (%1\$s). " .
+                'Please contact your local system administrator and ask for write privileges on the provided filename.',
+                $setupFile
+            ), MessagesHelper::MSG_NOTE_BOX],
         ];
         $this->messages->mapMessages($res, $map);
     }

--- a/src/Controller/Manage/LdapController.php
+++ b/src/Controller/Manage/LdapController.php
@@ -87,15 +87,16 @@ class LdapController extends ManageBaseController
         $config['ldap']['default_role'] = [];
         $res = Setup::save(['ldap' => $setup]);
 
+        $configPath = Setup::getConfigPath();
         // FIXME: translations
         $map = [
             1 => ['Thank you, the setup information was saved successfully.', MessagesHelper::MSG_INFO],
             -1 => ["ERROR: The system doesn't have the appropriate permissions " .
-                        'to create the configuration file in the setup directory (' . APP_CONFIG_PATH . '). ".
+                        'to create the configuration file in the setup directory (' . $configPath . '). ".
                         "Please contact your local system administrator and ask for write privileges on the provided path.',
                         MessagesHelper::MSG_HTML_BOX, ],
             -2 => ["ERROR: The system doesn't have the appropriate permissions " .
-                        'to update the configuration file in the setup directory (' . APP_CONFIG_PATH . '/ldap.php). ".
+                        'to update the configuration file in the setup directory (' . $configPath . '/ldap.php). ".
                         "Please contact your local system administrator ".
                         "and ask for write privileges on the provided filename.',
                    MessagesHelper::MSG_HTML_BOX, ],

--- a/src/Controller/Manage/MonitorController.php
+++ b/src/Controller/Manage/MonitorController.php
@@ -60,22 +60,24 @@ class MonitorController extends ManageBaseController
         ];
         $res = Setup::save(['monitor' => $setup]);
 
+        $setupFile = Setup::getSetupFile();
+        $configPath = Setup::getConfigPath();
         $map = [
             1 => [ev_gettext('Thank you, the setup information was saved successfully.'), MessagesHelper::MSG_INFO],
             -1 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions " .
-                            'to create the configuration file in the setup directory (%s). ' .
-                            'Please contact your local system administrator ' .
-                            'and ask for write privileges on the provided path.',
-                            APP_CONFIG_PATH
-                        ), MessagesHelper::MSG_NOTE_BOX],
+                "ERROR: The system doesn't have the appropriate permissions " .
+                'to create the configuration file in the setup directory (%s). ' .
+                'Please contact your local system administrator ' .
+                'and ask for write privileges on the provided path.',
+                $configPath
+            ), MessagesHelper::MSG_NOTE_BOX],
             -2 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions " .
-                            'to update the configuration file in the setup directory (%s). ' .
-                            'Please contact your local system administrator and ask ' .
-                            'for write privileges on the provided filename.',
-                            APP_SETUP_FILE
-                        ), MessagesHelper::MSG_NOTE_BOX],
+                "ERROR: The system doesn't have the appropriate permissions " .
+                'to update the configuration file in the setup directory (%s). ' .
+                'Please contact your local system administrator and ask ' .
+                'for write privileges on the provided filename.',
+                $setupFile
+            ), MessagesHelper::MSG_NOTE_BOX],
         ];
         $this->messages->mapMessages($res, $map);
     }

--- a/src/Controller/Manage/ScmController.php
+++ b/src/Controller/Manage/ScmController.php
@@ -43,7 +43,7 @@ class ScmController extends ManageBaseController
      */
     protected function defaultAction()
     {
-        if ($this->cat == 'update') {
+        if ($this->cat === 'update') {
             $this->updateAction();
         }
     }
@@ -56,16 +56,19 @@ class ScmController extends ManageBaseController
         $res = Setup::save($setup);
         $this->tpl->assign('result', $res);
 
+        $setupFile = Setup::getSetupFile();
+        $configPath = Setup::getConfigPath();
+
         $map = [
             1 => [ev_gettext('Thank you, the setup information was saved successfully.'), MessagesHelper::MSG_INFO],
             -1 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions to create the configuration file in the setup directory (%1\$s). " .
-                            'Please contact your local system administrator and ask for write privileges on the provided path.', APP_CONFIG_PATH
-                        ), MessagesHelper::MSG_NOTE_BOX],
+                "ERROR: The system doesn't have the appropriate permissions to create the configuration file in the setup directory (%1\$s). " .
+                'Please contact your local system administrator and ask for write privileges on the provided path.', $configPath
+            ), MessagesHelper::MSG_NOTE_BOX],
             -2 => [ev_gettext(
-                            "ERROR: The system doesn't have the appropriate permissions to update the configuration file in the setup directory (%1\$s). " .
-                            'Please contact your local system administrator and ask for write privileges on the provided filename.', APP_SETUP_FILE
-                        ), MessagesHelper::MSG_NOTE_BOX],
+                "ERROR: The system doesn't have the appropriate permissions to update the configuration file in the setup directory (%1\$s). " .
+                'Please contact your local system administrator and ask for write privileges on the provided filename.', $setupFile
+            ), MessagesHelper::MSG_NOTE_BOX],
         ];
         $this->messages->mapMessages($res, $map);
     }

--- a/src/Controller/Setup/SetupController.php
+++ b/src/Controller/Setup/SetupController.php
@@ -368,14 +368,15 @@ class SetupController extends BaseController
     private function write_config()
     {
         $post = $this->getRequest()->request;
-        $config_file_path = APP_CONFIG_PATH . '/config.php';
+        $configPath = Setup::getConfigPath();
+        $configFilePath = $configPath . '/config.php';
 
         // disable the full-text search feature for certain mysql server users
         $mysql_version = DB_Helper::getInstance(false)->getOne('SELECT VERSION()');
         preg_match('/(\d{1,2}\.\d{1,2}\.\d{1,2})/', $mysql_version, $matches);
         $enable_fulltext = $matches[1] > '4.0.23';
 
-        $protocol_type = $post->get('is_ssl') == 'yes' ? 'https://' : 'http://';
+        $protocol_type = $post->get('is_ssl') === 'yes' ? 'https://' : 'http://';
 
         $replace = [
             "'%{APP_HOSTNAME}%'" => $this->e($post->get('hostname')),
@@ -387,11 +388,11 @@ class SetupController extends BaseController
             "'%{APP_ENABLE_FULLTEXT}%'" => $this->e($enable_fulltext),
         ];
 
-        $config_contents = file_get_contents(APP_CONFIG_PATH . '/config.dist.php');
+        $config_contents = file_get_contents($configPath . '/config.dist.php');
         $config_contents = str_replace(array_keys($replace), array_values($replace), $config_contents);
 
         $fs = new Filesystem();
-        $fs->dumpFile($config_file_path, $config_contents, null);
+        $fs->dumpFile($configFilePath, $config_contents, null);
     }
 
     private function install()

--- a/src/Controller/Setup/SetupController.php
+++ b/src/Controller/Setup/SetupController.php
@@ -207,22 +207,25 @@ class SetupController extends BaseController
                 = "The 'file_uploads' directive needs to be enabled in your PHP.INI file in order for Eventum to work properly.";
         }
 
-        $error = $this->checkPermissions(APP_CONFIG_PATH, "Directory '" . APP_CONFIG_PATH . "'", true);
+        $configPath = Setup::getConfigPath();
+        $setupFile = Setup::getSetupFile();
+
+        $error = $this->checkPermissions($configPath, "Directory '" . $configPath . "'", true);
         if (!empty($error)) {
             $errors[] = $error;
         }
-        $error = $this->checkPermissions(APP_SETUP_FILE, "File '" . APP_SETUP_FILE . "'");
+        $error = $this->checkPermissions($setupFile, "File '" . $setupFile . "'");
         if (!empty($error)) {
             $errors[] = $error;
         }
         $error = $this->checkPermissions(
-            APP_CONFIG_PATH . '/private_key.php', "File '" . APP_CONFIG_PATH . '/private_key.php' . "'"
+            $configPath . '/private_key.php', "File '" . $configPath . '/private_key.php' . "'"
         );
         if (!empty($error)) {
             $errors[] = $error;
         }
         $error = $this->checkPermissions(
-            APP_CONFIG_PATH . '/config.php', "File '" . APP_CONFIG_PATH . '/config.php' . "'"
+            $configPath . '/config.php', "File '" . $configPath . '/config.php' . "'"
         );
         if (!empty($error)) {
             $errors[] = $error;

--- a/src/Crypto/CryptoKeyManager.php
+++ b/src/Crypto/CryptoKeyManager.php
@@ -14,6 +14,7 @@
 namespace Eventum\Crypto;
 
 use Defuse\Crypto\Key;
+use Setup;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
 
@@ -30,7 +31,7 @@ final class CryptoKeyManager
 
     public function __construct()
     {
-        $this->keyfile = APP_CONFIG_PATH . '/secret_key.php';
+        $this->keyfile = Setup::getConfigPath() . '/secret_key.php';
     }
 
     public function regen()

--- a/src/Db/Adapter/PdoAdapterBase.php
+++ b/src/Db/Adapter/PdoAdapterBase.php
@@ -38,7 +38,7 @@ abstract class PdoAdapterBase
     protected function getDsn($config)
     {
         $driver = $this->getDriverName($config);
-        $charset = $this->getCharset();
+        $charset = isset($config['charset']) ? $config['charset'] : $this->getCharset();
 
         $dsn = "{$driver}:host={$config['hostname']};dbname={$config['database']};charset={$charset}";
 
@@ -59,6 +59,7 @@ abstract class PdoAdapterBase
      * Get charset suitable for PDO mysql driver
      *
      * @return string
+     * @deprecated when dropping handle EventumDbCharsetConfig migration as well
      */
     protected function getCharset()
     {

--- a/src/Db/Adapter/YiiAdapter.php
+++ b/src/Db/Adapter/YiiAdapter.php
@@ -63,7 +63,7 @@ class YiiAdapter extends PdoAdapterBase implements AdapterInterface
                     'dsn' => $this->getDsn($config),
                     'username' => $config['username'],
                     'password' => $config['password'],
-                    'charset' => $this->getCharset(),
+                    'charset' => isset($config['charset']) ? $config['charset'] : $this->getCharset(),
                 ],
             ],
         ];

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -208,6 +208,12 @@ class ExtensionManager
      */
     protected function getAutoloader()
     {
-        return require APP_PATH . '/vendor/autoload.php';
+        foreach ([APP_PATH . '/vendor/autoload.php', APP_PATH . '/../../../vendor/autoload.php'] as $autoload) {
+            if (file_exists($autoload)) {
+                break;
+            }
+        }
+
+        return require $autoload;
     }
 }

--- a/src/Monolog/Logger.php
+++ b/src/Monolog/Logger.php
@@ -63,9 +63,10 @@ class Logger extends Registry
         /** @var \Zend\Config\Config $setup */
         $setup = Setup::get();
 
+        $configPath = Setup::getConfigPath();
         $files = [
             APP_PATH . '/res/config/logger.php',
-            APP_CONFIG_PATH . '/logger.php',
+            $configPath . '/logger.php',
         ];
         $config = [];
         foreach ($files as $file) {

--- a/tests/AuthCookieTest.php
+++ b/tests/AuthCookieTest.php
@@ -15,6 +15,7 @@ namespace Eventum\Test;
 
 use Auth;
 use AuthCookie;
+use Setup;
 
 /**
  * @group db
@@ -23,7 +24,7 @@ class AuthCookieTest extends TestCase
 {
     public static function setupBeforeClass()
     {
-        if (file_exists(APP_CONFIG_PATH . '/private_key.php')) {
+        if (file_exists(Setup::getConfigPath() . '/private_key.php')) {
             return;
         }
         Auth::generatePrivateKey();

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -18,7 +18,6 @@ use Eventum\Monolog\Logger;
 define('APP_PATH', dirname(__DIR__));
 define('APP_CONFIG_PATH', __DIR__);
 define('APP_VAR_PATH', APP_PATH . '/var');
-define('APP_SETUP_FILE', APP_CONFIG_PATH . '/_setup.php');
 // FIXME: HHVM: Warning: Constants may only evaluate to scalar values
 define('APP_ERROR_LOG', STDERR);
 define('APP_INC_PATH', APP_PATH . '/lib/eventum');
@@ -54,23 +53,6 @@ require_once APP_PATH . '/autoload.php';
 
 // set default timezone
 date_default_timezone_set(APP_DEFAULT_TIMEZONE);
-
-// create dummy file
-if (!file_exists(APP_SETUP_FILE)) {
-    // create new config
-    Setup::save([
-        'database' => [
-            'hostname' => 'localhost',
-            'database' => 'eventum',
-            'username' => 'mysql',
-            'password' => '',
-            'port' => 3306,
-        ],
-
-        // used for tests
-        'admin_user' => 2,
-    ]);
-}
 
 if (!getenv('TRAVIS')) {
     // init these from setup file


### PR DESCRIPTION
- db: move `APP_CHARSET` to config
- remove most of the `APP_CONFIG_PATH`, `APP_SETUP_FILE` usages
- support for using eventum being itself in vendor (unit tests in projects requiring eventum in composer)