### PR TITLE
Strip non numerical input from issue lookup shortcut

### DIFF
--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -61,8 +61,9 @@ $(document).ready(function() {
 
     $('#shortcut_form').submit(function(e) {
         var target = $('#shortcut');
-        if (!Validation.isNumberOnly(target.val())) {
-            alert('Please enter numbers only');
+        target.val(target.val().replace(/\D/g,''));
+        if (Validation.isWhitespace(target.val())) {
+            alert('Please enter a valid Issue ID');
             return false;
         }
     });


### PR DESCRIPTION
Currently if you had any non numeric characters such as whitespace or "." in the issue lookup shortcut field results in an error message. This automatically strips any non numeric values from the input.