### PR TITLE
Update phinx to 0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.6.x versions requires that you upgrade to 3.2.0 version first.
 
+- Update Phinx to 0.10 (@glensc, #388)
+
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 
 ## [3.5.6] - 2019-01-03

--- a/composer.json
+++ b/composer.json
@@ -89,7 +89,7 @@
 		"php-gettext/php-gettext": "1.0.*",
 		"phplot/phplot": "~6.1.0",
 		"phpxmlrpc/phpxmlrpc": "^4.1",
-		"robmorgan/phinx": "^0.9.2",
+		"robmorgan/phinx": "^0.10.6",
 		"smarty-gettext/smarty-gettext": "~1.0",
 		"smarty/smarty": "~3.1.12",
 		"sphinx/php-sphinxapi": "2.0.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,299 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "167d0c88ada439d91a66a21d253552b4",
+    "content-hash": "93cec5983cbe97e3b91a5659ba816005",
     "packages": [
+        {
+            "name": "cakephp/cache",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/cache.git",
+                "reference": "46fc6789956a086d728b5c35af13c912b62cf543"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/cache/zipball/46fc6789956a086d728b5c35af13c912b62cf543",
+                "reference": "46fc6789956a086d728b5c35af13c912b62cf543",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^3.6.0",
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Cache\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/cache/graphs/contributors"
+                }
+            ],
+            "description": "Easy to use Caching library with support for multiple caching backends",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cache",
+                "caching",
+                "cakephp"
+            ],
+            "time": "2018-12-09T01:18:53+00:00"
+        },
+        {
+            "name": "cakephp/collection",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/collection.git",
+                "reference": "5e28b596c85d163f8c8350c213c34b6102b641ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/collection/zipball/5e28b596c85d163f8c8350c213c34b6102b641ec",
+                "reference": "5e28b596c85d163f8c8350c213c34b6102b641ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Collection\\": "."
+                },
+                "files": [
+                    "functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/collection/graphs/contributors"
+                }
+            ],
+            "description": "Work easily with arrays and iterators by having a battery of utility traversal methods",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "arrays",
+                "cakephp",
+                "collections",
+                "iterators"
+            ],
+            "time": "2018-12-14T09:39:58+00:00"
+        },
+        {
+            "name": "cakephp/core",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/core.git",
+                "reference": "02b4d6579246d7011e5062058c50c041ab542fa9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/02b4d6579246d7011e5062058c50c041ab542fa9",
+                "reference": "02b4d6579246d7011e5062058c50c041ab542fa9",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/utility": "^3.6.0",
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "cakephp/event": "To use PluginApplicationInterface or plugin applications."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Core\\": "."
+                },
+                "files": [
+                    "functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/core/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Framework Core classes",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "core",
+                "framework"
+            ],
+            "time": "2018-12-13T23:20:56+00:00"
+        },
+        {
+            "name": "cakephp/database",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/database.git",
+                "reference": "b5649125528f9230d81c7b870edecfbe19ecac21"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/b5649125528f9230d81c7b870edecfbe19ecac21",
+                "reference": "b5649125528f9230d81c7b870edecfbe19ecac21",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/cache": "^3.6.0",
+                "cakephp/core": "^3.6.0",
+                "cakephp/datasource": "^3.6.0",
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "cakephp/log": "Require this if you want to use the built-in query logger"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Database\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/database/graphs/contributors"
+                }
+            ],
+            "description": "Flexible and powerful Database abstraction library with a familiar PDO-like API",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "abstraction",
+                "cakephp",
+                "database",
+                "database abstraction",
+                "pdo"
+            ],
+            "time": "2018-12-14T12:11:25+00:00"
+        },
+        {
+            "name": "cakephp/datasource",
+            "version": "3.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/datasource.git",
+                "reference": "d98a1675da0b62da834f86c976b2337db38adb49"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/d98a1675da0b62da834f86c976b2337db38adb49",
+                "reference": "d98a1675da0b62da834f86c976b2337db38adb49",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^3.6.0",
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "cakephp/cache": "If you decide to use Query caching.",
+                "cakephp/collection": "If you decide to use ResultSetInterface.",
+                "cakephp/utility": "If you decide to use EntityTrait."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Datasource\\": "."
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/datasource/graphs/contributors"
+                }
+            ],
+            "description": "Provides connection managing and traits for Entities and Queries that can be reused for different datastores",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "connection management",
+                "datasource",
+                "entity",
+                "query"
+            ],
+            "time": "2018-12-13T23:20:56+00:00"
+        },
+        {
+            "name": "cakephp/utility",
+            "version": "3.7.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/cakephp/utility.git",
+                "reference": "1a4d271d9a3ad6e0096eabf5778342c8b5f81978"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/1a4d271d9a3ad6e0096eabf5778342c8b5f81978",
+                "reference": "1a4d271d9a3ad6e0096eabf5778342c8b5f81978",
+                "shasum": ""
+            },
+            "require": {
+                "cakephp/core": "^3.6.0",
+                "php": ">=5.6.0"
+            },
+            "suggest": {
+                "ext-intl": "To use Text::transliterate() or Text::slug()",
+                "lib-ICU": "To use Text::transliterate() or Text::slug()"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Cake\\Utility\\": "."
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "CakePHP Community",
+                    "homepage": "https://github.com/cakephp/utility/graphs/contributors"
+                }
+            ],
+            "description": "CakePHP Utility classes such as Inflector, String, Hash, and Security",
+            "homepage": "https://cakephp.org",
+            "keywords": [
+                "cakephp",
+                "hash",
+                "inflector",
+                "security",
+                "string",
+                "utility"
+            ],
+            "time": "2018-09-14T01:26:50+00:00"
+        },
         {
             "name": "cebe/markdown",
             "version": "1.2.1",
@@ -1977,27 +2268,30 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "0.9.2",
+            "version": "0.10.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "e1698319ad55157c233b658c08f7a10617e797ca"
+                "reference": "f28a1c6ab1fa1f0295cddade9aea05eeb303bd2b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/e1698319ad55157c233b658c08f7a10617e797ca",
-                "reference": "e1698319ad55157c233b658c08f7a10617e797ca",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/f28a1c6ab1fa1f0295cddade9aea05eeb303bd2b",
+                "reference": "f28a1c6ab1fa1f0295cddade9aea05eeb303bd2b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4",
+                "cakephp/collection": "^3.6",
+                "cakephp/database": "^3.6",
+                "php": ">=5.6",
                 "symfony/config": "^2.8|^3.0|^4.0",
                 "symfony/console": "^2.8|^3.0|^4.0",
                 "symfony/yaml": "^2.8|^3.0|^4.0"
             },
             "require-dev": {
                 "cakephp/cakephp-codesniffer": "^3.0",
-                "phpunit/phpunit": "^4.8.35|^5.7|^6.5"
+                "phpunit/phpunit": ">=5.7",
+                "sebastian/comparator": ">=1.2.3"
             },
             "bin": [
                 "bin/phinx"
@@ -2005,7 +2299,7 @@
             "type": "library",
             "autoload": {
                 "psr-4": {
-                    "Phinx\\": "src/Phinx"
+                    "Phinx\\": "src/Phinx/"
                 }
             },
             "notification-url": "https://packagist.org/downloads/",
@@ -2044,7 +2338,7 @@
                 "migrations",
                 "phinx"
             ],
-            "time": "2017-12-23T06:48:51+00:00"
+            "time": "2018-08-12T17:22:43+00:00"
         },
         {
             "name": "smarty-gettext/smarty-gettext",

--- a/db/migrations/20170427170945_eventum_init_database.php
+++ b/db/migrations/20170427170945_eventum_init_database.php
@@ -17,16 +17,15 @@ class EventumInitDatabase extends AbstractMigration
 {
     public function change()
     {
-        $table = $this->table('api_token', ['id' => false, 'primary_key' => 'apt_id'])
-            ->addColumn('apt_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('api_token', ['id' => false, 'primary_key' => 'apt_id'])
+            ->addColumn('apt_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('apt_usr_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('apt_created', 'datetime')
             ->addColumn('apt_status', 'string', ['length' => 10, 'default' => 'active'])
             ->addColumn('apt_token', 'string', ['length' => 32])
             ->addIndex(['apt_usr_id', 'apt_status'])
-            ->addIndex(['apt_token']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['apt_token'])
+            ->create();
 
         $this->table('columns_to_display', ['id' => false, 'primary_key' => ['ctd_prj_id', 'ctd_page', 'ctd_field']])
             ->addColumn('ctd_prj_id', 'integer', ['signed' => false])
@@ -35,10 +34,10 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('ctd_min_role', 'boolean', ['default' => 0])
             ->addColumn('ctd_rank', 'integer', ['length' => self::INT_TINY, 'default' => 0])
             ->addIndex(['ctd_prj_id', 'ctd_page'])
-        ->create();
+            ->create();
 
-        $table = $this->table('commit', ['id' => false, 'primary_key' => 'com_id'])
-            ->addColumn('com_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('commit', ['id' => false, 'primary_key' => 'com_id'])
+            ->addColumn('com_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('com_scm_name', 'string', ['default' => 'default'])
             ->addColumn('com_project_name', 'string', ['null' => true])
             ->addColumn('com_changeset', 'string', ['length' => 40])
@@ -47,24 +46,22 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('com_author_name', 'string', ['null' => true])
             ->addColumn('com_usr_id', 'integer', ['null' => true])
             ->addColumn('com_commit_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
-            ->addColumn('com_message', 'text', ['length' => self::INT_MEDIUM, 'null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('com_message', 'text', ['length' => self::INT_MEDIUM, 'null' => true])
+            ->create();
 
-        $table = $this->table('commit_file', ['id' => false, 'primary_key' => 'cof_id'])
-            ->addColumn('cof_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('commit_file', ['id' => false, 'primary_key' => 'cof_id'])
+            ->addColumn('cof_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('cof_com_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('cof_filename', 'string', ['default' => ''])
             ->addColumn('cof_added', 'boolean', ['default' => 0])
             ->addColumn('cof_modified', 'boolean', ['default' => 0])
             ->addColumn('cof_removed', 'boolean', ['default' => 0])
             ->addColumn('cof_old_version', 'string', ['length' => 40, 'null' => true])
-            ->addColumn('cof_new_version', 'string', ['length' => 40, 'null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('cof_new_version', 'string', ['length' => 40, 'null' => true])
+            ->create();
 
-        $table = $this->table('custom_field', ['id' => false, 'primary_key' => 'fld_id'])
-            ->addColumn('fld_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('custom_field', ['id' => false, 'primary_key' => 'fld_id'])
+            ->addColumn('fld_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('fld_title', 'string', ['length' => 32, 'default' => ''])
             ->addColumn('fld_description', 'string', ['length' => 64, 'null' => true])
             ->addColumn('fld_type', 'string', ['length' => 8, 'default' => 'text'])
@@ -80,21 +77,19 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('fld_min_role_edit', 'boolean', ['default' => 0])
             ->addColumn('fld_rank', 'integer', ['length' => self::INT_SMALL, 'default' => 0])
             ->addColumn('fld_backend', 'string', ['length' => 100, 'null' => true])
-            ->addColumn('fld_order_by', 'string', ['length' => 20, 'default' => 'cfo_id ASC']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('fld_order_by', 'string', ['length' => 20, 'default' => 'cfo_id ASC'])
+            ->create();
 
-        $table = $this->table('custom_field_option', ['id' => false, 'primary_key' => 'cfo_id'])
-            ->addColumn('cfo_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('custom_field_option', ['id' => false, 'primary_key' => 'cfo_id'])
+            ->addColumn('cfo_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('cfo_fld_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('cfo_rank', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('cfo_value', 'string', ['length' => 128, 'default' => ''])
-            ->addIndex(['cfo_fld_id'], ['name' => 'icf_fld_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['cfo_fld_id'], ['name' => 'icf_fld_id'])
+            ->create();
 
-        $table = $this->table('custom_filter', ['id' => false, 'primary_key' => 'cst_id'])
-            ->addColumn('cst_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('custom_filter', ['id' => false, 'primary_key' => 'cst_id'])
+            ->addColumn('cst_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('cst_usr_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('cst_prj_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('cst_title', 'string', ['length' => 64, 'default' => ''])
@@ -136,34 +131,31 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('cst_is_global', 'integer', ['length' => 1, 'default' => 0, 'null' => true])
             ->addColumn('cst_search_type', 'string', ['length' => 15, 'default' => 'customer'])
             ->addColumn('cst_custom_field', 'text', ['null' => true])
-            ->addIndex(['cst_usr_id', 'cst_prj_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['cst_usr_id', 'cst_prj_id'])
+            ->create();
 
-        $table = $this->table('customer_account_manager', ['id' => false, 'primary_key' => 'cam_id'])
-            ->addColumn('cam_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('customer_account_manager', ['id' => false, 'primary_key' => 'cam_id'])
+            ->addColumn('cam_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('cam_prj_id', 'integer', ['signed' => false])
             ->addColumn('cam_customer_id', 'string', ['length' => 128])
             ->addColumn('cam_usr_id', 'integer', ['signed' => false])
             ->addColumn('cam_type', 'string', ['length' => 7])
             ->addIndex(['cam_prj_id', 'cam_customer_id', 'cam_usr_id'], ['name' => 'cam_manager', 'unique' => true])
-            ->addIndex(['cam_customer_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['cam_customer_id'])
+            ->create();
 
-        $table = $this->table('customer_note', ['id' => false, 'primary_key' => 'cno_id'])
-            ->addColumn('cno_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('customer_note', ['id' => false, 'primary_key' => 'cno_id'])
+            ->addColumn('cno_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('cno_prj_id', 'integer', ['signed' => false])
             ->addColumn('cno_customer_id', 'string', ['length' => 128])
             ->addColumn('cno_created_date', 'datetime')
             ->addColumn('cno_updated_date', 'datetime', ['null' => true])
             ->addColumn('cno_note', 'text', ['null' => true])
-            ->addIndex(['cno_prj_id', 'cno_customer_id'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['cno_prj_id', 'cno_customer_id'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('email_account', ['id' => false, 'primary_key' => 'ema_id'])
-            ->addColumn('ema_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('email_account', ['id' => false, 'primary_key' => 'ema_id'])
+            ->addColumn('ema_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('ema_prj_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('ema_type', 'string', ['length' => 32, 'default' => ''])
             ->addColumn('ema_folder', 'string', ['null' => true, 'encoding' => 'latin1'])
@@ -177,41 +169,37 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('ema_issue_auto_creation_options', 'text', ['null' => true])
             ->addColumn('ema_use_routing', 'boolean', ['default' => 0, 'null' => true])
             ->addIndex(['ema_username', 'ema_hostname', 'ema_folder'], ['unique' => true])
-            ->addIndex(['ema_prj_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ema_prj_id'])
+            ->create();
 
-        $table = $this->table('email_draft', ['id' => false, 'primary_key' => 'emd_id'])
-            ->addColumn('emd_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('email_draft', ['id' => false, 'primary_key' => 'emd_id'])
+            ->addColumn('emd_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('emd_usr_id', 'integer', ['signed' => false])
             ->addColumn('emd_iss_id', 'integer', ['signed' => false])
             ->addColumn('emd_sup_id', 'integer', ['null' => true, 'signed' => false])
-            ->addColumn('emd_status', 'enum', ['default' => 'pending', 'values' => [0 => 'pending',  1 => 'edited',  2 => 'sent']])
+            ->addColumn('emd_status', 'enum', ['default' => 'pending', 'values' => [0 => 'pending', 1 => 'edited', 2 => 'sent']])
             ->addColumn('emd_updated_date', 'datetime')
             ->addColumn('emd_subject', 'string')
             ->addColumn('emd_body', 'text', ['length' => self::INT_REGULAR])
-            ->addColumn('emd_unknown_user', 'string', ['null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('emd_unknown_user', 'string', ['null' => true])
+            ->create();
 
-        $table = $this->table('email_draft_recipient', ['id' => false, 'primary_key' => 'edr_id'])
-            ->addColumn('edr_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('email_draft_recipient', ['id' => false, 'primary_key' => 'edr_id'])
+            ->addColumn('edr_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('edr_emd_id', 'integer', ['signed' => false])
             ->addColumn('edr_is_cc', 'boolean', ['default' => 0, 'signed' => false])
-            ->addColumn('edr_email', 'string');
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('edr_email', 'string')
+            ->create();
 
-        $table = $this->table('email_response', ['id' => false, 'primary_key' => 'ere_id'])
-            ->addColumn('ere_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('email_response', ['id' => false, 'primary_key' => 'ere_id'])
+            ->addColumn('ere_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('ere_title', 'string', ['length' => 64])
             ->addColumn('ere_response_body', 'text')
-            ->addIndex(['ere_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ere_title'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('faq', ['id' => false, 'primary_key' => 'faq_id'])
-            ->addColumn('faq_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('faq', ['id' => false, 'primary_key' => 'faq_id'])
+            ->addColumn('faq_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('faq_prj_id', 'integer', ['signed' => false])
             ->addColumn('faq_usr_id', 'integer', ['signed' => false])
             ->addColumn('faq_created_date', 'datetime')
@@ -219,46 +207,42 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('faq_title', 'string', ['encoding' => 'utf8'])
             ->addColumn('faq_message', 'text', ['length' => self::INT_REGULAR])
             ->addColumn('faq_rank', 'integer', ['length' => self::INT_TINY, 'signed' => false])
-            ->addIndex(['faq_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['faq_title'], ['unique' => true])
+            ->create();
 
         $this->table('faq_support_level', ['id' => false, 'primary_key' => ['fsl_faq_id', 'fsl_support_level_id']])
             ->addColumn('fsl_faq_id', 'integer', ['signed' => false])
             ->addColumn('fsl_support_level_id', 'string', ['length' => 50])
-        ->create();
+            ->create();
 
-        $table = $this->table('group', ['id' => false, 'primary_key' => 'grp_id'])
-            ->addColumn('grp_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('group', ['id' => false, 'primary_key' => 'grp_id'])
+            ->addColumn('grp_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('grp_name', 'string', ['length' => 100])
             ->addColumn('grp_description', 'string', ['null' => true])
             ->addColumn('grp_manager_usr_id', 'integer', ['signed' => false])
-            ->addIndex(['grp_name'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['grp_name'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('history_type', ['id' => false, 'primary_key' => 'htt_id'])
-            ->addColumn('htt_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
+        $this->table('history_type', ['id' => false, 'primary_key' => 'htt_id'])
+            ->addColumn('htt_id', 'integer', ['length' => self::INT_TINY, 'signed' => false, 'identity' => true])
             ->addColumn('htt_name', 'string', ['length' => 25])
             ->addColumn('htt_role', 'boolean', ['default' => 0, 'null' => true])
-            ->addIndex(['htt_name'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['htt_name'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('irc_notice', ['id' => false, 'primary_key' => 'ino_id'])
-            ->addColumn('ino_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('irc_notice', ['id' => false, 'primary_key' => 'ino_id'])
+            ->addColumn('ino_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('ino_prj_id', 'integer')
             ->addColumn('ino_iss_id', 'integer', ['signed' => false])
             ->addColumn('ino_created_date', 'datetime')
             ->addColumn('ino_message', 'string')
             ->addColumn('ino_status', 'string', ['length' => 8, 'default' => 'pending'])
             ->addColumn('ino_target_usr_id', 'integer', ['null' => true, 'signed' => false])
-            ->addColumn('ino_category', 'string', ['length' => 25, 'null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('ino_category', 'string', ['length' => 25, 'null' => true])
+            ->create();
 
-        $table = $this->table('issue', ['id' => false, 'primary_key' => 'iss_id'])
-            ->addColumn('iss_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('issue', ['id' => false, 'primary_key' => 'iss_id'])
+            ->addColumn('iss_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('iss_customer_id', 'string', ['length' => 128, 'null' => true])
             ->addColumn('iss_customer_contact_id', 'string', ['length' => 128, 'null' => true])
             ->addColumn('iss_customer_contract_id', 'string', ['length' => 50, 'null' => true])
@@ -301,21 +285,19 @@ class EventumInitDatabase extends AbstractMigration
             ->addIndex(['iss_res_id'])
             ->addIndex(['iss_grp_id'])
             ->addIndex(['iss_duplicated_iss_id'])
-            ->addIndex(['iss_summary', 'iss_description'], ['type' => 'fulltext', 'name' => 'ft_issue']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['iss_summary', 'iss_description'], ['type' => 'fulltext', 'name' => 'ft_issue'])
+            ->create();
 
-        $table = $this->table('issue_access_list', ['id' => false, 'primary_key' => 'ial_id'])
-            ->addColumn('ial_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_access_list', ['id' => false, 'primary_key' => 'ial_id'])
+            ->addColumn('ial_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('ial_iss_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('ial_usr_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('ial_created', 'datetime')
-            ->addIndex(['ial_iss_id', 'ial_usr_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ial_iss_id', 'ial_usr_id'])
+            ->create();
 
-        $table = $this->table('issue_access_log', ['id' => false, 'primary_key' => 'alg_id'])
-            ->addColumn('alg_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_access_log', ['id' => false, 'primary_key' => 'alg_id'])
+            ->addColumn('alg_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('alg_iss_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('alg_usr_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('alg_failed', 'boolean', ['default' => 0])
@@ -324,18 +306,17 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('alg_ip_address', 'string', ['length' => 15, 'null' => true])
             ->addColumn('alg_item', 'string', ['length' => 10, 'null' => true])
             ->addColumn('alg_url', 'string', ['null' => true])
-            ->addIndex(['alg_iss_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['alg_iss_id'])
+            ->create();
 
         $this->table('issue_association', ['id' => false])
             ->addColumn('isa_issue_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('isa_associated_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addIndex(['isa_issue_id', 'isa_associated_id'])
-        ->create();
+            ->create();
 
-        $table = $this->table('issue_attachment', ['id' => false, 'primary_key' => 'iat_id'])
-            ->addColumn('iat_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_attachment', ['id' => false, 'primary_key' => 'iat_id'])
+            ->addColumn('iat_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('iat_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('iat_usr_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('iat_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
@@ -343,24 +324,22 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('iat_unknown_user', 'string', ['null' => true])
             ->addColumn('iat_status', 'enum', ['default' => 'public', 'values' => [0 => 'internal', 1 => 'public']])
             ->addColumn('iat_not_id', 'integer', ['null' => true, 'signed' => false])
-            ->addIndex(['iat_iss_id', 'iat_usr_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['iat_iss_id', 'iat_usr_id'])
+            ->create();
 
-        $table = $this->table('issue_attachment_file', ['id' => false, 'primary_key' => 'iaf_id'])
-            ->addColumn('iaf_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_attachment_file', ['id' => false, 'primary_key' => 'iaf_id'])
+            ->addColumn('iaf_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('iaf_iat_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('iaf_file', self::PHINX_TYPE_BLOB, ['length' => self::BLOB_LONG, 'null' => true])
             ->addColumn('iaf_filename', 'string', ['default' => ''])
             ->addColumn('iaf_filetype', 'string', ['null' => true])
             ->addColumn('iaf_filesize', 'string', ['length' => 32, 'default' => ''])
             ->addColumn('iaf_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
-            ->addIndex(['iaf_iat_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['iaf_iat_id'])
+            ->create();
 
-        $table = $this->table('issue_checkin', ['id' => false, 'primary_key' => 'isc_id'])
-            ->addColumn('isc_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_checkin', ['id' => false, 'primary_key' => 'isc_id'])
+            ->addColumn('isc_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('isc_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('isc_commitid', 'string', ['length' => 40, 'null' => true, 'collation' => 'utf8_bin'])
             ->addColumn('isc_reponame', 'string', ['default' => ''])
@@ -372,19 +351,17 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('isc_username', 'string', ['length' => 32, 'default' => ''])
             ->addColumn('isc_commit_msg', 'text', ['null' => true])
             ->addIndex(['isc_iss_id'])
-            ->addIndex(['isc_commitid']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['isc_commitid'])
+            ->create();
 
-        $table = $this->table('issue_commit', ['id' => false, 'primary_key' => 'isc_id'])
-            ->addColumn('isc_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_commit', ['id' => false, 'primary_key' => 'isc_id'])
+            ->addColumn('isc_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('isc_iss_id', 'integer', ['length' => 10, 'signed' => false])
-            ->addColumn('isc_com_id', 'integer', ['length' => 10, 'signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('isc_com_id', 'integer', ['length' => 10, 'signed' => false])
+            ->create();
 
-        $table = $this->table('issue_custom_field', ['id' => false, 'primary_key' => 'icf_id'])
-            ->addColumn('icf_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_custom_field', ['id' => false, 'primary_key' => 'icf_id'])
+            ->addColumn('icf_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('icf_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('icf_fld_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('icf_value', 'text', ['null' => true])
@@ -392,12 +369,11 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('icf_value_date', 'date', ['null' => true])
             ->addIndex(['icf_iss_id'])
             ->addIndex(['icf_fld_id'])
-            ->addIndex(['icf_value'], ['type' => 'fulltext', 'name' => 'ft_icf_value']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['icf_value'], ['type' => 'fulltext', 'name' => 'ft_icf_value'])
+            ->create();
 
-        $table = $this->table('issue_history', ['id' => false, 'primary_key' => 'his_id'])
-            ->addColumn('his_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('issue_history', ['id' => false, 'primary_key' => 'his_id'])
+            ->addColumn('his_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('his_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('his_usr_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('his_htt_id', 'integer', ['length' => self::INT_TINY, 'default' => 0])
@@ -408,32 +384,29 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('his_min_role', 'boolean', ['default' => 1])
             ->addIndex(['his_id'])
             ->addIndex(['his_iss_id'])
-            ->addIndex(['his_created_date']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['his_created_date'])
+            ->create();
 
         $this->table('issue_partner', ['id' => false, 'primary_key' => ['ipa_iss_id', 'ipa_par_code']])
             ->addColumn('ipa_iss_id', 'integer', ['signed' => false])
             ->addColumn('ipa_par_code', 'string', ['length' => 30])
             ->addColumn('ipa_created_date', 'datetime')
-        ->create();
+            ->create();
 
-        $table = $this->table('issue_product_version', ['id' => false, 'primary_key' => 'ipv_id'])
-            ->addColumn('ipv_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('issue_product_version', ['id' => false, 'primary_key' => 'ipv_id'])
+            ->addColumn('ipv_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('ipv_iss_id', 'integer', ['signed' => false])
             ->addColumn('ipv_pro_id', 'integer', ['signed' => false])
             ->addColumn('ipv_version', 'string')
-            ->addIndex(['ipv_iss_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ipv_iss_id'])
+            ->create();
 
-        $table = $this->table('issue_quarantine', ['id' => false, 'primary_key' => 'iqu_iss_id'])
-            ->addColumn('iqu_iss_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('issue_quarantine', ['id' => false, 'primary_key' => 'iqu_iss_id'])
+            ->addColumn('iqu_iss_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('iqu_expiration', 'datetime', ['null' => true])
             ->addColumn('iqu_status', 'boolean', ['null' => true])
-            ->addIndex(['iqu_expiration']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['iqu_expiration'])
+            ->create();
 
         $this->table('issue_user', ['id' => false, 'primary_key' => ['isu_iss_id', 'isu_usr_id']])
             ->addColumn('isu_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
@@ -443,29 +416,27 @@ class EventumInitDatabase extends AbstractMigration
             ->addIndex(['isu_order'])
             ->addIndex(['isu_usr_id'])
             ->addIndex(['isu_iss_id'])
-        ->create();
+            ->create();
 
-        $table = $this->table('issue_user_replier', ['id' => false, 'primary_key' => 'iur_id'])
-            ->addColumn('iur_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('issue_user_replier', ['id' => false, 'primary_key' => 'iur_id'])
+            ->addColumn('iur_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('iur_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('iur_usr_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('iur_email', 'string', ['null' => true])
             ->addIndex(['iur_usr_id'])
-            ->addIndex(['iur_iss_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['iur_iss_id'])
+            ->create();
 
-        $table = $this->table('link_filter', ['id' => false, 'primary_key' => 'lfi_id'])
-            ->addColumn('lfi_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('link_filter', ['id' => false, 'primary_key' => 'lfi_id'])
+            ->addColumn('lfi_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('lfi_pattern', 'string')
             ->addColumn('lfi_replacement', 'string')
             ->addColumn('lfi_usr_role', 'integer', ['length' => self::INT_TINY, 'default' => 0])
-            ->addColumn('lfi_description', 'string', ['null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('lfi_description', 'string', ['null' => true])
+            ->create();
 
-        $table = $this->table('mail_queue', ['id' => false, 'primary_key' => 'maq_id'])
-            ->addColumn('maq_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('mail_queue', ['id' => false, 'primary_key' => 'maq_id'])
+            ->addColumn('maq_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('maq_iss_id', 'integer', ['null' => true, 'signed' => false])
             ->addColumn('maq_queued_date', 'datetime')
             ->addColumn('maq_status', 'string', ['length' => 8, 'default' => 'pending'])
@@ -481,33 +452,30 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('maq_type_id', 'integer', ['null' => true, 'signed' => false])
             ->addIndex(['maq_status'])
             ->addIndex(['maq_iss_id'])
-            ->addIndex(['maq_type', 'maq_type_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['maq_type', 'maq_type_id'])
+            ->create();
 
-        $table = $this->table('mail_queue_log', ['id' => false, 'primary_key' => 'mql_id'])
-            ->addColumn('mql_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('mail_queue_log', ['id' => false, 'primary_key' => 'mql_id'])
+            ->addColumn('mql_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('mql_maq_id', 'integer', ['signed' => false])
             ->addColumn('mql_created_date', 'datetime')
             ->addColumn('mql_status', 'string', ['length' => 8, 'default' => 'error'])
             ->addColumn('mql_server_message', 'text', ['null' => true])
-            ->addIndex(['mql_maq_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['mql_maq_id'])
+            ->create();
 
-        $table = $this->table('news', ['id' => false, 'primary_key' => 'nws_id'])
-            ->addColumn('nws_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('news', ['id' => false, 'primary_key' => 'nws_id'])
+            ->addColumn('nws_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('nws_usr_id', 'integer', ['signed' => false])
             ->addColumn('nws_created_date', 'datetime')
             ->addColumn('nws_title', 'string', ['encoding' => 'utf8'])
             ->addColumn('nws_message', 'text')
             ->addColumn('nws_status', 'string', ['length' => 8, 'default' => 'active'])
-            ->addIndex(['nws_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['nws_title'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('note', ['id' => false, 'primary_key' => 'not_id'])
-            ->addColumn('not_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('note', ['id' => false, 'primary_key' => 'not_id'])
+            ->addColumn('not_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('not_iss_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('not_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
             ->addColumn('not_usr_id', 'integer', ['default' => 0, 'signed' => false])
@@ -523,17 +491,16 @@ class EventumInitDatabase extends AbstractMigration
             ->addIndex(['not_iss_id', 'not_usr_id'], ['name' => 'not_bug_id'])
             ->addIndex(['not_message_id'])
             ->addIndex(['not_parent_id'])
-            ->addIndex(['not_title', 'not_note'], ['type' => 'fulltext', 'name' => 'ft_note']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['not_title', 'not_note'], ['type' => 'fulltext', 'name' => 'ft_note'])
+            ->create();
 
         $this->table('partner_project', ['id' => false, 'primary_key' => ['pap_prj_id', 'pap_par_code']])
             ->addColumn('pap_prj_id', 'integer', ['signed' => false])
             ->addColumn('pap_par_code', 'string', ['length' => 30])
-        ->create();
+            ->create();
 
-        $table = $this->table('phone_support', ['id' => false, 'primary_key' => 'phs_id'])
-            ->addColumn('phs_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('phone_support', ['id' => false, 'primary_key' => 'phs_id'])
+            ->addColumn('phs_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('phs_usr_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('phs_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('phs_ttr_id', 'integer', ['length' => 10, 'null' => true, 'signed' => false])
@@ -549,23 +516,21 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('phs_description', 'text')
             ->addIndex(['phs_iss_id'])
             ->addIndex(['phs_usr_id'])
-            ->addIndex(['phs_description'], ['type' => 'fulltext', 'name' => 'ft_phone_support']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['phs_description'], ['type' => 'fulltext', 'name' => 'ft_phone_support'])
+            ->create();
 
-        $table = $this->table('product', ['id' => false, 'primary_key' => 'pro_id'])
-            ->addColumn('pro_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('product', ['id' => false, 'primary_key' => 'pro_id'])
+            ->addColumn('pro_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('pro_title', 'string')
             ->addColumn('pro_version_howto', 'string')
             ->addColumn('pro_rank', 'integer', ['length' => self::INT_MEDIUM, 'default' => 0, 'signed' => false])
             ->addColumn('pro_removed', 'boolean', ['default' => 0, 'signed' => false])
             ->addColumn('pro_email', 'string', ['null' => true])
-            ->addIndex(['pro_rank']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['pro_rank'])
+            ->create();
 
-        $table = $this->table('project', ['id' => false, 'primary_key' => 'prj_id'])
-            ->addColumn('prj_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project', ['id' => false, 'primary_key' => 'prj_id'])
+            ->addColumn('prj_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('prj_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
             ->addColumn('prj_title', 'string', ['length' => 64, 'default' => ''])
             ->addColumn('prj_status', 'set', ['default' => 'active', 'values' => ['active', 'archived']])
@@ -583,132 +548,121 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('prj_workflow_backend', 'string', ['length' => 64, 'null' => true])
             ->addColumn('prj_segregate_reporter', 'boolean', ['default' => 0, 'null' => true])
             ->addIndex(['prj_title'], ['unique' => true])
-            ->addIndex(['prj_lead_usr_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['prj_lead_usr_id'])
+            ->create();
 
-        $table = $this->table('project_category', ['id' => false, 'primary_key' => 'prc_id'])
-            ->addColumn('prc_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project_category', ['id' => false, 'primary_key' => 'prc_id'])
+            ->addColumn('prc_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('prc_prj_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('prc_title', 'string', ['length' => 64, 'default' => ''])
             ->addIndex(['prc_prj_id', 'prc_title'], ['unique' => true, 'name' => 'uniq_category'])
-            ->addIndex(['prc_prj_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['prc_prj_id'])
+            ->create();
 
-        $table = $this->table('project_custom_field', ['id' => false, 'primary_key' => 'pcf_id'])
-            ->addColumn('pcf_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('project_custom_field', ['id' => false, 'primary_key' => 'pcf_id'])
+            ->addColumn('pcf_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('pcf_prj_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('pcf_fld_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addIndex(['pcf_prj_id'])
-            ->addIndex(['pcf_fld_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['pcf_fld_id'])
+            ->create();
 
         $this->table('project_email_response', ['id' => false, 'primary_key' => ['per_prj_id', 'per_ere_id']])
             ->addColumn('per_prj_id', 'integer', ['signed' => false])
             ->addColumn('per_ere_id', 'integer', ['length' => 10, 'signed' => false])
-        ->create();
+            ->create();
 
         $this->table('project_field_display', ['id' => false, 'primary_key' => ['pfd_prj_id', 'pfd_field']])
             ->addColumn('pfd_prj_id', 'integer', ['signed' => false])
             ->addColumn('pfd_field', 'string', ['length' => 20])
             ->addColumn('pfd_min_role', 'boolean', ['default' => 0])
             ->addColumn('pfd_required', 'boolean', ['default' => 0])
-        ->create();
+            ->create();
 
         $this->table('project_group', ['id' => false, 'primary_key' => ['pgr_prj_id', 'pgr_grp_id']])
             ->addColumn('pgr_prj_id', 'integer', ['signed' => false])
             ->addColumn('pgr_grp_id', 'integer', ['signed' => false])
-        ->create();
+            ->create();
 
         $this->table('project_link_filter', ['id' => false, 'primary_key' => ['plf_prj_id', 'plf_lfi_id']])
             ->addColumn('plf_prj_id', 'integer')
             ->addColumn('plf_lfi_id', 'integer')
-        ->create();
+            ->create();
 
         $this->table('project_news', ['id' => false, 'primary_key' => ['prn_prj_id', 'prn_nws_id']])
             ->addColumn('prn_nws_id', 'integer', ['signed' => false])
             ->addColumn('prn_prj_id', 'integer', ['signed' => false])
-        ->create();
+            ->create();
 
-        $table = $this->table('project_phone_category', ['id' => false, 'primary_key' => 'phc_id'])
-            ->addColumn('phc_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project_phone_category', ['id' => false, 'primary_key' => 'phc_id'])
+            ->addColumn('phc_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('phc_prj_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('phc_title', 'string', ['length' => 64, 'default' => ''])
             ->addIndex(['phc_prj_id', 'phc_title'], ['unique' => true, 'name' => 'uniq_category'])
-            ->addIndex(['phc_prj_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['phc_prj_id'])
+            ->create();
 
-        $table = $this->table('project_priority', ['id' => false, 'primary_key' => 'pri_id'])
-            ->addColumn('pri_id', 'integer', ['length' => self::INT_SMALL, 'signed' => false])
+        $this->table('project_priority', ['id' => false, 'primary_key' => 'pri_id'])
+            ->addColumn('pri_id', 'integer', ['length' => self::INT_SMALL, 'signed' => false, 'identity' => true])
             ->addColumn('pri_prj_id', 'integer', ['signed' => false])
             ->addColumn('pri_title', 'string', ['length' => 64, 'default' => ''])
             ->addColumn('pri_rank', 'boolean')
             ->addColumn('pri_icon', 'integer', ['length' => self::INT_TINY, 'default' => 0])
-            ->addIndex(['pri_title', 'pri_prj_id'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['pri_title', 'pri_prj_id'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('project_release', ['id' => false, 'primary_key' => 'pre_id'])
-            ->addColumn('pre_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('project_release', ['id' => false, 'primary_key' => 'pre_id'])
+            ->addColumn('pre_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('pre_prj_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('pre_title', 'string', ['length' => 128, 'default' => ''])
             ->addColumn('pre_scheduled_date', 'date', ['default' => '0000-00-00'])
-            ->addColumn('pre_status', 'enum', ['default' => 'available', 'values' => [0 => 'available',  1 => 'unavailable']])
-            ->addIndex(['pre_prj_id', 'pre_title'], ['unique' => true, 'name' => 'pre_title']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('pre_status', 'enum', ['default' => 'available', 'values' => [0 => 'available', 1 => 'unavailable']])
+            ->addIndex(['pre_prj_id', 'pre_title'], ['unique' => true, 'name' => 'pre_title'])
+            ->create();
 
-        $table = $this->table('project_round_robin', ['id' => false, 'primary_key' => 'prr_id'])
-            ->addColumn('prr_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project_round_robin', ['id' => false, 'primary_key' => 'prr_id'])
+            ->addColumn('prr_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('prr_prj_id', 'integer', ['signed' => false])
             ->addColumn('prr_blackout_start', 'time')
             ->addColumn('prr_blackout_end', 'time')
-            ->addIndex(['prr_prj_id'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['prr_prj_id'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('project_severity', ['id' => false, 'primary_key' => 'sev_id'])
-            ->addColumn('sev_id', 'integer', ['length' => self::INT_SMALL, 'signed' => false])
+        $this->table('project_severity', ['id' => false, 'primary_key' => 'sev_id'])
+            ->addColumn('sev_id', 'integer', ['length' => self::INT_SMALL, 'signed' => false, 'identity' => true])
             ->addColumn('sev_prj_id', 'integer', ['signed' => false])
             ->addColumn('sev_title', 'string', ['length' => 64, 'default' => ''])
             ->addColumn('sev_description', 'string', ['null' => true])
             ->addColumn('sev_rank', 'boolean')
-            ->addIndex(['sev_title', 'sev_prj_id'], ['unique' => true, 'name' => 'sev_title']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sev_title', 'sev_prj_id'], ['unique' => true, 'name' => 'sev_title'])
+            ->create();
 
-        $table = $this->table('project_status', ['id' => false, 'primary_key' => 'prs_id'])
-            ->addColumn('prs_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('project_status', ['id' => false, 'primary_key' => 'prs_id'])
+            ->addColumn('prs_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('prs_prj_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('prs_sta_id', 'integer', ['length' => 10, 'signed' => false])
-            ->addIndex(['prs_prj_id', 'prs_sta_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['prs_prj_id', 'prs_sta_id'])
+            ->create();
 
-        $table = $this->table('project_status_date', ['id' => false, 'primary_key' => 'psd_id'])
-            ->addColumn('psd_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project_status_date', ['id' => false, 'primary_key' => 'psd_id'])
+            ->addColumn('psd_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('psd_prj_id', 'integer', ['signed' => false])
             ->addColumn('psd_sta_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('psd_date_field', 'string', ['length' => 64])
             ->addColumn('psd_label', 'string', ['length' => 32])
-            ->addIndex(['psd_prj_id', 'psd_sta_id'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['psd_prj_id', 'psd_sta_id'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('project_user', ['id' => false, 'primary_key' => 'pru_id'])
-            ->addColumn('pru_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('project_user', ['id' => false, 'primary_key' => 'pru_id'])
+            ->addColumn('pru_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('pru_prj_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('pru_usr_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('pru_role', 'boolean', ['default' => 1, 'signed' => false])
-            ->addIndex(['pru_prj_id', 'pru_usr_id'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['pru_prj_id', 'pru_usr_id'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('reminder_action', ['id' => false, 'primary_key' => 'rma_id'])
-            ->addColumn('rma_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_action', ['id' => false, 'primary_key' => 'rma_id'])
+            ->addColumn('rma_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rma_rem_id', 'integer', ['signed' => false])
             ->addColumn('rma_rmt_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
             ->addColumn('rma_created_date', 'datetime')
@@ -717,137 +671,124 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('rma_rank', 'integer', ['length' => self::INT_TINY, 'signed' => false])
             ->addColumn('rma_alert_irc', 'boolean', ['default' => 0, 'signed' => false])
             ->addColumn('rma_alert_group_leader', 'boolean', ['default' => 0, 'signed' => false])
-            ->addColumn('rma_boilerplate', 'string', ['null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rma_boilerplate', 'string', ['null' => true])
+            ->create();
 
         $this->table('reminder_action_list', ['id' => false])
             ->addColumn('ral_rma_id', 'integer', ['signed' => false])
             ->addColumn('ral_email', 'string')
             ->addColumn('ral_usr_id', 'integer', ['signed' => false])
-        ->create();
+            ->create();
 
-        $table = $this->table('reminder_action_type', ['id' => false, 'primary_key' => 'rmt_id'])
-            ->addColumn('rmt_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
+        $this->table('reminder_action_type', ['id' => false, 'primary_key' => 'rmt_id'])
+            ->addColumn('rmt_id', 'integer', ['length' => self::INT_TINY, 'signed' => false, 'identity' => true])
             ->addColumn('rmt_type', 'string', ['length' => 32])
             ->addColumn('rmt_title', 'string', ['length' => 64])
             ->addIndex(['rmt_type'], ['unique' => true])
-            ->addIndex(['rmt_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['rmt_title'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('reminder_field', ['id' => false, 'primary_key' => 'rmf_id'])
-            ->addColumn('rmf_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
+        $this->table('reminder_field', ['id' => false, 'primary_key' => 'rmf_id'])
+            ->addColumn('rmf_id', 'integer', ['length' => self::INT_TINY, 'signed' => false, 'identity' => true])
             ->addColumn('rmf_title', 'string', ['length' => 128])
             ->addColumn('rmf_sql_field', 'string', ['length' => 32])
             ->addColumn('rmf_sql_representation', 'string')
             ->addColumn('rmf_allow_column_compare', 'boolean', ['default' => 0, 'null' => true])
-            ->addIndex(['rmf_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['rmf_title'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('reminder_history', ['id' => false, 'primary_key' => 'rmh_id'])
-            ->addColumn('rmh_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_history', ['id' => false, 'primary_key' => 'rmh_id'])
+            ->addColumn('rmh_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rmh_iss_id', 'integer')
             ->addColumn('rmh_rma_id', 'integer')
-            ->addColumn('rmh_created_date', 'datetime');
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rmh_created_date', 'datetime')
+            ->create();
 
-        $table = $this->table('reminder_level', ['id' => false, 'primary_key' => 'rem_id'])
-            ->addColumn('rem_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_level', ['id' => false, 'primary_key' => 'rem_id'])
+            ->addColumn('rem_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rem_created_date', 'datetime')
             ->addColumn('rem_rank', 'boolean')
             ->addColumn('rem_last_updated_date', 'datetime', ['null' => true])
             ->addColumn('rem_title', 'string', ['length' => 64])
             ->addColumn('rem_prj_id', 'integer', ['signed' => false])
-            ->addColumn('rem_skip_weekend', 'boolean', ['default' => 0]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rem_skip_weekend', 'boolean', ['default' => 0])
+            ->create();
 
-        $table = $this->table('reminder_level_condition', ['id' => false, 'primary_key' => 'rlc_id'])
-            ->addColumn('rlc_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_level_condition', ['id' => false, 'primary_key' => 'rlc_id'])
+            ->addColumn('rlc_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rlc_rma_id', 'integer', ['signed' => false])
             ->addColumn('rlc_rmf_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
             ->addColumn('rlc_rmo_id', 'boolean', ['signed' => false])
             ->addColumn('rlc_created_date', 'datetime')
             ->addColumn('rlc_last_updated_date', 'datetime', ['null' => true])
             ->addColumn('rlc_value', 'string', ['length' => 64])
-            ->addColumn('rlc_comparison_rmf_id', 'integer', ['length' => self::INT_TINY, 'null' => true, 'signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rlc_comparison_rmf_id', 'integer', ['length' => self::INT_TINY, 'null' => true, 'signed' => false])
+            ->create();
 
-        $table = $this->table('reminder_operator', ['id' => false, 'primary_key' => 'rmo_id'])
-            ->addColumn('rmo_id', 'integer', ['length' => self::INT_TINY, 'signed' => false])
+        $this->table('reminder_operator', ['id' => false, 'primary_key' => 'rmo_id'])
+            ->addColumn('rmo_id', 'integer', ['length' => self::INT_TINY, 'signed' => false, 'identity' => true])
             ->addColumn('rmo_title', 'string', ['length' => 32, 'null' => true])
             ->addColumn('rmo_sql_representation', 'string', ['length' => 32, 'null' => true])
-            ->addIndex(['rmo_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['rmo_title'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('reminder_priority', ['id' => false, 'primary_key' => 'rep_id'])
-            ->addColumn('rep_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_priority', ['id' => false, 'primary_key' => 'rep_id'])
+            ->addColumn('rep_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rep_rem_id', 'integer', ['signed' => false])
-            ->addColumn('rep_pri_id', 'integer', ['signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rep_pri_id', 'integer', ['signed' => false])
+            ->create();
 
-        $table = $this->table('reminder_product', ['id' => false, 'primary_key' => 'rpr_id'])
-            ->addColumn('rpr_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_product', ['id' => false, 'primary_key' => 'rpr_id'])
+            ->addColumn('rpr_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rpr_rem_id', 'integer', ['signed' => false])
-            ->addColumn('rpr_pro_id', 'integer', ['signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rpr_pro_id', 'integer', ['signed' => false])
+            ->create();
 
-        $table = $this->table('reminder_requirement', ['id' => false, 'primary_key' => 'rer_id'])
-            ->addColumn('rer_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_requirement', ['id' => false, 'primary_key' => 'rer_id'])
+            ->addColumn('rer_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rer_rem_id', 'integer', ['signed' => false])
             ->addColumn('rer_iss_id', 'integer', ['null' => true, 'signed' => false])
             ->addColumn('rer_support_level_id', 'integer', ['null' => true, 'signed' => false])
             ->addColumn('rer_customer_id', 'string', ['length' => 128, 'null' => true])
-            ->addColumn('rer_trigger_all_issues', 'boolean', ['default' => 0, 'signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rer_trigger_all_issues', 'boolean', ['default' => 0, 'signed' => false])
+            ->create();
 
-        $table = $this->table('reminder_severity', ['id' => false, 'primary_key' => 'rms_id'])
-            ->addColumn('rms_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('reminder_severity', ['id' => false, 'primary_key' => 'rms_id'])
+            ->addColumn('rms_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('rms_rem_id', 'integer', ['signed' => false])
-            ->addColumn('rms_sev_id', 'integer', ['signed' => false]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('rms_sev_id', 'integer', ['signed' => false])
+            ->create();
 
         $this->table('reminder_triggered_action', ['id' => false, 'primary_key' => ['rta_iss_id']])
             ->addColumn('rta_iss_id', 'integer', ['signed' => false])
             ->addColumn('rta_rma_id', 'integer', ['signed' => false])
-        ->create();
+            ->create();
 
-        $table = $this->table('resolution', ['id' => false, 'primary_key' => 'res_id'])
-            ->addColumn('res_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('resolution', ['id' => false, 'primary_key' => 'res_id'])
+            ->addColumn('res_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('res_title', 'string', ['length' => 64, 'default' => ''])
             ->addColumn('res_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
             ->addColumn('res_rank', 'integer', ['length' => 2])
-            ->addIndex(['res_title'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['res_title'], ['unique' => true])
+            ->create();
 
         $this->table('round_robin_user', ['id' => false])
             ->addColumn('rru_prr_id', 'integer', ['signed' => false])
             ->addColumn('rru_usr_id', 'integer', ['signed' => false])
             ->addColumn('rru_next', 'boolean', ['null' => true, 'signed' => false])
-        ->create();
+            ->create();
 
-        $table = $this->table('search_profile', ['id' => false, 'primary_key' => 'sep_id'])
-            ->addColumn('sep_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('search_profile', ['id' => false, 'primary_key' => 'sep_id'])
+            ->addColumn('sep_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('sep_usr_id', 'integer', ['signed' => false])
             ->addColumn('sep_prj_id', 'integer', ['signed' => false])
             ->addColumn('sep_type', 'char', ['length' => 5])
             ->addColumn('sep_user_profile', self::PHINX_TYPE_BLOB)
-            ->addIndex(['sep_usr_id', 'sep_prj_id', 'sep_type'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sep_usr_id', 'sep_prj_id', 'sep_type'], ['unique' => true])
+            ->create();
 
-        $table = $this->table('status', ['id' => false, 'primary_key' => 'sta_id'])
-            ->addColumn('sta_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('status', ['id' => false, 'primary_key' => 'sta_id'])
+            ->addColumn('sta_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('sta_title', 'string', ['length' => 64, 'default' => ''])
             ->addColumn('sta_abbreviation', 'char', ['length' => 3])
             ->addColumn('sta_rank', 'integer', ['length' => 2])
@@ -855,31 +796,28 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('sta_is_closed', 'boolean', ['default' => 0])
             ->addIndex(['sta_abbreviation'], ['unique' => true])
             ->addIndex(['sta_rank'])
-            ->addIndex(['sta_is_closed']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sta_is_closed'])
+            ->create();
 
-        $table = $this->table('subscription', ['id' => false, 'primary_key' => 'sub_id'])
-            ->addColumn('sub_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('subscription', ['id' => false, 'primary_key' => 'sub_id'])
+            ->addColumn('sub_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('sub_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('sub_usr_id', 'integer', ['length' => 10, 'null' => true, 'signed' => false])
             ->addColumn('sub_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
             ->addColumn('sub_level', 'string', ['length' => 10, 'default' => 'user'])
             ->addColumn('sub_email', 'string', ['null' => true])
-            ->addIndex(['sub_iss_id', 'sub_usr_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sub_iss_id', 'sub_usr_id'])
+            ->create();
 
-        $table = $this->table('subscription_type', ['id' => false, 'primary_key' => 'sbt_id'])
-            ->addColumn('sbt_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('subscription_type', ['id' => false, 'primary_key' => 'sbt_id'])
+            ->addColumn('sbt_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('sbt_sub_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('sbt_type', 'string', ['length' => 10, 'default' => ''])
-            ->addIndex(['sbt_sub_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sbt_sub_id'])
+            ->create();
 
-        $table = $this->table('support_email', ['id' => false, 'primary_key' => 'sup_id'])
-            ->addColumn('sup_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('support_email', ['id' => false, 'primary_key' => 'sup_id'])
+            ->addColumn('sup_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('sup_ema_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('sup_parent_id', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('sup_iss_id', 'integer', ['default' => 0, 'null' => true, 'signed' => false])
@@ -898,19 +836,18 @@ class EventumInitDatabase extends AbstractMigration
             ->addIndex(['sup_removed'])
             ->addIndex(['sup_removed', 'sup_ema_id', 'sup_iss_id'])
             ->addIndex(['sup_removed', 'sup_ema_id', 'sup_date'])
-            ->addIndex(['sup_usr_id']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['sup_usr_id'])
+            ->create();
 
         $this->table('support_email_body', ['id' => false, 'primary_key' => ['seb_sup_id']])
             ->addColumn('seb_sup_id', 'integer', ['signed' => false])
             ->addColumn('seb_body', 'text', ['length' => self::INT_REGULAR])
             ->addColumn('seb_full_email', self::PHINX_TYPE_BLOB, ['length' => self::BLOB_LONG])
             ->addIndex(['seb_body'], ['type' => 'fulltext', 'name' => 'ft_support_email'])
-        ->create();
+            ->create();
 
-        $table = $this->table('time_tracking', ['id' => false, 'primary_key' => 'ttr_id'])
-            ->addColumn('ttr_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('time_tracking', ['id' => false, 'primary_key' => 'ttr_id'])
+            ->addColumn('ttr_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('ttr_ttc_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('ttr_iss_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('ttr_usr_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
@@ -919,21 +856,19 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('ttr_summary', 'string', ['default' => ''])
             ->addIndex(['ttr_ttc_id', 'ttr_iss_id', 'ttr_usr_id'])
             ->addIndex(['ttr_iss_id'])
-            ->addIndex(['ttr_summary'], ['type' => 'fulltext', 'name' => 'ft_time_tracking']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ttr_summary'], ['type' => 'fulltext', 'name' => 'ft_time_tracking'])
+            ->create();
 
-        $table = $this->table('time_tracking_category', ['id' => false, 'primary_key' => 'ttc_id'])
-            ->addColumn('ttc_id', 'integer', ['length' => 10, 'signed' => false])
+        $this->table('time_tracking_category', ['id' => false, 'primary_key' => 'ttc_id'])
+            ->addColumn('ttc_id', 'integer', ['length' => 10, 'signed' => false, 'identity' => true])
             ->addColumn('ttc_prj_id', 'integer', ['length' => 10, 'default' => 0, 'signed' => false])
             ->addColumn('ttc_title', 'string', ['length' => 128, 'default' => ''])
             ->addColumn('ttc_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
-            ->addIndex(['ttc_prj_id', 'ttc_title'], ['name' => 'ttc_title']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['ttc_prj_id', 'ttc_title'], ['name' => 'ttc_title'])
+            ->create();
 
-        $table = $this->table('user', ['id' => false, 'primary_key' => 'usr_id'])
-            ->addColumn('usr_id', 'integer', ['length' => 11, 'signed' => false])
+        $this->table('user', ['id' => false, 'primary_key' => 'usr_id'])
+            ->addColumn('usr_id', 'integer', ['length' => 11, 'signed' => false, 'identity' => true])
             ->addColumn('usr_customer_id', 'string', ['length' => 128, 'null' => true])
             ->addColumn('usr_customer_contact_id', 'string', ['length' => 128, 'null' => true])
             ->addColumn('usr_created_date', 'datetime', ['default' => '0000-00-00 00:00:00'])
@@ -949,22 +884,21 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('usr_last_failed_login', 'datetime', ['null' => true])
             ->addColumn('usr_failed_logins', 'integer', ['default' => 0, 'signed' => false])
             ->addColumn('usr_par_code', 'string', ['length' => 30, 'null' => true])
-            ->addIndex(['usr_email'], ['unique' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addIndex(['usr_email'], ['unique' => true])
+            ->create();
 
         $this->table('user_alias', ['id' => false])
             ->addColumn('ual_usr_id', 'integer', ['signed' => false])
             ->addColumn('ual_email', 'string', ['null' => true, 'encoding' => 'latin1'])
             ->addIndex(['ual_email'], ['unique' => true])
             ->addIndex(['ual_usr_id', 'ual_email'])
-        ->create();
+            ->create();
 
         $this->table('user_group', ['id' => false, 'primary_key' => ['ugr_usr_id', 'ugr_grp_id']])
             ->addColumn('ugr_usr_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('ugr_grp_id', 'integer', ['length' => 10, 'signed' => false])
             ->addColumn('ugr_created', 'datetime')
-        ->create();
+            ->create();
 
         $this->table('user_preference', ['id' => false, 'primary_key' => ['upr_usr_id']])
             ->addColumn('upr_usr_id', 'integer', ['signed' => false])
@@ -978,7 +912,7 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('upr_auto_close_popup_window', 'boolean', ['default' => 0, 'null' => true])
             ->addColumn('upr_relative_date', 'boolean', ['default' => 1, 'null' => true])
             ->addColumn('upr_collapsed_emails', 'boolean', ['default' => 1, 'null' => true])
-        ->create();
+            ->create();
 
         $this->table('user_project_preference', ['id' => false, 'primary_key' => ['upp_usr_id', 'upp_prj_id']])
             ->addColumn('upp_usr_id', 'integer', ['signed' => false])
@@ -986,6 +920,6 @@ class EventumInitDatabase extends AbstractMigration
             ->addColumn('upp_receive_assigned_email', 'boolean', ['default' => 1, 'null' => true])
             ->addColumn('upp_receive_new_issue_email', 'boolean', ['default' => 0, 'null' => true])
             ->addColumn('upp_receive_copy_of_own_action', 'boolean', ['default' => 0, 'null' => true])
-        ->create();
+            ->create();
     }
 }

--- a/db/migrations/20170512193942_eventum_flysystem_pdo.php
+++ b/db/migrations/20170512193942_eventum_flysystem_pdo.php
@@ -22,21 +22,18 @@ class EventumFlysystemPdo extends AbstractMigration
 {
     public function change()
     {
-        $table = $this->table('attachment_path', ['id' => false, 'primary_key' => 'path_id']);
-        $table
-            ->addColumn('path_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false])
+        $this->table('attachment_path', ['id' => false, 'primary_key' => 'path_id'])
+            ->addColumn('path_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false, 'identity' => true])
             ->addColumn('type', 'enum', ['values' => ['dir', 'file']])
             ->addColumn('path', 'string', ['limit' => self::TEXT_TINY])
             ->addColumn('mimetype', 'string', ['null' => true, 'limit' => self::TEXT_TINY, 'encoding' => 'ascii'])
             ->addColumn('visibility', 'string', ['null' => true, 'default' => '', 'limit' => 25])
             ->addColumn('size', 'integer', ['null' => true, 'signed' => false])
             ->addColumn('is_compressed', 'integer', ['default' => '1', 'limit' => self::INT_TINY])
-            ->addColumn('update_ts', 'timestamp', ['default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP']);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+            ->addColumn('update_ts', 'timestamp', ['default' => 'CURRENT_TIMESTAMP', 'update' => 'CURRENT_TIMESTAMP'])
+            ->create();
 
-        $table = $this->table('attachment_chunk', ['id' => false, 'primary_key' => ['path_id', 'chunk_no']]);
-        $table
+        $this->table('attachment_chunk', ['id' => false, 'primary_key' => ['path_id', 'chunk_no']])
             ->addColumn('path_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false])
             ->addColumn('chunk_no', 'integer', ['limit' => self::INT_SMALL, 'signed' => false])
             ->addColumn('content', self::PHINX_TYPE_BLOB, ['length' => self::BLOB_MEDIUM])

--- a/db/migrations/20170512210935_eventum_extension_class.php
+++ b/db/migrations/20170512210935_eventum_extension_class.php
@@ -34,6 +34,7 @@ class EventumExtensionClass extends AbstractMigration
     {
         $options += ['limit' => self::TEXT_TINY, 'encoding' => 'ascii'];
         $this->table($table)
-            ->changeColumn($column, 'string', $options);
+            ->changeColumn($column, 'string', $options)
+            ->save();
     }
 }

--- a/db/migrations/20170630191008_eventum_attachments.php
+++ b/db/migrations/20170630191008_eventum_attachments.php
@@ -21,10 +21,9 @@ class EventumAttachments extends AbstractMigration
             ->addColumn('iat_min_role', 'integer', ['after' => 'iat_usr_id', 'length' => '1', 'signed' => false, 'null' => false, 'default' => 1])
             ->update();
 
-        $table = $this->table('issue_attachment_file_path', ['id' => false, 'primary_key' => 'iap_iaf_id'])
-            ->addColumn('iap_iaf_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false])
-            ->addColumn('iap_flysystem_path', 'string', ['length' => 255, 'null' => true]);
-        $this->getPrimaryKey($table)->setIdentity(true);
-        $table->create();
+        $this->table('issue_attachment_file_path', ['id' => false, 'primary_key' => 'iap_iaf_id'])
+            ->addColumn('iap_iaf_id', 'integer', ['limit' => self::INT_MEDIUM, 'signed' => false, 'identity' => true])
+            ->addColumn('iap_flysystem_path', 'string', ['length' => 255, 'null' => true])
+            ->create();
     }
 }

--- a/db/migrations/20170920202640_eventum_sup_header_length.php
+++ b/db/migrations/20170920202640_eventum_sup_header_length.php
@@ -28,6 +28,7 @@ class EventumSupHeaderLength extends AbstractMigration
             ->changeColumn('sup_from', $type, $options)
             ->changeColumn('sup_to', $type, $options)
             ->changeColumn('sup_cc', $type, $options)
-            ->changeColumn('sup_subject', $type, $options);
+            ->changeColumn('sup_subject', $type, $options)
+            ->save();
     }
 }

--- a/db/migrations/20171109145542_eventum_custom_filter_multiselect.php
+++ b/db/migrations/20171109145542_eventum_custom_filter_multiselect.php
@@ -29,8 +29,8 @@ class EventumCustomFilterMultiselect extends AbstractMigration
     {
         $table = $this->table('custom_filter');
         foreach (self::COLUMNS as $old_name => $new_name) {
-            $table->changeColumn($old_name, 'string', ['length' => 255, 'null' => true]);
-            $table->renameColumn($old_name, $new_name);
+            $table->changeColumn($old_name, 'string', ['length' => 255, 'null' => true])->save();
+            $table->renameColumn($old_name, $new_name)->save();
         }
         $table->changeColumn('cst_users', 'string', ['length' => 255, 'null' => true]);
         $table->save();

--- a/db/migrations/20180501205449_eventum_irc_notice_indices.php
+++ b/db/migrations/20180501205449_eventum_irc_notice_indices.php
@@ -18,7 +18,6 @@ class EventumIrcNoticeIndices extends AbstractMigration
     public function change()
     {
         $this->table('irc_notice')
-            ->removeIndex(['ino_status'])
             ->addIndex(['ino_status', 'ino_prj_id'])
             ->update();
     }


### PR DESCRIPTION
https://github.com/cakephp/phinx/releases/tag/v0.10.0

bumps `"php": ">=5.4"` to `"php": ">=5.6"` (irrelevant to us, we require 5.6 already)

```

  - Installing cakephp/core (3.6.4): Loading from cache
  - Installing cakephp/utility (3.6.4): Loading from cache
  - Installing cakephp/datasource (3.6.4): Loading from cache
  - Installing cakephp/cache (3.6.4): Loading from cache
  - Installing cakephp/database (3.6.4): Loading from cache
  - Installing cakephp/collection (3.6.4): Loading from cache
  - Updating robmorgan/phinx (0.9.2 => 0.10.0): Loading from cache
```

probably merge in 3.6.0