### PR TITLE
extension loader: skip components that fail to initialize

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.5.x versions requires that you upgrade to 3.2.0 version first.
 
+- Extensions: skip components that fail to initialize (@glensc, #431)
+
 [3.5.6]: https://github.com/eventum/eventum/compare/v3.5.5...master
 
 ## [3.5.5] - 2018-12-26

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -13,6 +13,8 @@
 
 namespace Eventum\Extension;
 
+use Eventum\Monolog\Logger;
+use Exception;
 use InvalidArgumentException;
 use Setup;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -111,7 +113,11 @@ class ExtensionManager
         $instances = [];
         foreach ($this->extensions as $extension) {
             foreach ($extension->$methodName() as $className) {
-                $instances[$className] = $this->createInstance($extension, $className);
+                try {
+                    $instances[$className] = $this->createInstance($extension, $className);
+                } catch (Exception $e) {
+                    Logger::app()->error("Unable to create $className: {$e->getMessage()}", ['exception' => $e]);
+                }
             }
         }
 


### PR DESCRIPTION
for example I had event subscriber missing slack token

cc @balsdorf 