### PR TITLE
Fix for reports date picker

### DIFF
--- a/src/Controller/Report/ReportBaseController.php
+++ b/src/Controller/Report/ReportBaseController.php
@@ -54,8 +54,8 @@ abstract class ReportBaseController extends BaseController
         $request = $this->getRequest();
 
         return
-            $request->get("{$field}[Year]", null, true)
-            && $request->get("{$field}[Month]", null, true)
-            && $request->get("{$field}[Day]", null, true);
+            $request->get($field)['Year']
+            && $request->get($field)['Month']
+            && $request->get($field)['Day'];
     }
 }


### PR DESCRIPTION
Little fix for the report date picker to get the correct request vars from the form.
This specifically fixes /reports/workload_date_range.php and /reports/weekly.php which were not getting the start and end dates from the date picker.