### PR TITLE
Handle uncaught header exception from mail download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
+- Handle uncaught header exception from mail download (@glensc, #398)
+
 [3.5.3]: https://github.com/eventum/eventum/compare/v3.5.2...master
 
 ## [3.5.2] - 2017-07-05

--- a/src/Console/Command/MailDownloadCommand.php
+++ b/src/Console/Command/MailDownloadCommand.php
@@ -19,6 +19,7 @@ use Eventum\Mail\Exception\InvalidMessageException;
 use Eventum\Mail\ImapMessage;
 use Eventum\Monolog\Logger;
 use InvalidArgumentException;
+use Psr\Log\LoggerInterface;
 use RuntimeException;
 use Support;
 
@@ -27,6 +28,9 @@ class MailDownloadCommand
     const DEFAULT_COMMAND = 'mail:download';
     const USAGE = self::DEFAULT_COMMAND . ' [username] [hostname] [mailbox] [--limit=] [--no-lock]';
 
+    /** @var LoggerInterface */
+    private $logger;
+
     /**
      * Limit amount of emails to process.
      * Default unlimited: 0
@@ -34,6 +38,11 @@ class MailDownloadCommand
      * @var int
      */
     private $limit = 0;
+
+    public function __construct()
+    {
+        $this->logger = Logger::app();
+    }
 
     /**
      * @param string $username
@@ -75,7 +84,7 @@ class MailDownloadCommand
                     try {
                         $mail = ImapMessage::createFromImap($mbox, $i, $account);
                     } catch (InvalidMessageException $e) {
-                        Logger::app()->error($e->getMessage(), ['num' => $i]);
+                        $this->logger->error($e->getMessage(), ['num' => $i]);
                         continue;
                     }
                     Support::processMailMessage($mail, $account);
@@ -92,7 +101,7 @@ class MailDownloadCommand
                     try {
                         $mail = ImapMessage::createFromImap($mbox, $i, $account);
                     } catch (InvalidMessageException $e) {
-                        Logger::app()->error($e->getMessage(), ['num' => $i]);
+                        $this->logger->error($e->getMessage(), ['num' => $i]);
                         continue;
                     }
                     Support::processMailMessage($mail, $account);

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -13,8 +13,28 @@
 
 namespace Eventum\Mail\Exception;
 
+use Exception;
 use RuntimeException;
+use Zend\Mail;
 
 class InvalidMessageException extends RuntimeException
 {
+    public static function create(Exception $e, array $params)
+    {
+        if (isset($params['headers'])) {
+            // test loading each header to identify which one fails with better error message
+            $headers = new Mail\Headers();
+            foreach ($params['headers'] as $i => $header) {
+                try {
+                    $headers->addHeaderLine($header);
+                } catch (Mail\Exception\InvalidArgumentException $e) {
+                    $message = $e->getMessage() . '; Header: ' . $header;
+
+                    return new self($message, $e->getCode());
+                }
+            }
+        }
+
+        return new self($e->getMessage(), $e->getCode());
+    }
 }

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Mail\Exception;
+
+use RuntimeException;
+
+class InvalidMessageException extends RuntimeException
+{
+}

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Mail\Exception;
 
+use Eventum\Mail\Helper\MailLoader;
 use Exception;
 use RuntimeException;
 use Zend\Mail;
@@ -22,6 +23,10 @@ class InvalidMessageException extends RuntimeException
     public static function create(Exception $e, array $params)
     {
         if (isset($params['headers'])) {
+            if (!is_array($params['headers'])) {
+                MailLoader::convertHeaders($params['headers']);
+            }
+
             // test loading each header to identify which one fails with better error message
             $headers = new Mail\Headers();
             foreach ($params['headers'] as $i => $header) {

--- a/src/Mail/Helper/MailLoader.php
+++ b/src/Mail/Helper/MailLoader.php
@@ -66,6 +66,22 @@ class MailLoader
         }
     }
 
+    public static function convertHeaders(&$headers)
+    {
+        // unfold message headers
+        $headers = preg_replace("/\r?\n/", "\r\n", $headers);
+        $headers = preg_replace("/\r\n(\t| )+/", ' ', $headers);
+
+        // split by \r\n, but \r may be optional
+        $headers = preg_split("/\r?\n/", $headers);
+
+        // strip any leftover \r
+        $headers = array_map('trim', $headers);
+
+        static::encodeHeaders($headers);
+        static::fixBrokenHeaders($headers);
+    }
+
     private static function fallbackMessageSplit($raw, &$headers, &$content)
     {
         // retry with manual \r\n splitting
@@ -80,19 +96,7 @@ class MailLoader
 
         list($headers, $content) = $parts;
 
-        // unfold message headers
-        $headers = preg_replace("/\r?\n/", "\r\n", $headers);
-        $headers = preg_replace("/\r\n(\t| )+/", ' ', $headers);
-
-        // split by \r\n, but \r may be optional
-        $headers = preg_split("/\r?\n/", $headers);
-
-        // strip any leftover \r
-        $headers = array_map('trim', $headers);
-
-        static::encodeHeaders($headers);
-
-        static::fixBrokenHeaders($headers);
+        self::convertHeaders($headers);
     }
 
     /**

--- a/src/Mail/Helper/MailLoader.php
+++ b/src/Mail/Helper/MailLoader.php
@@ -71,7 +71,14 @@ class MailLoader
         // retry with manual \r\n splitting
         // retry our own splitting
         // message likely corrupted by Eventum itself
-        list($headers, $content) = explode("\r\n\r\n", $raw, 2);
+        $parts = explode("\r\n\r\n", $raw, 2);
+
+        if (count($parts) === 1) {
+            // not \r\n separated. retry with \n\n
+            $parts = explode("\n\n", $raw, 2);
+        }
+
+        list($headers, $content) = $parts;
 
         // unfold message headers
         $headers = preg_replace("/\r?\n/", "\r\n", $headers);

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -37,7 +37,6 @@ use Zend\Mail\Header\To;
 use Zend\Mail\Headers;
 use Zend\Mail\Storage;
 use Zend\Mail\Storage\Message;
-use Zend\Mime;
 
 /**
  * Class MailMessage
@@ -65,8 +64,8 @@ class MailMessage extends Message
     {
         try {
             parent::__construct($params);
-        } catch (Mail\Exception\InvalidArgumentException  $e) {
-            throw new InvalidMessageException($e->getMessage(), $e->getCode());
+        } catch (Mail\Exception\InvalidArgumentException $e) {
+            throw InvalidMessageException::create($e, $params);
         }
 
         // do not do this for "child" messages (attachments)

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -16,6 +16,7 @@ namespace Eventum\Mail;
 use Date_Helper;
 use DateTime;
 use DomainException;
+use Eventum\Mail\Exception\InvalidMessageException;
 use Eventum\Mail\Helper\MailLoader;
 use Eventum\Mail\Helper\SanitizeHeaders;
 use Eventum\Mail\Helper\TextMessage;
@@ -62,7 +63,11 @@ class MailMessage extends Message
      */
     public function __construct(array $params = [])
     {
-        parent::__construct($params);
+        try {
+            parent::__construct($params);
+        } catch (Mail\Exception\InvalidArgumentException  $e) {
+            throw new InvalidMessageException($e->getMessage(), $e->getCode());
+        }
 
         // do not do this for "child" messages (attachments)
         if (!empty($params['root'])) {


### PR DESCRIPTION
the uncaught exception made one faulty email stop email download process

```
In Address.php line 41:

The input is not a valid email address. Use the basic format local-part@hostname
```

the faulty email was:
```
From: "Benny   Higgins " <>
```