### PR TITLE
Fix bounce emails not to produce errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 - [CVE-2018-12621] Fixed open redirect (@balsdorf, Yaroslav Babin)
 - [CVE-2018-11569] Fixed remote code execution vulnerability (@balsdorf, Yaroslav Babin)
 - [CVE-2018-12622, CVE-2018-12623, CVE-2018-12624, CVE-2018-12625, CVE-2018-12626, CVE-2018-12627] XSS fixes (@balsdorf, Yaroslav Babin)
+- Fix bounce emails not to produce errors (@glensc, #396)
 
 Special thanks to Yaroslav Babin of Positive Technologies for reporting the security issues
 fixed in this release.

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -405,7 +405,7 @@ class Support
         $tpl->assign([
             'error_code' => $e->getCode(),
             'error_message' => $e->getMessage(),
-            'date' => $mail->getMailDate(),
+            'date' => $mail->date,
             'subject' => $mail->subject,
             'from' => $mail->from,
             'to' => $mail->to,

--- a/templates/notifications/bounced_email.tpl.text
+++ b/templates/notifications/bounced_email.tpl.text
@@ -2,7 +2,7 @@
 {$error_message}
 
 ----- {t escape=no}The original message headers follow{/t} -----
-{$original_message}
+
 Date: {$date}
 Subject: {$subject}
 From: {$from}


### PR DESCRIPTION
1. remove $original_message from bounced_email.tpl, it is never filled. the changes introduced from:
* e5d9bb42a - add template for bounceMessage() (10 years ago) <Elan Ruusamäe>
* 2d79d6849 - add bounceMessage(), not used yet (10 years ago) <Elan Ruusamäe>

2. fix date type for bounced email template