### PR TITLE
Add SystemEvents::hasEvent to feature test availability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
+- Add SystemEvents::hasEvent to feature test availability (@glensc, #422)
+
 [3.5.5]: https://github.com/eventum/eventum/compare/v3.5.4...master
 
 ## [3.5.4] - 2018-09-05

--- a/src/Event/Subscriber/IrcSubscriber.php
+++ b/src/Event/Subscriber/IrcSubscriber.php
@@ -11,10 +11,11 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Event;
+namespace Eventum\Event\Subscriber;
 
 use Date_Helper;
 use DB_Helper;
+use Eventum\Event\SystemEvents;
 use Setup;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;

--- a/src/Event/Subscriber/MailQueueListener.php
+++ b/src/Event/Subscriber/MailQueueListener.php
@@ -11,10 +11,11 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Event;
+namespace Eventum\Event\Subscriber;
 
 use Date_Helper;
 use DB_Helper;
+use Eventum\Event\SystemEvents;
 use Eventum\Mail\MailMessage;
 use League\Flysystem\Exception;
 use Mail_Helper;

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Event;
 
+use Eventum\Event\Subscriber\MailQueueListener;
 use Eventum\Model\Repository\CommitRepository;
 
 final class SystemEvents

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -157,4 +157,18 @@ final class SystemEvents
      * @since 3.4.2
      */
     const IRC_FORMAT_MESSAGE = 'irc.format.message';
+
+    /**
+     * Helper to feature test whether specific event is being emitted by Eventum.
+     *
+     * @param string $eventName
+     * @return bool
+     * @since 3.5.5
+     */
+    public static function hasEvent($eventName)
+    {
+        $const = sprintf('%s::%s', self::class, $eventName);
+
+        return defined($const);
+    }
 }

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\EventDispatcher;
 
-use Eventum\Event\MailQueueListener;
+use Eventum\Event\Subscriber\MailQueueListener;
 use Eventum\Extension\ExtensionManager;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;

--- a/src/Extension/IrcNotifyExtension.php
+++ b/src/Extension/IrcNotifyExtension.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Extension;
 
-use Eventum\Event\IrcSubscriber;
+use Eventum\Event\Subscriber\IrcSubscriber;
 use Setup;
 
 class IrcNotifyExtension extends AbstractExtension


### PR DESCRIPTION
This is useful from workflow to test different eventum versions.

It's quite common for me to pre-test some eventum branch while using same workflow setup.

cc @balsdorf 