### PR TITLE
Mail: Rename unparseable headers

### DIFF
--- a/tests/Mail/LoadEmailTest.php
+++ b/tests/Mail/LoadEmailTest.php
@@ -23,4 +23,11 @@ class LoadEmailTest extends TestCase
         $raw = $this->readDataFile('kallenote.eml');
         MailMessage::createFromString($raw);
     }
+
+    public function testLoadCCHeader()
+    {
+        $raw = $this->readDataFile('92367.txt');
+        $mail = MailMessage::createFromString($raw);
+        $this->assertTrue($mail->getHeaders()->has('X-Broken-Header-CC'));
+    }
 }

--- a/tests/Mail/LoadEmailTest.php
+++ b/tests/Mail/LoadEmailTest.php
@@ -21,7 +21,8 @@ class LoadEmailTest extends TestCase
     public function testLoadBrokenReferences1()
     {
         $raw = $this->readDataFile('kallenote.eml');
-        MailMessage::createFromString($raw);
+        $mail = MailMessage::createFromString($raw);
+        $this->assertTrue($mail->getHeaders()->has('In-Reply-To'));
     }
 
     public function testLoadCCHeader()

--- a/tests/data/92367.txt
+++ b/tests/data/92367.txt
@@ -1,0 +1,9 @@
+MIME-Version: 1.0
+From: NOC Support <support@example.net>
+To:
+Date: Wed, 18 Jul 2018 07:36:06 -0400
+Subject: Call Ref: T20180718.0098
+Message-ID: <LON-X-AT83qsyWVLEFN000047a7.atmail@LON-X-AT83.autotask.lon>
+Cc: "<issue-102188"@eventum.example.net
+
+any content.


### PR DESCRIPTION
This makes it possible to still load emails, whose headers can't be parsed.

The headers are named with `X-Broken-Header-` prefix