### PR TITLE
Update zend-mail to 2.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.7.x versions requires that you upgrade to latest 3.5.x version fi
 
 - GitLab: skip issue matching on empty text (@glensc, #562)
 - Add Status Entity (@glensc, #560)
+- Update zend-mail to 2.10 (@glensc, #432)
 
 [3.7.1]: https://github.com/eventum/eventum/compare/v3.7.0...master
 

--- a/composer.json
+++ b/composer.json
@@ -117,16 +117,15 @@
 		"webuni/commonmark-table-extension": "^0.9.0",
 		"willdurand/email-reply-parser": "^2.7.0",
 		"xemlock/htmlpurifier-html5": "^0.1.10",
-		"zendframework/zend-config": "2.4.*",
-		"zendframework/zend-mail": "dev-develop-2.4",
-		"zendframework/zend-servicemanager": "2.4.*"
+		"zendframework/zend-config": "^3.2",
+		"zendframework/zend-mail": "2.10.x-dev",
+		"zendframework/zend-servicemanager": "^3.4"
 	},
 	"replace": {
 		"paragonie/random_compat": "9.99.99",
 		"symfony/polyfill-ctype": "1.10.0",
 		"symfony/polyfill-intl-normalizer": "1.10.0",
-		"symfony/polyfill-mbstring": "1.10.0",
-		"zendframework/zend-crypt": "2.4.9"
+		"symfony/polyfill-mbstring": "1.10.0"
 	},
 	"require-dev": {
 		"alcaeus/mongo-php-adapter": "^1.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "edab04ef85ae4dfcdf93b64f3ef4d299",
+    "content-hash": "f0771653d31eda20246b6366a3e85883",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -341,6 +341,37 @@
                 "utility"
             ],
             "time": "2019-03-14T14:41:29+00:00"
+        },
+        {
+            "name": "container-interop/container-interop",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/container-interop/container-interop.git",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/container-interop/container-interop/zipball/79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "reference": "79cbf1341c22ec75643d841642dd5d6acd83bdb8",
+                "shasum": ""
+            },
+            "require": {
+                "psr/container": "^1.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Interop\\Container\\": "src/Interop/Container/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Promoting the interoperability of container objects (DIC, SL, etc.)",
+            "homepage": "https://github.com/container-interop/container-interop",
+            "time": "2017-02-14T19:40:03+00:00"
         },
         {
             "name": "defuse/php-encryption",
@@ -4514,42 +4545,45 @@
         },
         {
             "name": "zendframework/zend-config",
-            "version": "2.4.13",
+            "version": "3.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-config.git",
-                "reference": "6b879e54096b8e0d2290f7414c38f9a5947cb8ac"
+                "reference": "6796f5dcba52c84ef2501d7313618989b5ef3023"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/6b879e54096b8e0d2290f7414c38f9a5947cb8ac",
-                "reference": "6b879e54096b8e0d2290f7414c38f9a5947cb8ac",
+                "url": "https://api.github.com/repos/zendframework/zend-config/zipball/6796f5dcba52c84ef2501d7313618989b5ef3023",
+                "reference": "6796f5dcba52c84ef2501d7313618989b5ef3023",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "self.version"
+                "ext-json": "*",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^2.7.7 || ^3.1"
+            },
+            "conflict": {
+                "container-interop/container-interop": "<1.2.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
-                "zendframework/zend-filter": "self.version",
-                "zendframework/zend-i18n": "self.version",
-                "zendframework/zend-json": "self.version",
-                "zendframework/zend-servicemanager": "self.version"
+                "malukenho/docheader": "^0.1.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-filter": "^2.7.2",
+                "zendframework/zend-i18n": "^2.7.4",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3"
             },
             "suggest": {
-                "zendframework/zend-filter": "Zend\\Filter component",
-                "zendframework/zend-i18n": "Zend\\I18n component",
-                "zendframework/zend-json": "Zend\\Json to use the Json reader or writer classes",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager for use with the Config Factory to retrieve reader and writer instances"
+                "zendframework/zend-filter": "^2.7.2; install if you want to use the Filter processor",
+                "zendframework/zend-i18n": "^2.7.4; install if you want to use the Translator processor",
+                "zendframework/zend-servicemanager": "^2.7.8 || ^3.3; if you need an extensible plugin manager for use with the Config Factory"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -4562,40 +4596,39 @@
                 "BSD-3-Clause"
             ],
             "description": "provides a nested object property based user interface for accessing this configuration data within application code",
-            "homepage": "https://github.com/zendframework/zend-config",
             "keywords": [
+                "ZendFramework",
                 "config",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-05-07T14:55:31+00:00"
+            "time": "2018-04-24T19:26:44+00:00"
         },
         {
             "name": "zendframework/zend-loader",
-            "version": "2.4.13",
+            "version": "2.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-loader.git",
-                "reference": "5e62c44a4d23c4e09d35fcc2a3b109c944dbdc22"
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/5e62c44a4d23c4e09d35fcc2a3b109c944dbdc22",
-                "reference": "5e62c44a4d23c4e09d35fcc2a3b109c944dbdc22",
+                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/78f11749ea340f6ca316bca5958eef80b38f9b6c",
+                "reference": "78f11749ea340f6ca316bca5958eef80b38f9b6c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master"
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
                 }
             },
             "autoload": {
@@ -4607,52 +4640,58 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-loader",
+            "description": "Autoloading and plugin loading strategies",
             "keywords": [
+                "ZendFramework",
                 "loader",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-05-07T14:55:31+00:00"
+            "time": "2018-04-30T15:20:54+00:00"
         },
         {
             "name": "zendframework/zend-mail",
-            "version": "dev-develop-2.4",
+            "version": "dev-develop-2.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/eventum/zend-mail.git",
-                "reference": "cb8d0e08189df56689704584b0f9c38c6a21c351"
+                "reference": "e92282e8ab30a161bf9b69e010e1002a893a6428"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eventum/zend-mail/zipball/cb8d0e08189df56689704584b0f9c38c6a21c351",
-                "reference": "cb8d0e08189df56689704584b0f9c38c6a21c351",
+                "url": "https://api.github.com/repos/eventum/zend-mail/zipball/e92282e8ab30a161bf9b69e010e1002a893a6428",
+                "reference": "e92282e8ab30a161bf9b69e010e1002a893a6428",
                 "shasum": ""
             },
             "require": {
-                "php": "^5.4 || ^7.0",
+                "ext-iconv": "*",
+                "php": "^5.6 || ^7.0",
                 "true/punycode": "^2.1",
-                "zendframework/zend-loader": "~2.4.0",
-                "zendframework/zend-mime": "~2.4.0",
-                "zendframework/zend-stdlib": "~2.4.0",
-                "zendframework/zend-validator": "~2.4.0"
+                "zendframework/zend-loader": "^2.5",
+                "zendframework/zend-mime": "^2.5",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0",
+                "zendframework/zend-validator": "^2.10.2"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "zendframework/zend-config": "~2.4.0",
-                "zendframework/zend-crypt": "~2.4.0",
-                "zendframework/zend-servicemanager": "~2.4.0"
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-crypt": "^2.6 || ^3.0",
+                "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1"
             },
             "suggest": {
                 "zendframework/zend-crypt": "Crammd5 support in SMTP Auth",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager component"
+                "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1 when using SMTP to deliver messages"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop-2.4": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.10.x-dev",
+                    "dev-develop-2.10": "2.10.x-dev",
+                    "dev-develop": "2.11.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Mail",
+                    "config-provider": "Zend\\Mail\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -4665,43 +4704,65 @@
                     "ZendTest\\Mail\\": "test/"
                 }
             },
+            "scripts": {
+                "check": [
+                    "@cs-check",
+                    "@test"
+                ],
+                "cs-check": [
+                    "phpcs"
+                ],
+                "cs-fix": [
+                    "phpcbf"
+                ],
+                "test": [
+                    "phpunit --colors=always"
+                ],
+                "test-coverage": [
+                    "phpunit --colors=always --coverage-clover clover.xml"
+                ]
+            },
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
-            "homepage": "https://github.com/zendframework/zend-mail",
+            "description": "Provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
             "keywords": [
                 "mail",
-                "zf2"
+                "zendframework",
+                "zf"
             ],
             "support": {
-                "source": "https://github.com/eventum/zend-mail/tree/develop-2.4"
+                "docs": "https://docs.zendframework.com/zend-mail/",
+                "issues": "https://github.com/zendframework/zend-mail/issues",
+                "source": "https://github.com/zendframework/zend-mail",
+                "rss": "https://github.com/zendframework/zend-mail/releases.atom",
+                "chat": "https://zendframework-slack.herokuapp.com",
+                "forum": "https://discourse.zendframework.com/c/questions/components"
             },
-            "time": "2019-03-07T09:08:22+00:00"
+            "time": "2019-05-02T21:03:22+00:00"
         },
         {
             "name": "zendframework/zend-mime",
-            "version": "2.4.13",
+            "version": "2.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-mime.git",
-                "reference": "df81ca9f94f0d1cd31175b8d2df6002b61dd5973"
+                "reference": "52ae5fa9f12845cae749271034a2d594f0e4c6f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-mime/zipball/df81ca9f94f0d1cd31175b8d2df6002b61dd5973",
-                "reference": "df81ca9f94f0d1cd31175b8d2df6002b61dd5973",
+                "url": "https://api.github.com/repos/zendframework/zend-mime/zipball/52ae5fa9f12845cae749271034a2d594f0e4c6f2",
+                "reference": "52ae5fa9f12845cae749271034a2d594f0e4c6f2",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "self.version"
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^2.7 || ^3.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
-                "zendframework/zend-mail": "self.version"
+                "phpunit/phpunit": "^5.7.21 || ^6.3",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-mail": "^2.6"
             },
             "suggest": {
                 "zendframework/zend-mail": "Zend\\Mail component"
@@ -4709,8 +4770,8 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.7-dev",
+                    "dev-develop": "2.8-dev"
                 }
             },
             "autoload": {
@@ -4722,45 +4783,59 @@
             "license": [
                 "BSD-3-Clause"
             ],
+            "description": "Create and parse MIME messages and parts",
             "homepage": "https://github.com/zendframework/zend-mime",
             "keywords": [
+                "ZendFramework",
                 "mime",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-05-07T16:53:42+00:00"
+            "time": "2018-05-14T19:02:50+00:00"
         },
         {
             "name": "zendframework/zend-servicemanager",
-            "version": "2.4.13",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "855294e12771b4295c26446b6ed2df2f1785f234"
+                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/855294e12771b4295c26446b6ed2df2f1785f234",
-                "reference": "855294e12771b4295c26446b6ed2df2f1785f234",
+                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/a1ed6140d0d3ee803fec96582593ed024950067b",
+                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "container-interop/container-interop": "^1.2",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0",
+                "zendframework/zend-stdlib": "^3.2.1"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
-                "zendframework/zend-di": "self.version"
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "suggest": {
-                "ocramius/proxy-manager": "ProxyManager 0.5.* to handle lazy initialization of services",
-                "zendframework/zend-di": "Zend\\Di component"
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
+                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
             },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
                 }
             },
             "autoload": {
@@ -4772,50 +4847,46 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-service-manager",
+            "description": "Factory-Driven Dependency Injection Container",
             "keywords": [
+                "PSR-11",
+                "ZendFramework",
+                "dependency-injection",
+                "di",
+                "dic",
+                "service-manager",
                 "servicemanager",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-05-07T14:55:31+00:00"
+            "time": "2018-12-22T06:05:09+00:00"
         },
         {
             "name": "zendframework/zend-stdlib",
-            "version": "2.4.13",
+            "version": "3.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "d8ecb629a72da9f91bd95c5af006384823560b42"
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/d8ecb629a72da9f91bd95c5af006384823560b42",
-                "reference": "d8ecb629a72da9f91bd95c5af006384823560b42",
+                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
+                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23"
+                "php": "^5.6 || ^7.0"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
-                "zendframework/zend-eventmanager": "self.version",
-                "zendframework/zend-filter": "self.version",
-                "zendframework/zend-serializer": "self.version",
-                "zendframework/zend-servicemanager": "self.version"
-            },
-            "suggest": {
-                "zendframework/zend-eventmanager": "To support aggregate hydrator usage",
-                "zendframework/zend-filter": "To support naming strategy hydrator usage",
-                "zendframework/zend-serializer": "Zend\\Serializer component",
-                "zendframework/zend-servicemanager": "To support hydrator plugin manager usage"
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
+                "zendframework/zend-coding-standard": "~1.0.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
                 }
             },
             "autoload": {
@@ -4827,59 +4898,68 @@
             "license": [
                 "BSD-3-Clause"
             ],
-            "homepage": "https://github.com/zendframework/zend-stdlib",
+            "description": "SPL extensions, array utilities, error handlers, and more",
             "keywords": [
+                "ZendFramework",
                 "stdlib",
-                "zf2"
+                "zf"
             ],
-            "time": "2015-07-21T13:55:46+00:00"
+            "time": "2018-08-28T21:34:05+00:00"
         },
         {
             "name": "zendframework/zend-validator",
-            "version": "2.4.13",
+            "version": "2.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "81415511fe729e6de19a61936313cef43c80d337"
+                "reference": "64c33668e5fa2d39c6289a878f927ea2b0850c30"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/81415511fe729e6de19a61936313cef43c80d337",
-                "reference": "81415511fe729e6de19a61936313cef43c80d337",
+                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/64c33668e5fa2d39c6289a878f927ea2b0850c30",
+                "reference": "64c33668e5fa2d39c6289a878f927ea2b0850c30",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.3.23",
-                "zendframework/zend-stdlib": "~2.4.0"
+                "container-interop/container-interop": "^1.1",
+                "php": "^5.6 || ^7.0",
+                "zendframework/zend-stdlib": "^3.2.1"
             },
             "require-dev": {
-                "fabpot/php-cs-fixer": "1.7.*",
-                "phpunit/phpunit": "~4.0",
-                "satooshi/php-coveralls": "dev-master",
-                "zendframework/zend-config": "~2.4.0",
-                "zendframework/zend-db": "~2.4.0",
-                "zendframework/zend-filter": "~2.4.0",
-                "zendframework/zend-i18n": "~2.4.0",
-                "zendframework/zend-math": "~2.4.0",
-                "zendframework/zend-servicemanager": "~2.4.0",
-                "zendframework/zend-session": "~2.4.0",
-                "zendframework/zend-uri": "~2.4.0"
+                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
+                "psr/http-message": "^1.0",
+                "zendframework/zend-cache": "^2.6.1",
+                "zendframework/zend-coding-standard": "~1.0.0",
+                "zendframework/zend-config": "^2.6",
+                "zendframework/zend-db": "^2.7",
+                "zendframework/zend-filter": "^2.6",
+                "zendframework/zend-http": "^2.5.4",
+                "zendframework/zend-i18n": "^2.6",
+                "zendframework/zend-math": "^2.6",
+                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
+                "zendframework/zend-session": "^2.8",
+                "zendframework/zend-uri": "^2.5"
             },
             "suggest": {
-                "zendframework/zend-db": "Zend\\Db component",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators",
+                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
                 "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
-                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages as well as to use the various Date validators",
-                "zendframework/zend-math": "Zend\\Math component",
-                "zendframework/zend-resources": "Translations of validator messages",
+                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
+                "zendframework/zend-i18n-resources": "Translations of validator messages",
+                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
                 "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "zendframework/zend-session": "Zend\\Session component",
+                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
                 "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.4-dev",
-                    "dev-develop": "2.5-dev"
+                    "dev-master": "2.12.x-dev",
+                    "dev-develop": "2.13.x-dev"
+                },
+                "zf": {
+                    "component": "Zend\\Validator",
+                    "config-provider": "Zend\\Validator\\ConfigProvider"
                 }
             },
             "autoload": {
@@ -4897,7 +4977,7 @@
                 "validator",
                 "zf2"
             ],
-            "time": "2015-09-08T21:04:17+00:00"
+            "time": "2019-01-30T14:26:10+00:00"
         }
     ],
     "packages-dev": [

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -251,7 +251,8 @@ class MailMessageTest extends TestCase
         $message = MailMessage::createFromString($raw);
 
         // test that getting back raw content works
-        // NOTE: the result is not always identical, however this is saved from this same method before manually verifying result is okay
+        // NOTE: the result is not always identical,
+        // however this is saved from this same method before manually verifying result is okay
         $content = $message->getRawContent();
 
         $raw = preg_split("/\r?\n/", $raw);
@@ -453,7 +454,8 @@ class MailMessageTest extends TestCase
 
         $mail->addHeaders($add_headers);
         $raw = $mail->getRawContent();
-        $this->assertContains("dede\r\n dede", $raw, 'value has been wrapped');
+        $folding = Headers::FOLDING;
+        $this->assertContains("<dede>{$folding}<dede>", $raw, 'value has been wrapped');
     }
 
     /**

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -232,6 +232,7 @@ class MailMessageTest extends TestCase
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/multipart-text-html.txt');
         $mail->setInReplyTo('fu!');
         $mail->getRawContent();
+        $this->assertTrue(true);
     }
 
     public function testGetAddresses(): void
@@ -503,6 +504,7 @@ class MailMessageTest extends TestCase
         $mail->setTo($to);
         $mail->setContent($text_message);
         Mail_Queue::queue($mail, $to);
+        $this->assertTrue(true);
     }
 
     /**
@@ -513,7 +515,6 @@ class MailMessageTest extends TestCase
     public function testMailSendZF(): void
     {
         $text_message = 'tere';
-        $issue_id = 1;
         $from = 'Eventum <support@example.org>';
         $recipient = 'Eventum <support@example.org>';
         $subject = '[#1] Issue Created';
@@ -527,6 +528,7 @@ class MailMessageTest extends TestCase
 
         // add($recipient, $headers, $body, $save_email_copy = 0, $issue_id = false, $type = '', $sender_usr_id = false, $type_id = false)
         Mail_Queue::queue($mail, $recipient);
+        $this->assertTrue(true);
     }
 
     public function testMailFromHeaderBody(): void
@@ -553,6 +555,7 @@ class MailMessageTest extends TestCase
         $mail->setSubject('[#3] Note: new ää');
         $headers = $mail->getHeadersArray();
         MailMessage::createFromHeaderBody($headers, $body);
+        $this->assertTrue(true);
     }
 
     public function testSendPlainMail(): void
@@ -595,14 +598,18 @@ class MailMessageTest extends TestCase
             }
         );
         $transport->send($mail);
+        $this->assertTrue(true);
     }
 
     public function testReSetMessageId(): void
     {
         $mail = MailMessage::createNew();
         $headers = [];
-        $headers['Message-ID'] = Mail_Helper::generateMessageID();
+        $messageId = Mail_Helper::generateMessageID();
+        $headers['Message-ID'] = $messageId;
         $mail->addHeaders($headers);
+        $result = $mail->messageId;
+        $this->assertEquals($messageId, $result);
     }
 
     public function testZFPlainMail(): void
@@ -630,6 +637,7 @@ class MailMessageTest extends TestCase
             'type' => $type,
         ];
         Mail_Queue::queue($mail, $to, $options);
+        $this->assertTrue(true);
     }
 
     /**

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -24,6 +24,7 @@ use Routing;
 use Setup;
 use Zend;
 use Zend\Mail\AddressList;
+use Zend\Mail\Headers;
 
 /**
  * @group mail
@@ -210,16 +211,17 @@ class MailMessageTest extends TestCase
         $exp = '<CAG5u9y_0RRMmCf_o28KmfmyCn5UN9PVM1=avWp4wWqbHGgojsA@4.example.org>';
         $this->assertEquals($exp, $msg_id);
 
-        $this->assertEquals($exp, $mail->InReplyTo);
+        $this->assertEquals($exp, $mail->inReplyTo);
 
         $mail->setInReplyTo('foo-bar-123');
-        $value = 'foo-bar-123';
-        $this->assertEquals($value, $mail->InReplyTo);
+        $value = '<foo-bar-123>';
+        $this->assertEquals($value, $mail->inReplyTo);
 
         $references = [1, $msg_id];
         $mail->setReferences($references);
-        $exp = '1 <CAG5u9y_0RRMmCf_o28KmfmyCn5UN9PVM1=avWp4wWqbHGgojsA@4.example.org>';
-        $this->assertEquals($exp, $mail->References);
+        $folding = Headers::FOLDING;
+        $exp = "<1>$folding<CAG5u9y_0RRMmCf_o28KmfmyCn5UN9PVM1=avWp4wWqbHGgojsA@4.example.org>";
+        $this->assertEquals($exp, $mail->references);
     }
 
     /**

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -423,7 +423,7 @@ class MailMessageTest extends TestCase
                 'Subject: ',
                 'X-Eventum-Group-Issue: something 123 143',
                 'X-Eventum-Group-Replier: =?UTF-8?Q?m=C3=B5min?=',
-                'X-Eventum-Group-Assignee: =?UTF-8?Q?UUser1,=20juus=C3=B5r2?=',
+                'X-Eventum-Group-Assignee: =?UTF-8?Q?UUser1=2C=20juus=C3=B5r2?=',
                 'X-Eventum-Customer: cust om er',
                 'X-Eventum-Assignee: foo, bar',
                 'X-Eventum-Category: Title Cat',
@@ -648,11 +648,13 @@ class MailMessageTest extends TestCase
      */
     public function testParseHeaders(): void
     {
-        $header = "Subject: [#77675] New Issue:xxxxxxxxx xxxxxxx xxxxxxxx xxxxxxxxxxxxx xxxxxxxxxx xxxxxxxx, =?utf-8?b?dMOkaHRhZWc=?= xx.xx, xxxx\r\n";
+        $header = "Subject: [#77675] New Issue:xxxxxxxxx xxxxxxx xxxxxxxx xxxxxxxxxxxxx xxxxxxxxxx xxxxxxxx=2C =?utf-8?b?dMOkaHRhZWc=?= xx.xx, xxxx\r\n";
         /** @see \Zend\Mail\Header\HeaderWrap::canBeEncoded */
         $v0 = \Zend\Mail\Headers::fromString($header);
-        $folder = "\r\n ";
-        $this->assertEquals("Subject: =?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20?={$folder}=?UTF-8?Q?xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx,=20t=C3=A4htaeg=20xx.xx,=20xxxx?=\r\n", $v0->toString());
+        $folding = Headers::FOLDING;
+        $eol = Headers::EOL;
+
+        $this->assertEquals("Subject: =?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20?={$folding}=?UTF-8?Q?xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx=3D2C=20t=C3=A4htaeg=20?={$folding}=?UTF-8?Q?xx.xx=2C=20xxxx?={$eol}", $v0->toString());
 
         // the above fails with:
         // "iconv_mime_encode(): Unknown error (7)"
@@ -662,11 +664,11 @@ class MailMessageTest extends TestCase
         $v = iconv_mime_encode(
             'x-test', $value, ['scheme' => 'Q', 'line-length' => '76', 'line-break-chars' => ' ']
         );
-        $this->assertEquals('x-test: =?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20?=  =?UTF-8?Q?xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx,=20t=C3=A4htaeg=20xx.xx,?=  =?UTF-8?Q?=20xxxx?=', $v);
+        $this->assertEqualsIgnoringCase('x-test: =?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20?=  =?UTF-8?Q?xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx,=20t=C3=A4htaeg=20xx.xx,?=  =?UTF-8?Q?=20xxxx?=', $v);
 
         // this works too
         $v2 = \Zend\Mail\Header\HeaderWrap::mimeEncodeValue($value, 'UTF-8');
-        $this->assertEquals('=?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx,=20t=C3=A4htaeg=20xx.xx,=20xxxx?=', $v2);
+        $this->assertEquals('=?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx=2C=20t=C3=A4htaeg=20xx.xx=2C=20xxxx?=', $v2);
     }
 
     /**

--- a/tests/data/in-reply-to.txt
+++ b/tests/data/in-reply-to.txt
@@ -14,7 +14,8 @@ References: <CAAaem7eL8Tz0LBqncnX6O+SVBPBXZe+-YFmfdCPfuAFLfjk2YQ@4.example.org>
  <CAAaem7fhEfPyksxO45NKph7VQ=F-4r2KwP2P3hzQB0yT=Z-Okg@4.example.org>
  <55DEC5DF.8030103@3.example.org>
  <CAG5u9y8dtK1-9Dx3uvetcJOENiYM6yT7N0kmiT8kLyQYahnKeA@4.example.org>
- <55DED903.9080304@3.example.org> <55E59719.5010303@3.example.org>
+ <55DED903.9080304@3.example.org>
+ <55E59719.5010303@3.example.org>
  <CAG5u9y9xfjVDL4nb=dGpZG2vpEuUgCTaNbxsVxh_Nd5MLRrJrQ@4.example.org>
  <55E59AF9.7040903@3.example.org>
  <CAG5u9y9384O3zSZcp4DZEkXt5Fjh3Ga+0wvQnKg5CUTpyeFbOw@4.example.org>


### PR DESCRIPTION
Refs: #426

```
Installing dependencies (including require-dev) from lock file
Package operations: 1 install, 6 updates, 1 removal
  - Removing zendframework/zend-servicemanager (2.4.13)
  - Updating zendframework/zend-stdlib (2.4.13 => 3.2.1): Loading from cache
  - Updating zendframework/zend-config (2.4.13 => 3.2.0): Loading from cache
  - Updating zendframework/zend-validator (2.4.13 => 2.11.0): Loading from cache
  - Updating zendframework/zend-mime (2.4.13 => 2.7.1): Loading from cache
  - Updating zendframework/zend-loader (2.4.13 => 2.6.0): Loading from cache
  - Installing true/punycode (v2.1.0): Loading from cache
  - Updating zendframework/zend-mail (dev-develop-2.4 cbabc38 => 2.10.0):  Checking out d7beb63d5f
```

need to ensure the changes present in our 2.4 fork are present upstream:
- https://github.com/eventum/zend-mail/compare/release-2.4.13...develop-2.4?w=1

or if needed cherry-pick the changes into `develop-2.10` branch

cc @balsdorf 