### PR TITLE
Change charset to utf8mb4 of support_email and issue tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,11 @@
 ## [3.8.0]
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
+Eventum 3.8.x requires MySQL server 5.5.3, see #433
 
 - Add index: `support_email`.`sup_message_id` (@glensc, #632)
 - Always enable Markdown rendering (@glensc, #633)
+- Change charset to utf8mb4 of `support_email` and `issue` tables (@glensc, #433)
 
 [3.8.0]: https://github.com/eventum/eventum/compare/v3.7.4...master
 

--- a/db/migrations/20181231121638_eventum_utf8_mb4.php
+++ b/db/migrations/20181231121638_eventum_utf8_mb4.php
@@ -20,6 +20,7 @@ class EventumUtf8Mb4 extends AbstractMigration
 {
     private const MIN_VERSION = '5.5.3';
     private const CHARSET = 'utf8mb4';
+    private const COLLATION = 'utf8mb4_unicode_ci';
 
     public function up(): void
     {
@@ -32,6 +33,7 @@ class EventumUtf8Mb4 extends AbstractMigration
         $config = Setup::get();
         $config['database']['charset_rollback'] = $config['database']['charset'];
         $config['database']['charset'] = self::CHARSET;
+        $config['database']['collation'] = self::COLLATION;
 
         Setup::save();
     }
@@ -44,7 +46,7 @@ class EventumUtf8Mb4 extends AbstractMigration
         }
 
         $config['database']['charset'] = $config['database']['charset_rollback'];
-        unset($config['database']['charset_rollback']);
+        unset($config['database']['charset_rollback'], $config['database']['collation']);
 
         Setup::save();
     }

--- a/db/migrations/20181231121638_eventum_utf8_mb4.php
+++ b/db/migrations/20181231121638_eventum_utf8_mb4.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+/**
+ * Upgrade MySQL charset to utf8mb4
+ */
+class EventumUtf8Mb4 extends AbstractMigration
+{
+    private const MIN_VERSION = '5.5.3';
+    private const CHARSET = 'utf8mb4';
+
+    public function up(): void
+    {
+        $version = $this->getMySqlVersion();
+
+        if (!version_compare($version, self::MIN_VERSION, '>=')) {
+            throw new RuntimeException('Requires MySQL Version >=' . self::MIN_VERSION);
+        }
+
+        $config = Setup::get();
+        $config['database']['charset_rollback'] = $config['database']['charset'];
+        $config['database']['charset'] = self::CHARSET;
+
+        Setup::save();
+    }
+
+    public function down(): void
+    {
+        $config = Setup::get();
+        if (!$config['database']['charset_rollback']) {
+            return;
+        }
+
+        $config['database']['charset'] = $config['database']['charset_rollback'];
+        unset($config['database']['charset_rollback']);
+
+        Setup::save();
+    }
+
+    private function getMySqlVersion(): string
+    {
+        return $this->queryOne('SELECT VERSION()');
+    }
+}

--- a/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
+++ b/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
@@ -20,17 +20,13 @@ class EventumUtf8Mb4Convert extends AbstractMigration
     public function up(): void
     {
         $this->upgradeTables([
-            [
-                'support_email',
-                [
-                    // lower length not to exceed row length
-                    $this->getColumn('support_email', 'sup_from')
-                        ->setLimit(2048),
-                    'sup_to',
-                    'sup_cc',
-                    'sup_subject',
-                ],
-            ],
+            'support_email' => [
+                // lower length not to exceed row length
+                ['sup_from', 2048],
+                'sup_to',
+                'sup_cc',
+                'sup_subject',
+            ]
         ]);
     }
 
@@ -60,13 +56,21 @@ class EventumUtf8Mb4Convert extends AbstractMigration
      */
     private function getUpgradeColumns(array $definitions): Generator
     {
-        foreach ($definitions as [$tableName, $columnNames]) {
+        foreach ($definitions as $tableName => $columnNames) {
             $table = $this->table($tableName);
             $columns = $this->getColumns($table);
 
             foreach ($columnNames as $column) {
+                if (is_array($column)) {
+                    [$column, $limit] = $column;
+                } else {
+                    $limit = null;
+                }
                 if (!$column instanceof Column) {
                     $column = $columns[$column];
+                }
+                if ($limit) {
+                    $column->setLimit($limit);
                 }
                 $column->setEncoding($this->charset);
                 $column->setCollation($this->collation);

--- a/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
+++ b/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
@@ -1,0 +1,36 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumUtf8Mb4Convert extends AbstractMigration
+{
+    public function up(): void
+    {
+        $this->upgradeTable('support_email', ['sup_from', 'sup_to', 'sup_cc', 'sup_subject']);
+    }
+
+    private function upgradeTable($tableName, $columnNames): void
+    {
+        $table = $this->table($tableName);
+        $columns = $this->getColumns($table, $columnNames);
+
+        foreach ($columns as $column) {
+            $column->setEncoding($this->charset);
+            $column->setCollation($this->collation);
+            $table->changeColumn($column->getName(), $column);
+        }
+
+        $table->update();
+    }
+}

--- a/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
+++ b/db/migrations/20181231125822_eventum_utf8_mb4_convert.php
@@ -26,7 +26,11 @@ class EventumUtf8Mb4Convert extends AbstractMigration
                 'sup_to',
                 'sup_cc',
                 'sup_subject',
-            ]
+            ],
+            'issue' => [
+                'iss_summary',
+                'iss_description',
+            ],
         ]);
     }
 
@@ -36,6 +40,7 @@ class EventumUtf8Mb4Convert extends AbstractMigration
         $columns = iterator_to_array($columnsGenerator);
         $progressBar = $this->createProgressBar(count($columns));
         $progressBar->start();
+        $tables = new SplObjectStorage();
 
         /**
          * @var Table $table
@@ -44,6 +49,11 @@ class EventumUtf8Mb4Convert extends AbstractMigration
         foreach ($columns as [$table, $column]) {
             $table->changeColumn($column->getName(), $column);
             $progressBar->advance();
+            $tables->attach($table);
+        }
+
+        foreach ($tables as $table) {
+            $table->save();
         }
 
         $progressBar->setMessage('');

--- a/phinx.php
+++ b/phinx.php
@@ -74,14 +74,8 @@ $phinx = [
             'engine' => 'MyISAM',
 
             // charset and collation must be utf8 compatible
-
-            // for MySQL < 5.5.3
-            'charset' => 'utf8',
-            'collation' => 'utf8_general_ci',
-
-            // for MySQL >= 5.5.3
-//            'charset' => 'utf8mb4',
-//            'collation' => 'utf8mb4_unicode_ci',
+            'charset' => $config['charset'],
+            'collation' => $config['collation'] ?? 'utf8_general_ci',
 
             // set SQL_MODE
             // http://dev.mysql.com/doc/refman/5.7/en/sql-mode.html


### PR DESCRIPTION
NOTE:
- MySQL >= 5.5.3 is required after this PR
- MySQL >= 5.7 is recommended: https://mysqlserverteam.com/mysql-8-0-when-to-use-utf8mb3-over-utf8mb4/
- Requires [`db/migrations/20180520134959_eventum_db_charset_config.php`](https://github.com/eventum/eventum/blob/v3.5.0/db/migrations/20180520134959_eventum_db_charset_config.php) be applied (Eventum `3.5.0`)

Changes:
- [x] config: add db migration to change connection charset to `utf8mb4`
- [x] config: specify `utf8mb4_unicode_ci` collation
- [x] phinx: use `$config['charset']`, `$config['collation']`
- [ ] <del>pdo adapter: use `$config['collation']`</del>
- [ ] <del>doctrine: use `$config['collation']`</del>
- [ ] upgrade columns to `utf8mb4`
  - [x] `support_email`: `sup_from(2048)`, `sup_to`, `sup_cc`, `sup_subject`
  - [x] `issue`: `iss_summary`, `iss_description`
- [ ] test database schema from scratch install (we changed columns, so tables and database should stay at `utf8`)
- [x] fix php 5.6 compat or update depdendency: `foreach ($columns as [$table, $column]) {`
- [x] require phinx 0.10 for batch updates: https://github.com/eventum/eventum/pull/433#issuecomment-450650122
- [ ] setup: use `utf8mb4` in adapter config
- [ ] test phinx integration
- [ ] setup: cleanup: `$enable_fulltext = $matches[1] > '4.0.23'`

# additional reading
- https://mathiasbynens.be/notes/mysql-utf8mb4
- https://kittmedia.com/2017/running-gitlab-with-utf8mb4-and-mysql-5-5-and-5-6/

cc @balsdorf 