### PR TITLE
Fix Duplicate Subject resulting Array as title

### DIFF
--- a/db/migrations/20180829203455_eventum_duplicate_subject.php
+++ b/db/migrations/20180829203455_eventum_duplicate_subject.php
@@ -23,15 +23,32 @@ class EventumDuplicateSubject extends AbstractMigration
 {
     public function up()
     {
-        foreach ($this->getEmailEntries() as $id) {
+        $entries = $this->getEmailEntries();
+        foreach ($this->getIterator($entries) as $id) {
             $mail = $this->getEmail($id);
             $this->setEmailSubject($id, $mail->subject);
         }
+        $count = count($entries);
+        $this->writeln("Fixed $count emails");
 
-        foreach ($this->getNoteEntries() as $id) {
+        $entries = $this->getNoteEntries();
+        foreach ($this->getIterator($entries) as $id) {
             $mail = $this->getNote($id);
             $this->setNoteTitle($id, $mail->subject);
         }
+        $count = count($entries);
+        $this->writeln("Fixed $count notes");
+    }
+
+    private function getIterator($entries)
+    {
+        $progressBar = $this->createProgressBar(count($entries));
+        foreach ($entries as $entry) {
+            yield $entry;
+            $progressBar->advance();
+        }
+        $progressBar->finish();
+        $this->writeln('');
     }
 
     private function getEmailEntries($idColumn = 'sup_id')

--- a/db/migrations/20180829203455_eventum_duplicate_subject.php
+++ b/db/migrations/20180829203455_eventum_duplicate_subject.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+use Eventum\Mail\MailMessage;
+
+/**
+ * Fixes note and email tables
+ * where legacy code filled subject as Array
+ * when email contained duplicate "Subject:" headers.
+ */
+class EventumDuplicateSubject extends AbstractMigration
+{
+    public function up()
+    {
+        foreach ($this->getEmailEntries() as $id) {
+            $mail = $this->getEmail($id);
+            $this->setEmailSubject($id, $mail->subject);
+        }
+
+        foreach ($this->getNoteEntries() as $id) {
+            $mail = $this->getNote($id);
+            $this->setNoteTitle($id, $mail->subject);
+        }
+    }
+
+    private function getEmailEntries($idColumn = 'sup_id')
+    {
+        $sql = "select `$idColumn` from `support_email` where `sup_subject`='Array'";
+
+        return $this->queryColumn($sql, $idColumn);
+    }
+
+    private function getNoteEntries($idColumn = 'not_id')
+    {
+        $sql = "select `$idColumn` from `note` where `not_title`='Array'";
+
+        return $this->queryColumn($sql, $idColumn);
+    }
+
+    private function getEmail($id, $emailField = 'seb_full_email')
+    {
+        $sql = "select `$emailField` from `support_email_body` where seb_sup_id=$id";
+
+        $raw = $this->queryOne($sql, $emailField);
+
+        return MailMessage::createFromString($raw);
+    }
+
+    private function getNote($id, $emailField = 'not_full_message')
+    {
+        $sql = "select `$emailField` from `note` where not_id=$id";
+
+        $raw = $this->queryOne($sql, $emailField);
+
+        return MailMessage::createFromString($raw);
+    }
+
+    private function setEmailSubject($id, $subject)
+    {
+        $subject = $this->quote($subject);
+        $sql = "UPDATE `support_email` SET sup_subject=$subject WHERE sup_id=$id";
+
+        $this->query($sql);
+    }
+
+    private function setNoteTitle($id, $title)
+    {
+        $title = $this->quote($title);
+        $sql = "UPDATE `note` SET not_title=$title WHERE not_id=$id";
+
+        $this->query($sql);
+    }
+}

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -149,7 +149,7 @@ class Note
      * @param   int $note_id The note ID
      * @return MailMessage
      */
-    public static function getBlockedMessage($note_id)
+    public static function getNoteMessage($note_id)
     {
         $stmt = 'SELECT
                     not_full_message
@@ -158,9 +158,9 @@ class Note
                  WHERE
                     not_id=?';
 
-        $blocked_message = DB_Helper::getInstance()->getOne($stmt, [$note_id]);
+        $message = DB_Helper::getInstance()->getOne($stmt, [$note_id]);
 
-        return MailMessage::createFromString($blocked_message);
+        return MailMessage::createFromString($message);
     }
 
     /**
@@ -520,7 +520,7 @@ class Note
     {
         $issue_id = self::getIssueID($note_id);
         $email_account_id = Email_Account::getEmailAccount();
-        $mail = self::getBlockedMessage($note_id);
+        $mail = self::getNoteMessage($note_id);
         $unknown_user = self::getUnknownUser($note_id);
         $sender_email = $mail->getSender();
         $usr_id = Auth::getUserID();

--- a/src/Controller/GetAttachmentController.php
+++ b/src/Controller/GetAttachmentController.php
@@ -57,7 +57,7 @@ class GetAttachmentController extends BaseController
         $get = $this->getRequest()->query;
 
         if ($this->cat == 'blocked_email') {
-            $mail = Note::getBlockedMessage($get->getInt('note_id'));
+            $mail = Note::getNoteMessage($get->getInt('note_id'));
         } else {
             $mail = Support::getSupportEmail($get->getInt('sup_id'));
         }

--- a/src/Controller/ViewHeadersController.php
+++ b/src/Controller/ViewHeadersController.php
@@ -62,7 +62,7 @@ class ViewHeadersController extends BaseController
     protected function prepareTemplate()
     {
         if ($this->cat == 'note') {
-            $mail = Note::getBlockedMessage($this->id);
+            $mail = Note::getNoteMessage($this->id);
         } else {
             $mail = Support::getSupportEmail($this->id);
         }


### PR DESCRIPTION
This fixes database from old bug which resulted `Array` being displayed if email contained multiple `Subject` headers.

The bug itself has been fixed for ages, but as `note` and `support_email` store copy of the subject, the database may still contain the result of the bug.