### PR TITLE
WIP: Escape HTML in plain description.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
+- Escape HTML in issue plain description (@balsdorf, #428)
+
 [3.5.6]: https://github.com/eventum/eventum/compare/v3.5.5...master
 
 ## [3.5.5] - 2018-12-26

--- a/templates/view_form.tpl.html
+++ b/templates/view_form.tpl.html
@@ -204,7 +204,7 @@
                     <td>
                         <span id="issue_description" {get_display_style element_name="issue_description"}>
                           <span id="description_formatted">{$issue.iss_description|textFormat:$issue.iss_id}</span>
-                          <span id="description_plain" class="fixed_width" style="display: none">{$issue.iss_description}</span>
+                          <span id="description_plain" class="fixed_width" style="display: none">{$issue.iss_description|escape:htmlall}</span>
                         </span>
                         <span id="description_hidden" style="display: none"><em>{t}Description is currently collapsed{/t}.</em></span>
                     </td>


### PR DESCRIPTION
Previously, putting an open comment would break the rest of the page due to plain description not being escaped.

```
<!-- everything after this is broken
```