### PR TITLE
Fix attachment delete permissions check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
 - Extensions: skip components that fail to initialize (@glensc, #431)
 - Handle text/html only email rendering (@TexasGitHubber, @glensc, #399, #429, #400, #401)
+- Fix attachment delete permissions check (@glensc, #412)
 
 [3.5.6]: https://github.com/eventum/eventum/compare/v3.5.5...master
 

--- a/src/Attachment/AttachmentGroup.php
+++ b/src/Attachment/AttachmentGroup.php
@@ -129,13 +129,14 @@ class AttachmentGroup
      */
     public function canAccess($usr_id)
     {
-        if (Issue::canAccess($this->issue_id, $usr_id)
-            && User::getRoleByUser($usr_id, Issue::getProjectID($this->issue_id) >= $this->minimum_role)
-        ) {
-            return true;
+        if (!Issue::canAccess($this->issue_id, $usr_id)) {
+            return false;
         }
 
-        return false;
+        $prj_id = Issue::getProjectID($this->issue_id);
+        $user_role = User::getRoleByUser($usr_id, $prj_id);
+
+        return $user_role >= $this->minimum_role;
     }
 
     /**

--- a/src/Attachment/AttachmentManager.php
+++ b/src/Attachment/AttachmentManager.php
@@ -375,8 +375,9 @@ class AttachmentManager
             $usr_id = Auth::getUserID();
             $attachment = self::getAttachment($iaf_id);
             $group = $attachment->getGroup();
+            $user_role = User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id));
             if (!$attachment->canAccess($usr_id) ||
-                ($usr_id != $group->user_id && User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id) < User::ROLE_MANAGER))
+                ($usr_id != $group->user_id && $user_role < User::ROLE_MANAGER)
             ) {
                 return -2;
             }
@@ -402,10 +403,12 @@ class AttachmentManager
     {
         $usr_id = Auth::getUserID();
         $group = self::getGroup($iat_id);
-        if (!$group->canAccess($usr_id) ||
-            ($usr_id != $group->user_id &&
-                User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id)) < User::ROLE_MANAGER)
-        ) {
+        if (!$group->canAccess($usr_id)) {
+            return -2;
+        }
+
+        $user_role = User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id));
+        if ($usr_id != $group->user_id && $user_role < User::ROLE_MANAGER) {
             return -2;
         }
 


### PR DESCRIPTION
fixes: #412

the problem was caused by mispatched less than operator
```diff
- ($usr_id != $group->user_id && User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id) < User::ROLE_MANAGER))
+ ($usr_id != $group->user_id && User::getRoleByUser($usr_id, Issue::getProjectID($group->issue_id)) < User::ROLE_MANAGER)

```

the bugs were introduced by:
- ff310a91c8a508e5e3c68b287fce364f91e0e4d1
- 1d49286a35af4c049daef16584a295ddb8a1c1b6

simplified code to use local variables

cc @balsdorf, @lmoralesa