### PR TITLE
deprecate config loading from workflow class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ This version drops IRC Bot from Eventum Core, see #371
 - Drop IRC Bot from eventum core, available as eventum/irc-bot instead (@glensc, #371)
 - Fix parsing of link references in markdown (@glensc, #367)
 - Add Factory support for Extension to construct it's own classes (@glensc, #375)
+- Deprecate config loading from workflow class (@glensc, #378)
 
 [3.5.0]: https://github.com/eventum/eventum/compare/v3.4.2...master
 

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -54,6 +54,7 @@ abstract class Abstract_Workflow_Backend
      *
      * @param string $option
      * @return mixed
+     * @deprecated since 3.5.0, implement such loading on your own
      */
     public function getConfig($option = null)
     {
@@ -68,6 +69,7 @@ abstract class Abstract_Workflow_Backend
      * loadConfig()
      * merges the workflow's default settings with any local settings
      * this function is automatically called through getConfig()
+     * @deprecated since 3.5.0, implement such loading on your own
      */
     private function loadConfig()
     {
@@ -99,6 +101,7 @@ abstract class Abstract_Workflow_Backend
     /**
      * If you made changes to config, you may call this to persist the changes
      * back to disk
+     * @deprecated since 3.5.0, implement such loading on your own
      */
     protected function saveConfig()
     {
@@ -111,6 +114,7 @@ abstract class Abstract_Workflow_Backend
 
     /**
      * You should override this in your workflow class
+     * @deprecated since 3.5.0, implement such loading on your own
      */
     protected function getConfigDefaults()
     {


### PR DESCRIPTION
the config loading into workflow class was too tightly coupled. if someone needs such logic, they should copy to their own workflow class.

besides, i believe i am the only one who used this feature.

cc @balsdorf 