### PR TITLE
attachment migrate: rename --yes to --migrate

### DIFF
--- a/bin/migrate_storage_adapter.php
+++ b/bin/migrate_storage_adapter.php
@@ -25,7 +25,6 @@ use Eventum\Console\Command\AttachmentMigrateCommand as Command;
 
 require_once __DIR__ . '/../init.php';
 
-
 $app = new Application();
 $app->command(Command::USAGE, [new Command(), 'execute']);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);

--- a/src/Console/Command/AttachmentMigrateCommand.php
+++ b/src/Console/Command/AttachmentMigrateCommand.php
@@ -30,7 +30,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 class AttachmentMigrateCommand extends Command
 {
     const DEFAULT_COMMAND = 'attachment:migrate';
-    const USAGE = self::DEFAULT_COMMAND . ' [source_adapter] [target_adapter] [--chunksize=] [--limit=] [--yes] [--verify]';
+    const USAGE = self::DEFAULT_COMMAND . ' [source_adapter] [target_adapter] [--chunksize=] [--limit=] [--migrate] [--verify]';
 
     /** @var AdapterInterface */
     private $db;
@@ -44,10 +44,10 @@ class AttachmentMigrateCommand extends Command
     /** @var string */
     private $target_adapter;
 
-    public function execute(OutputInterface $output, $source_adapter, $target_adapter, $yes, $verify, $limit, $chunksize = 100)
+    public function execute(OutputInterface $output, $source_adapter, $target_adapter, $migrate, $verify, $limit, $chunksize = 100)
     {
         $this->output = $output;
-        $this->assertInput($source_adapter, $target_adapter, $yes, $verify);
+        $this->assertInput($source_adapter, $target_adapter, $migrate, $verify);
 
         $this->source_adapter = $source_adapter;
         $this->target_adapter = $target_adapter;
@@ -242,7 +242,7 @@ class AttachmentMigrateCommand extends Command
                 'WARNING: Migrating data has risks. ' .
                 "Make sure all your data is backed up before continuing.\n" .
 
-                "Pass '--yes' argument to skip this warning " .
+                "Pass '--migrate' argument to skip this warning " .
                 'and perform the migration.'
             );
         }

--- a/src/Console/Command/AttachmentMigrateCommand.php
+++ b/src/Console/Command/AttachmentMigrateCommand.php
@@ -75,26 +75,17 @@ class AttachmentMigrateCommand extends Command
             return;
         }
 
-        for ($i = 0, $nchunks = ceil($total / $chunkSize); $i < $nchunks; $i++) {
-            $files = $this->getChunk($chunkSize);
-            if (empty($files)) {
-                break;
-            }
-
-            foreach ($files as $entry) {
-                try {
-                    $this->sm->getFile($entry['iap_flysystem_path']);
-                } catch (FileNotFoundException $e) {
-                    $this->writeln("<error>ERROR</error>: {$e->getMessage()}");
-                    continue;
-                } catch (Exception $e) {
-                    $this->writeln("<error>ERROR</error>: {$e->getMessage()}");
-                    continue;
-                }
+        foreach ($this->getIterator($total, $chunkSize) as $file) {
+            try {
+                $this->sm->getFile($file['iap_flysystem_path']);
+            } catch (FileNotFoundException $e) {
+                $this->writeln("<error>ERROR</error>: {$e->getMessage()}");
+                continue;
+            } catch (Exception $e) {
+                $this->writeln("<error>ERROR</error>: {$e->getMessage()}");
+                continue;
             }
         }
-
-        $this->writeln('');
     }
 
     private function migrateAttachments($chunkSize, $limit)

--- a/src/Console/Command/AttachmentMigrateCommand.php
+++ b/src/Console/Command/AttachmentMigrateCommand.php
@@ -110,7 +110,9 @@ class AttachmentMigrateCommand extends Command
             return;
         }
 
-        ProgressBar::setFormatDefinition('custom', ' %current%/%max% [%bar%] %percent:3s%% %elapsed:6s%/%estimated:-6s% %memory:6s% (%id%: %filename%)');
+        $format = ProgressBar::getFormatDefinition('debug');
+        $format .= ' (%id%: %filename%)';
+        ProgressBar::setFormatDefinition('custom', $format);
         $progressBar = new ProgressBar($this->output, $total);
         $progressBar->setFormat('custom');
         $progressBar->start();
@@ -129,6 +131,7 @@ class AttachmentMigrateCommand extends Command
             }
         }
 
+        $progressBar->setFormat('debug');
         $progressBar->finish();
         $this->writeln('');
     }


### PR DESCRIPTION
makes more sense if you look at the usage:

Verify:

```
$ ./bin/migrate_storage_adapter.php --verify legacy
Verifying data in 'legacy://' Adapter
Preparing temporary table. Please wait...
Verifying 1516 file(s)
```

Perform actual migration:

```
$ ./bin/migrate_storage_adapter.php --yes pdo local --limit=100
Migrating data from 'pdo://' to 'local://'
Preparing temporary table. Please wait...
Moving 1 file(s)
 1/1 [============================] 100% < 1 sec/< 1 sec 6.8 MiB (93046: pdo://102959/93046.docx)
You might need to run 'OPTIMIZE TABLE attachment_chunk' to reclaim space from the database
```