### PR TITLE
storage adapter: add verify option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
+- Storage adapter: add verify option (@glensc, #384)
+
 [3.5.2]: https://github.com/eventum/eventum/compare/v3.5.1...master
 
 ## [3.5.1] - 2018-06-09


### PR DESCRIPTION
i got disk full error while migrating. with previous testing it (migration) was rather unreliable (not atomic commit).

so wanted to know which attachments got broken state.

```
root@eventum ~/eventum# ./contrib/migrate_storage_adapter.php local --verify
Verifying data in 'local://' Adapter
Preparing temporary table. Please wait...
Verifying 5302 file(s)

```