### PR TITLE
Detect invalid mail header starting with "From " (issue #427) and a testcase

### DIFF
--- a/src/Mail/Helper/MailLoader.php
+++ b/src/Mail/Helper/MailLoader.php
@@ -118,6 +118,11 @@ class MailLoader
                     $line = str_replace("\r", '', $line);
                 }
 
+                if ($e->getMessage() === 'Invalid header name detected' && substr($line, 0, 5) === 'From ') {
+                    // remove Mbox header from message if it is present
+                    $line = "X-Broken-Header-Mbox: $line";
+                }
+
                 list($name, $value) = Header\GenericHeader::splitHeaderLine($line);
             }
 

--- a/tests/Mail/LoadEmailTest.php
+++ b/tests/Mail/LoadEmailTest.php
@@ -52,4 +52,11 @@ class LoadEmailTest extends TestCase
         $headers = $mail->getHeaders();
         $this->assertTrue($headers->has('X-Broken-Header-Sender'));
     }
+
+    public function testLoadOddMboxHeader()
+    {
+        $raw = $this->readDataFile('from_nocolon.txt');
+        $mail = MailMessage::createFromString($raw);
+        $this->assertTrue($mail->getHeaders()->has('X-Broken-Header-Mbox'));
+    }
 }


### PR DESCRIPTION
Email viewer (view_email.php) fails with an exception "Invalid header name detected"
if a stored raw email starts with a Mbox line "From name@example.com .." which is
not a correct mail header.

This PR includes a testcase.