### PR TITLE
Allow auth adapters to be chained

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ first, also the PHP version required is 7.1, see [#426].
 - Drop outdated PEAR packages (@glensc, #443)
 - Add `SystemEvents::NOTIFICATION_NOTIFY_ADDRESS` event handling (@glensc, #438)
 - TextMessage: do not parse subparts if no content-type given (@glensc, #452)
+- Allow auth adapters to be chained (@glensc, #441)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/config/config.dist.php
+++ b/config/config.dist.php
@@ -63,9 +63,6 @@ define('APP_SYSTEM_USER_ID', 1);
 define('APP_ENABLE_FULLTEXT', '%{APP_ENABLE_FULLTEXT}%');
 define('APP_FULLTEXT_SEARCH_CLASS', 'mysql_fulltext_search');
 
-// auth backend. 'Mysql_Auth_Backend' (default), 'LDAP_Auth_Backend' for LDAP
-//define('APP_AUTH_BACKEND', 'LDAP_Auth_Backend');
-
 // 'native' or 'php'. Try native first, if you experience strange issues
 // such as language switching randomly, try php
 define('APP_GETTEXT_MODE', 'native');

--- a/db/migrations/20170428180919_eventum_initial_data.php
+++ b/db/migrations/20170428180919_eventum_initial_data.php
@@ -11,6 +11,7 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Auth\PasswordHash;
 use Eventum\Db\AbstractMigration;
 
 class EventumInitialData extends AbstractMigration
@@ -639,7 +640,7 @@ class EventumInitialData extends AbstractMigration
                 'Admin User',
                 'admin@example.com',
                 // TODO: issue for changing this: https://github.com/eventum/eventum/issues/138
-                AuthPassword::hash('admin'),
+                PasswordHash::hash('admin'),
                 'active',
             ],
 

--- a/db/migrations/20190115211455_eventum_auth_adapter_setup.php
+++ b/db/migrations/20190115211455_eventum_auth_adapter_setup.php
@@ -1,0 +1,51 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Auth\Adapter;
+use Eventum\Db\AbstractMigration;
+
+class EventumAuthAdapterSetup extends AbstractMigration
+{
+    const DEFAULT_ADAPTER = Adapter\MysqlAdapter::class;
+    const CLASS_MAPPING = [
+        'mysql_auth_backend' => Adapter\MysqlAdapter::class,
+        'ldap_auth_backend' => Adapter\LdapAdapter::class,
+        'cas_auth_backend' => Adapter\CasAdapter::class,
+    ];
+
+    public function up()
+    {
+        $this->setupAuthAdapter();
+    }
+
+    private function setupAuthAdapter()
+    {
+        $setup = Setup::get();
+        $className = $this->getClassName();
+        $reflection = new ReflectionClass($className);
+        $setup['auth'][$reflection->getName()] = $reflection->getFileName();
+        Setup::save();
+    }
+
+    private function getClassName()
+    {
+        $class = self::DEFAULT_ADAPTER;
+        if (!defined('APP_AUTH_BACKEND')) {
+            return $class;
+        }
+
+        $class = strtolower(APP_AUTH_BACKEND);
+
+        return self::CLASS_MAPPING[$class] ?? self::DEFAULT_ADAPTER;
+    }
+}

--- a/db/migrations/20190115211455_eventum_auth_adapter_setup.php
+++ b/db/migrations/20190115211455_eventum_auth_adapter_setup.php
@@ -16,8 +16,8 @@ use Eventum\Db\AbstractMigration;
 
 class EventumAuthAdapterSetup extends AbstractMigration
 {
-    const DEFAULT_ADAPTER = Adapter\MysqlAdapter::class;
-    const CLASS_MAPPING = [
+    private const DEFAULT_ADAPTER = Adapter\Factory::DEFAULT_ADAPTER;
+    private const CLASS_MAPPING = [
         'mysql_auth_backend' => Adapter\MysqlAdapter::class,
         'ldap_auth_backend' => Adapter\ChainAdapter::class,
         'cas_auth_backend' => Adapter\CasAdapter::class,

--- a/db/migrations/20190115211455_eventum_auth_adapter_setup.php
+++ b/db/migrations/20190115211455_eventum_auth_adapter_setup.php
@@ -34,6 +34,10 @@ class EventumAuthAdapterSetup extends AbstractMigration
         $this->setupAuthAdapter();
     }
 
+    public function down()
+    {
+    }
+
     private function setupAuthAdapter(): void
     {
         $setup = Setup::get();

--- a/htdocs/manage/auth.php
+++ b/htdocs/manage/auth.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+require_once __DIR__ . '/../../init.php';
+
+$controller = new Eventum\Controller\Manage\AuthController();
+$controller->run();

--- a/init.php
+++ b/init.php
@@ -61,9 +61,6 @@ $define('APP_ANON_USER', '');
 $define('APP_ENABLE_FULLTEXT', false);
 $define('APP_FULLTEXT_SEARCH_CLASS', 'MySQL_Fulltext_Search');
 
-$define('APP_AUTH_BACKEND', 'Mysql_Auth_Backend');
-
-$define('APP_AUTH_BACKEND_ALLOW_FALLBACK', false);
 $define('APP_DEFAULT_ASSIGNED_EMAILS', 1);
 $define('APP_DEFAULT_NEW_EMAILS', 0);
 $define('APP_DEFAULT_COPY_OF_OWN_ACTION', 0);

--- a/lib/eventum/auth/APIAuthToken.php
+++ b/lib/eventum/auth/APIAuthToken.php
@@ -11,6 +11,7 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Auth\AuthException;
 use Eventum\Db\DatabaseException;
 
 class APIAuthToken

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -11,6 +11,8 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Auth\Adapter\AdapterInterface;
+use Eventum\Auth\Adapter\MysqlAdapter;
 use Eventum\Monolog\Logger;
 use Eventum\Session;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -482,21 +484,21 @@ class Auth
     }
 
     /**
-     * @return Auth_Backend_Interface
+     * @return AdapterInterface
      */
     public static function getAuthBackend()
     {
-        /** @var Auth_Backend_Interface $instance */
+        /** @var AdapterInterface $instance */
         static $instance = false;
 
-        if ($instance == false) {
+        if ($instance === false) {
             $class = APP_AUTH_BACKEND;
 
             // legacy: allow lowercase variants
-            if (strtolower($class) == 'mysql_auth_backend') {
-                $class = 'Mysql_Auth_Backend';
-            } elseif (strtolower($class) == 'ldap_auth_backend') {
-                $class = 'LDAP_Auth_Backend';
+            if (strtolower($class) == 'Eventum\Auth\Adapter\MysqlAdapter') {
+                $class = 'Eventum\Auth\Adapter\MysqlAdapter';
+            } elseif (strtolower($class) == 'Eventum\Auth\Adapter\LdapAdapter') {
+                $class = 'Eventum\Auth\Adapter\LdapAdapter';
             }
 
             try {
@@ -524,14 +526,14 @@ class Auth
      * Returns an instance of the MySQL Auth Backend.
      * This is used when the primary backend is not handling the user.
      *
-     * @return Auth_Backend_Interface
+     * @return AdapterInterface
      */
     public static function getFallBackAuthBackend()
     {
         static $instance;
 
         if (!$instance) {
-            $instance = new Mysql_Auth_Backend();
+            $instance = new MysqlAdapter();
         }
 
         return $instance;

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -483,10 +483,7 @@ class Auth
         }
     }
 
-    /**
-     * @return AdapterInterface
-     */
-    public static function getAuthBackend()
+    public static function getAuthBackend(): AdapterInterface
     {
         /** @var AdapterInterface $adapter */
         static $adapter = false;

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -12,6 +12,7 @@
  */
 
 use Eventum\Auth\Adapter\AdapterInterface;
+use Eventum\Auth\AuthException;
 use Eventum\Monolog\Logger;
 use Eventum\Session;
 use Symfony\Component\Filesystem\Exception\IOException;

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -12,7 +12,6 @@
  */
 
 use Eventum\Auth\Adapter\AdapterInterface;
-use Eventum\Auth\Adapter\MysqlAdapter;
 use Eventum\Monolog\Logger;
 use Eventum\Session;
 use Symfony\Component\Filesystem\Exception\IOException;
@@ -390,7 +389,7 @@ class Auth
         $usr_id = self::getUserID();
         $projects = Project::getAssocList($usr_id);
         if ($usr_id == APP_SYSTEM_USER_ID) {
-            return isset($cookie['prj_id']) ? (int) $cookie['prj_id'] : null;
+            return isset($cookie['prj_id']) ? (int)$cookie['prj_id'] : null;
         }
 
         if ($projects != null && !in_array($cookie['prj_id'], array_keys($projects))) {
@@ -466,9 +465,9 @@ class Auth
     /**
      * Sets a cookie in the browser
      *
-     * @param   string  $name The name of the cookie
-     * @param   string  $value The value of the cookie
-     * @param   string  $expiration The expiration data of the cookie
+     * @param   string $name The name of the cookie
+     * @param   string $value The value of the cookie
+     * @param   string $expiration The expiration data of the cookie
      */
     public static function setCookie($name, $value, $expiration)
     {
@@ -506,23 +505,6 @@ class Auth
         }
 
         return $adapter;
-    }
-
-    /**
-     * Returns an instance of the MySQL Auth Backend.
-     * This is used when the primary backend is not handling the user.
-     *
-     * @return AdapterInterface
-     */
-    public static function getFallBackAuthBackend()
-    {
-        static $instance;
-
-        if (!$instance) {
-            $instance = new MysqlAdapter();
-        }
-
-        return $instance;
     }
 
     /**

--- a/src/Auth/Adapter/AdapterInterface.php
+++ b/src/Auth/Adapter/AdapterInterface.php
@@ -11,10 +11,12 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth\Adapter;
+
 /**
  * Auth Backend Interface
  */
-interface Auth_Backend_Interface
+interface AdapterInterface
 {
     /**
      * Checks whether the provided password match against the login or email

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -15,7 +15,7 @@ namespace Eventum\Auth\Adapter;
 
 use Auth;
 use AuthCookie;
-use AuthException;
+use Eventum\Auth\AuthException;
 use Misc;
 use phpCAS;
 use Setup;

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -11,6 +11,16 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth\Adapter;
+
+use Auth;
+use AuthCookie;
+use AuthException;
+use Misc;
+use phpCAS;
+use Setup;
+use User;
+
 /**
  * This auth backend integrates with a CAS server
  *
@@ -21,7 +31,7 @@
  * then fill in the CAS server details config/cas.php. An example config file is
  * in docs/examples/config/cas.php
  */
-class CAS_Auth_Backend implements Auth_Backend_Interface
+class CasAdapter implements AdapterInterface
 {
     protected $client;
 

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -31,6 +31,8 @@ use User;
  */
 class CasAdapter implements AdapterInterface
 {
+    public const displayName = 'CAS authentication adapter';
+
     protected $client;
 
     public function __construct()

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -27,9 +27,7 @@ use User;
  * This backend will look for users in the default mysql backend if no CAS
  * user is found. This behaviour may be configurable in the future.
  *
- * Set define('APP_AUTH_BACKEND', 'CAS_Auth_Backend') in the config file and
- * then fill in the CAS server details config/cas.php. An example config file is
- * in docs/examples/config/cas.php
+ * An example config file is in docs/examples/config/cas.php
  */
 class CasAdapter implements AdapterInterface
 {

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -16,14 +16,16 @@ namespace Eventum\Auth\Adapter;
 class ChainAdapter implements AdapterInterface
 {
     /** @var AdapterInterface[] */
-    private $adapters;
+    private $adapters = [];
 
     /**
      * @param AdapterInterface[] $adapters
      */
     public function __construct(array $adapters = [])
     {
-        $this->adapters = $adapters;
+        foreach ($adapters as $adapterName) {
+            $this->adapters[] = Factory::create(['adapter' => $adapterName]);
+        }
     }
 
     /**

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -15,6 +15,8 @@ namespace Eventum\Auth\Adapter;
 
 class ChainAdapter implements AdapterInterface
 {
+    public const displayName = 'Chained authentication adapter';
+
     /** @var AdapterInterface[] */
     private $adapters = [];
 

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -1,0 +1,224 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Auth\Adapter;
+
+class ChainAdapter implements AdapterInterface
+{
+    /** @var AdapterInterface[] */
+    private $adapters;
+
+    /**
+     * @param AdapterInterface[] $adapters
+     */
+    public function __construct(array $adapters = [])
+    {
+        $this->adapters = $adapters;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function verifyPassword($login, $password)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->verifyPassword($login, $password)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function updatePassword($usr_id, $password)
+    {
+        $result = false;
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->updatePassword($usr_id, $password)) {
+                $result = true;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function userExists($login)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->userExists($login)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getUserIDByLogin($login)
+    {
+        foreach ($this->adapters as $adapter) {
+            $usr_id = $adapter->getUserIDByLogin($login);
+            if ($usr_id !== null) {
+                return $usr_id;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canUserUpdateName($usr_id)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->canUserUpdateName($usr_id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canUserUpdateEmail($usr_id)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->canUserUpdateEmail($usr_id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function canUserUpdatePassword($usr_id)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->canUserUpdatePassword($usr_id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function incrementFailedLogins($usr_id)
+    {
+        $result = false;
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->incrementFailedLogins($usr_id)) {
+                $result = true;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function resetFailedLogins($usr_id)
+    {
+        $result = false;
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->resetFailedLogins($usr_id)) {
+                $result = true;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function isUserBackOffLocked($usr_id)
+    {
+        foreach ($this->adapters as $adapter) {
+            if ($adapter->isUserBackOffLocked($usr_id)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getExternalLoginURL()
+    {
+        foreach ($this->adapters as $adapter) {
+            $url = $adapter->getExternalLoginURL();
+            if ($url) {
+                return $url;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function autoRedirectToExternalLogin()
+    {
+        foreach ($this->adapters as $adapter) {
+            $redirect = $adapter->autoRedirectToExternalLogin();
+            if ($redirect !== null) {
+                return $redirect;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function checkAuthentication()
+    {
+        foreach ($this->adapters as $adapter) {
+            $adapter->checkAuthentication();
+        }
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function logout()
+    {
+        foreach ($this->adapters as $adapter) {
+            $adapter->logout();
+        }
+
+        return null;
+    }
+}

--- a/src/Auth/Adapter/Factory.php
+++ b/src/Auth/Adapter/Factory.php
@@ -41,12 +41,32 @@ abstract class Factory
         }
 
         $className = $spec['adapter'] ?? self::DEFAULT_ADAPTER;
-        $arguments = $spec['arguments'] ?? [];
+        $arguments = $spec['options'][$className] ?? [];
         $reflection = new ReflectionClass($className);
 
         /** @var AdapterInterface $adapter */
         $adapter = $reflection->newInstanceArgs($arguments);
 
         return $adapter;
+    }
+
+    /**
+     * Return list of possible adapters with their default options.
+     *
+     * @return array
+     */
+    public static function getAdapterList(): array
+    {
+        return [
+            MysqlAdapter::class => [],
+            LdapAdapter::class => [],
+            CasAdapter::class => [],
+            ChainAdapter::class => [
+                [
+                    MysqlAdapter::class,
+                    LdapAdapter::class,
+                ],
+            ],
+        ];
     }
 }

--- a/src/Auth/Adapter/Factory.php
+++ b/src/Auth/Adapter/Factory.php
@@ -1,0 +1,52 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Auth\Adapter;
+
+use InvalidArgumentException;
+use ReflectionClass;
+use Traversable;
+use Zend\Stdlib\ArrayUtils;
+
+abstract class Factory
+{
+    public const DEFAULT_ADAPTER = MysqlAdapter::class;
+
+    /**
+     * @param array $spec
+     * @return AdapterInterface
+     */
+    public static function create($spec = [])
+    {
+        if ($spec instanceof Traversable) {
+            $spec = ArrayUtils::iteratorToArray($spec);
+        }
+
+        if (!is_array($spec)) {
+            throw new InvalidArgumentException(sprintf(
+                '%s expects an array or Traversable argument; received "%s"',
+                __METHOD__,
+                (is_object($spec) ? get_class($spec) : gettype($spec))
+            ));
+        }
+
+        $className = $spec['adapter'] ?? self::DEFAULT_ADAPTER;
+        $arguments = $spec['arguments'] ?? [];
+        $reflection = new ReflectionClass($className);
+
+        /** @var AdapterInterface $adapter */
+        $adapter = $reflection->newInstanceArgs($arguments);
+
+        return $adapter;
+    }
+}

--- a/src/Auth/Adapter/Factory.php
+++ b/src/Auth/Adapter/Factory.php
@@ -26,7 +26,7 @@ abstract class Factory
      * @param array $spec
      * @return AdapterInterface
      */
-    public static function create($spec = [])
+    public static function create($spec = []): AdapterInterface
     {
         if ($spec instanceof Traversable) {
             $spec = ArrayUtils::iteratorToArray($spec);

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -413,13 +413,13 @@ class LdapAdapter implements AdapterInterface
     {
         // check if this is an ldap or internal
         $usr_id = $this->getUserIDByLogin($login);
-        $local_user_info = User::getDetails($usr_id);
-        $usr_external_id = $local_user_info['usr_external_id'] ?? null;
-        if (!$usr_external_id) {
+        $external_id = User::getExternalID($usr_id) ?? null;
+
+        if (!$external_id) {
             return false;
         }
 
-        return $this->validatePassword($usr_external_id, $password);
+        return $this->validatePassword($external_id, $password);
     }
 
     /**

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -449,33 +449,6 @@ class LdapAdapter implements AdapterInterface
     }
 
     /**
-     * Method used to get the system-wide defaults.
-     *
-     * @return array of the default parameters
-     */
-    public static function getDefaults()
-    {
-        // to avoid dead-loop,
-        // don't do anything complex here that would require loading setup
-        return [
-            'host' => 'localhost',
-            'port' => '389',
-            'binddn' => '',
-            'bindpw' => '',
-            'basedn' => 'dc=example,dc=org',
-            'user_id_attribute' => '',
-            'userdn' => 'uid=%UID%,ou=People,dc=example,dc=org',
-            'customer_id_attribute' => '',
-            'contact_id_attribute' => '',
-            'user_filter' => '',
-            'create_users' => null,
-            'active_dn' => 'ou=People,dc=example,dc=org',
-            'inactive_dn' => 'ou=Inactive Accounts,dc=example,dc=org',
-            'default_role' => [],
-        ];
-    }
-
-    /**
      * {@inheritdoc}
      */
     public function updatePassword($usr_id, $password)

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -11,10 +11,16 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth\Adapter;
+
+use Auth;
+use AuthException;
 use Eventum\Auth\Ldap\LdapConnection;
 use Eventum\Auth\Ldap\UserEntry;
 use Eventum\Monolog\Logger;
+use Setup;
 use Symfony\Component\Ldap\Entry;
+use User;
 
 /**
  * This auth backend integrates with an LDAP server and if set to, will create
@@ -27,7 +33,7 @@ use Symfony\Component\Ldap\Entry;
  * Set define('APP_AUTH_BACKEND', 'LDAP_Auth_Backend') in the config file and
  * then fill in the LDAP server details in manage
  */
-class LDAP_Auth_Backend implements Auth_Backend_Interface
+class LdapAdapter implements AdapterInterface
 {
     /** @var bool */
     public $create_users;

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -29,6 +29,8 @@ use User;
  */
 class LdapAdapter implements AdapterInterface
 {
+    public const displayName = 'LDAP authentication adapter';
+
     /** @var bool */
     public $create_users;
 

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -14,7 +14,7 @@
 namespace Eventum\Auth\Adapter;
 
 use Auth;
-use AuthException;
+use Eventum\Auth\AuthException;
 use Eventum\Auth\Ldap\LdapConnection;
 use Eventum\Auth\Ldap\UserEntry;
 use Eventum\Monolog\Logger;

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -65,14 +65,12 @@ class LdapAdapter implements AdapterInterface
      */
     public function __construct()
     {
+        $config = Setup::get()['ldap'];
         $this->logger = Logger::auth();
-        $this->ldap = new LdapConnection(Setup::get()['ldap']);
-
-        $setup = Setup::get()['ldap'];
-
-        $this->active_dn = $setup['active_dn'];
-        $this->inactive_dn = $setup['inactive_dn'];
-        $this->create_users = (bool)$setup['create_users'];
+        $this->ldap = new LdapConnection($config);
+        $this->active_dn = $config['active_dn'];
+        $this->inactive_dn = $config['inactive_dn'];
+        $this->create_users = (bool)$config['create_users'];
     }
 
     /**

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -26,12 +26,6 @@ use User;
  * This auth backend integrates with an LDAP server and if set to, will create
  * a local user with the specified name and email. The user will be
  * authenticated against the LDAP server on each login.
- *
- * This backend will look for users in the default mysql backend if no LDAP
- * user is found. This behaviour may be configurable in the future.
- *
- * Set define('APP_AUTH_BACKEND', 'LDAP_Auth_Backend') in the config file and
- * then fill in the LDAP server details in manage
  */
 class LdapAdapter implements AdapterInterface
 {
@@ -71,6 +65,10 @@ class LdapAdapter implements AdapterInterface
         $this->active_dn = $config['active_dn'];
         $this->inactive_dn = $config['inactive_dn'];
         $this->create_users = (bool)$config['create_users'];
+
+        if (!$this->active_dn || !$this->inactive_dn) {
+            throw new AuthException('LDAP Adapter not configured');
+        }
     }
 
     /**

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -11,12 +11,17 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth\Adapter;
+
+use AuthPassword;
+use DB_Helper;
 use Eventum\Db\DatabaseException;
+use User;
 
 /**
  * MySQL (builtin) auth backend
  */
-class Mysql_Auth_Backend implements Auth_Backend_Interface
+class MysqlAdapter implements AdapterInterface
 {
     /**
      * Checks whether the provided password match against the email

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -23,6 +23,8 @@ use User;
  */
 class MysqlAdapter implements AdapterInterface
 {
+    public const displayName = 'MySQL builtin authentication adapter';
+
     /**
      * Checks whether the provided password match against the email
      * address provided.

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -13,8 +13,8 @@
 
 namespace Eventum\Auth\Adapter;
 
-use AuthPassword;
 use DB_Helper;
+use Eventum\Auth\PasswordHash;
 use Eventum\Db\DatabaseException;
 use User;
 
@@ -37,7 +37,7 @@ class MysqlAdapter implements AdapterInterface
         $user = User::getDetails($usr_id);
         $hash = $user['usr_password'];
 
-        if (!AuthPassword::verify($password, $hash)) {
+        if (!PasswordHash::verify($password, $hash)) {
             $this->incrementFailedLogins($usr_id);
 
             return false;
@@ -47,7 +47,7 @@ class MysqlAdapter implements AdapterInterface
 
         // check if hash needs rehashing,
         // old md5 or more secure default
-        if (AuthPassword::needs_rehash($hash)) {
+        if (PasswordHash::needs_rehash($hash)) {
             $this->updatePassword($usr_id, $password);
         }
 
@@ -69,7 +69,7 @@ class MysqlAdapter implements AdapterInterface
                     usr_password=?
                  WHERE
                     usr_id=?';
-        $params = [AuthPassword::hash($password), $usr_id];
+        $params = [PasswordHash::hash($password), $usr_id];
         try {
             DB_Helper::getInstance()->query($stmt, $params);
         } catch (DatabaseException $e) {

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -38,17 +38,17 @@ class MysqlAdapter implements AdapterInterface
         $hash = $user['usr_password'];
 
         if (!AuthPassword::verify($password, $hash)) {
-            self::incrementFailedLogins($usr_id);
+            $this->incrementFailedLogins($usr_id);
 
             return false;
         }
 
-        self::resetFailedLogins($usr_id);
+        $this->resetFailedLogins($usr_id);
 
         // check if hash needs rehashing,
         // old md5 or more secure default
         if (AuthPassword::needs_rehash($hash)) {
-            self::updatePassword($usr_id, $password);
+            $this->updatePassword($usr_id, $password);
         }
 
         return true;

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -36,6 +36,10 @@ class MysqlAdapter implements AdapterInterface
     public function verifyPassword($login, $password)
     {
         $usr_id = User::getUserIDByEmail($login, true);
+        if (!$usr_id) {
+            return false;
+        }
+
         $user = User::getDetails($usr_id);
         $hash = $user['usr_password'];
 

--- a/src/Auth/AuthException.php
+++ b/src/Auth/AuthException.php
@@ -11,6 +11,10 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth;
+
+use RuntimeException;
+
 class AuthException extends RuntimeException
 {
 }

--- a/src/Auth/Ldap/LdapConnection.php
+++ b/src/Auth/Ldap/LdapConnection.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Auth\Ldap;
 
-use AuthException;
+use Eventum\Auth\AuthException;
 use Symfony\Component\Ldap\Adapter\CollectionInterface;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Adapter;
 use Symfony\Component\Ldap\Adapter\ExtLdap\Collection;
@@ -134,7 +134,7 @@ class LdapConnection
      * @param string $dn
      * @param string $filter
      * @param array $options
-     * @throws AuthException
+     * @throws \Eventum\Auth\AuthException
      * @return Entry|null
      */
     private function searchOne($dn, $filter, array $options = [])

--- a/src/Auth/PasswordHash.php
+++ b/src/Auth/PasswordHash.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Auth;
 
-use InvalidArgumentException;
 use RuntimeException;
 
 /**
@@ -30,7 +29,7 @@ class PasswordHash
      * @throws RuntimeException
      * @return string the hashed password, throws on error
      */
-    public static function hash($password): string
+    public static function hash(string $password): string
     {
         $res = password_hash($password, self::HASH_ALGO);
         if (!$res) {
@@ -43,18 +42,12 @@ class PasswordHash
     /**
      * Verify a password against a hash using a timing attack resistant approach
      *
-     * @param string $hash The hash to verify against
      * @param string $password The password to verify
-     * @throws InvalidArgumentException in case non-strings were passed as hash or password
+     * @param string $hash The hash to verify against
      * @return bool If the password matches the hash
      */
-    public static function verify($password, $hash): bool
+    public static function verify(string $password, string $hash): bool
     {
-        if (!is_string($password) || !is_string($hash)) {
-            throw new InvalidArgumentException('password and hash need to be strings');
-        }
-
-        // verify passwords in constant time, i.e always do all checks
         return password_verify($password, $hash);
     }
 
@@ -66,7 +59,7 @@ class PasswordHash
      * @param string $hash The hash to test
      * @return bool true if the password needs to be rehashed
      */
-    public static function needs_rehash($hash): bool
+    public static function needs_rehash(string $hash): bool
     {
         return password_needs_rehash($hash, self::HASH_ALGO);
     }

--- a/src/Auth/PasswordHash.php
+++ b/src/Auth/PasswordHash.php
@@ -11,12 +11,17 @@
  * that were distributed with this source code.
  */
 
+namespace Eventum\Auth;
+
+use InvalidArgumentException;
+use RuntimeException;
+
 /**
  * Class dealing with user passwords
  */
-class AuthPassword
+class PasswordHash
 {
-    const HASH_ALGO = PASSWORD_DEFAULT;
+    private const HASH_ALGO = PASSWORD_DEFAULT;
 
     /**
      * Hash the password
@@ -25,7 +30,7 @@ class AuthPassword
      * @throws RuntimeException
      * @return string the hashed password, throws on error
      */
-    public static function hash($password)
+    public static function hash($password): string
     {
         $res = password_hash($password, self::HASH_ALGO);
         if (!$res) {
@@ -43,7 +48,7 @@ class AuthPassword
      * @throws InvalidArgumentException in case non-strings were passed as hash or password
      * @return bool If the password matches the hash
      */
-    public static function verify($password, $hash)
+    public static function verify($password, $hash): bool
     {
         if (!is_string($password) || !is_string($hash)) {
             throw new InvalidArgumentException('password and hash need to be strings');
@@ -61,7 +66,7 @@ class AuthPassword
      * @param string $hash The hash to test
      * @return bool true if the password needs to be rehashed
      */
-    public static function needs_rehash($hash)
+    public static function needs_rehash($hash): bool
     {
         return password_needs_rehash($hash, self::HASH_ALGO);
     }

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -14,9 +14,9 @@
 namespace Eventum\Console\Command;
 
 use AuthException;
+use Eventum\Auth\Adapter\LdapAdapter;
 use Eventum\Auth\Ldap\UserEntry;
 use InvalidArgumentException;
-use LDAP_Auth_Backend;
 use RuntimeException;
 use Symfony\Component\Console\Output\OutputInterface;
 
@@ -25,7 +25,7 @@ class LdapSyncCommand extends Command
     const DEFAULT_COMMAND = 'ldap:sync';
     const USAGE = self::DEFAULT_COMMAND . ' [--dry-run] [--create-users] [--no-update] [--no-disable]';
 
-    /** @var LDAP_Auth_Backend */
+    /** @var LdapAdapter */
     private $ldap;
 
     /** @var bool */
@@ -37,7 +37,7 @@ class LdapSyncCommand extends Command
         $this->output = $output;
         $this->dryrun = $dryrun;
 
-        $this->ldap = new LDAP_Auth_Backend();
+        $this->ldap = new LdapAdapter();
         $this->ldap->create_users = $createUsers;
         $this->updateUsers(!$noUpdate);
         $this->disableUsers(!$noDisable);
@@ -172,7 +172,7 @@ class LdapSyncCommand extends Command
 
     private function assertLdapAuthEnabled()
     {
-        if (strtolower(APP_AUTH_BACKEND) !== 'ldap_auth_backend') {
+        if (strtolower(APP_AUTH_BACKEND) !== 'Eventum\Auth\Adapter\LdapAdapter') {
             throw new RuntimeException('You should enable and configure LDAP backend first');
         }
     }

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -13,8 +13,8 @@
 
 namespace Eventum\Console\Command;
 
-use AuthException;
 use Eventum\Auth\Adapter\LdapAdapter;
+use Eventum\Auth\AuthException;
 use Eventum\Auth\Ldap\UserEntry;
 use InvalidArgumentException;
 use RuntimeException;

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -33,12 +33,12 @@ class LdapSyncCommand extends Command
 
     public function execute(OutputInterface $output, $dryrun = false, $createUsers, $noUpdate, $noDisable)
     {
-        $this->assertLdapAuthEnabled();
         $this->output = $output;
         $this->dryrun = $dryrun;
 
         $this->ldap = new LdapAdapter();
         $this->ldap->create_users = $createUsers;
+
         $this->updateUsers(!$noUpdate);
         $this->disableUsers(!$noDisable);
     }
@@ -167,13 +167,6 @@ class LdapSyncCommand extends Command
         $res = $this->ldap->disableAccount($uid);
         if ($res !== true) {
             throw new RuntimeException("Account disable for $uid ($dn) failed");
-        }
-    }
-
-    private function assertLdapAuthEnabled()
-    {
-        if (strtolower(APP_AUTH_BACKEND) !== 'Eventum\Auth\Adapter\LdapAdapter') {
-            throw new RuntimeException('You should enable and configure LDAP backend first');
         }
     }
 }

--- a/src/Controller/Manage/AuthController.php
+++ b/src/Controller/Manage/AuthController.php
@@ -1,0 +1,118 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Controller\Manage;
+
+use Eventum\Auth\Adapter\Factory;
+use Eventum\Auth\AuthException;
+use ReflectionClass;
+use Setup;
+use User;
+
+class AuthController extends ManageBaseController
+{
+    /** @var string */
+    protected $tpl_name = 'manage/auth.tpl.html';
+
+    /** @var int */
+    protected $min_role = User::ROLE_ADMINISTRATOR;
+
+    /** @var string */
+    private $cat;
+
+    /** @var array */
+    private $config;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function configure(): void
+    {
+        $request = $this->getRequest();
+        $this->cat = $request->request->get('cat') ?: $request->query->get('cat');
+        $this->config = $this->getAuthAdapterConfig();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function defaultAction(): void
+    {
+        if ($this->cat === 'update') {
+            $this->updateAction();
+        }
+    }
+
+    private function updateAction(): void
+    {
+        $post = $this->getRequest()->request;
+        $config = Setup::get()['auth'];
+
+        $adapter = $post->get('adapter');
+        /* NOTYET
+        $options = $post->get('options');
+        */
+        $options = $this->config['options'][$adapter];
+
+        $config['adapter'] = $adapter;
+        $config['options'][$adapter] = $options ?: null;
+
+        try {
+            // validate the setup before saving
+            Factory::create($config);
+        } catch (AuthException $e) {
+            $this->error('Invalid authentication configuration: ' . $e->getMessage());
+        }
+
+        Setup::save();
+        $this->messages->addInfoMessage(ev_gettext('Authentication configuration updated'));
+        $this->redirect('auth.php');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function prepareTemplate(): void
+    {
+        $this->tpl->assign(
+            [
+                'adapters' => $this->config['list'],
+                'adapter' => $this->config['default'],
+                'options' => $this->config['options'],
+            ]
+        );
+    }
+
+    private function getAuthAdapterConfig(): array
+    {
+        /** @var \Zend\Config\Config $config */
+        $config = Setup::get()['auth'];
+        $configOptions = $config['options']->toArray();
+        $adapters = [];
+        $options = [];
+
+        $adapterList = Factory::getAdapterList();
+        foreach ($adapterList as $adapterClass => $defaultOptions) {
+            $reflection = new ReflectionClass($adapterClass);
+            $displayName = $reflection->getConstant('displayName');
+            $adapters[$adapterClass] = $displayName;
+            $options[$adapterClass] = $configOptions[$adapterClass] ?? $defaultOptions;
+        }
+
+        return [
+            'default' => $config['adapter'],
+            'list' => $adapters,
+            'options' => $options,
+        ];
+    }
+}

--- a/src/Controller/Manage/LdapController.php
+++ b/src/Controller/Manage/LdapController.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Controller\Manage;
 
-use Eventum\Auth\Adapter\LdapAdapter;
 use Eventum\Controller\Helper\MessagesHelper;
 use Project;
 use Setup;
@@ -111,7 +110,7 @@ class LdapController extends ManageBaseController
      */
     protected function prepareTemplate()
     {
-        $setup = Setup::setDefaults('ldap', LdapAdapter::getDefaults());
+        $setup = Setup::setDefaults('ldap', $this->getDefaults());
 
         $this->tpl->assign(
             [
@@ -121,5 +120,30 @@ class LdapController extends ManageBaseController
                 'user_roles' => User::getRoles([User::ROLE_CUSTOMER]),
             ]
         );
+    }
+
+    /**
+     * Method used to get the system-wide defaults.
+     *
+     * @return array of the default parameters
+     */
+    public function getDefaults()
+    {
+        return [
+            'host' => 'localhost',
+            'port' => '389',
+            'binddn' => '',
+            'bindpw' => '',
+            'basedn' => 'dc=example,dc=org',
+            'user_id_attribute' => '',
+            'userdn' => 'uid=%UID%,ou=People,dc=example,dc=org',
+            'customer_id_attribute' => '',
+            'contact_id_attribute' => '',
+            'user_filter' => '',
+            'create_users' => null,
+            'active_dn' => 'ou=People,dc=example,dc=org',
+            'inactive_dn' => 'ou=Inactive Accounts,dc=example,dc=org',
+            'default_role' => [],
+        ];
     }
 }

--- a/src/Controller/Manage/LdapController.php
+++ b/src/Controller/Manage/LdapController.php
@@ -13,8 +13,8 @@
 
 namespace Eventum\Controller\Manage;
 
+use Eventum\Auth\Adapter\LdapAdapter;
 use Eventum\Controller\Helper\MessagesHelper;
-use LDAP_Auth_Backend;
 use Project;
 use Setup;
 use User;
@@ -111,7 +111,7 @@ class LdapController extends ManageBaseController
      */
     protected function prepareTemplate()
     {
-        $setup = Setup::setDefaults('ldap', LDAP_Auth_Backend::getDefaults());
+        $setup = Setup::setDefaults('ldap', LdapAdapter::getDefaults());
 
         $this->tpl->assign(
             [

--- a/src/Controller/Manage/ManageBaseController.php
+++ b/src/Controller/Manage/ManageBaseController.php
@@ -13,6 +13,8 @@
 
 namespace Eventum\Controller\Manage;
 
+use Eventum\Auth\Adapter\LdapAdapter;
+use Eventum\Auth\AuthException;
 use Eventum\Controller\BaseController;
 use User;
 
@@ -27,7 +29,7 @@ abstract class ManageBaseController extends BaseController
 
         $this->tpl->assign(
             [
-                'auth_backend' => strtolower(APP_AUTH_BACKEND),
+                'ldap_auth' => $this->hasLdapAuth(),
             ]
         );
     }
@@ -38,5 +40,16 @@ abstract class ManageBaseController extends BaseController
         // then give access permission.
         // probably canRoleAccess satisfied access restriction.
         return true;
+    }
+
+    private function hasLdapAuth()
+    {
+        try {
+            new LdapAdapter();
+
+            return true;
+        } catch (AuthException $e) {
+            return false;
+        }
     }
 }

--- a/src/Db/Adapter/AdapterInterface.php
+++ b/src/Db/Adapter/AdapterInterface.php
@@ -16,7 +16,7 @@ namespace Eventum\Db\Adapter;
 use Eventum\Db\DatabaseException;
 
 /**
- * Interface AdapterInterface
+ * Interface Eventum\Auth\Adapter\AdapterInterface
  *
  * Database interface designed against PEAR::DB
  */

--- a/src/Setup/DatabaseSetup.php
+++ b/src/Setup/DatabaseSetup.php
@@ -185,9 +185,9 @@ class DatabaseSetup
         throw new RuntimeException($err, $e->getCode());
     }
 
-    private function checkDatabaseExists(string $database): string
+    private function checkDatabaseExists(string $database): bool
     {
-        return $this->conn->getOne('SHOW DATABASES LIKE ?', [$database]);
+        return $this->conn->getOne('SHOW DATABASES LIKE ?', [$database]) !== null;
     }
 
     private function createDatabase($db_name): void

--- a/templates/help/ldap.tpl.html
+++ b/templates/help/ldap.tpl.html
@@ -1,11 +1,17 @@
 <h4>{t}LDAP Authentication{/t}</h4>
 
 <p>
-  {t escape="no"}Eventum can be used with an LDAP directory service for centralized authentication. To enable this feature, set the following option in <b>config.php</b>:{/t}
+  {t}Eventum can be used with an LDAP directory service for centralized authentication.{/t}
+  {t escape="no"}To enable this feature, set the following option in <b>config/setup.php</b>:{/t}
 </p>
 
 <pre>
-  {literal}define('APP_AUTH_BACKEND', 'LDAP_Auth_Backend');{/literal}
+  {literal}
+    'auth' => [
+      'adapter' => 'Eventum\\Auth\\Adapter\\LdapAdapter',
+      'arguments' => [],
+    ],
+  {/literal}
 </pre>
 
 <p>

--- a/templates/help/ldap.tpl.html
+++ b/templates/help/ldap.tpl.html
@@ -2,17 +2,7 @@
 
 <p>
   {t}Eventum can be used with an LDAP directory service for centralized authentication.{/t}
-  {t escape="no"}To enable this feature, set the following option in <b>config/setup.php</b>:{/t}
 </p>
-
-<pre>
-  {literal}
-    'auth' => [
-      'adapter' => 'Eventum\\Auth\\Adapter\\LdapAdapter',
-      'arguments' => [],
-    ],
-  {/literal}
-</pre>
 
 <p>
   {t}The following parameters need to be configured to enable LDAP integration:{/t}

--- a/templates/manage/auth.tpl.html
+++ b/templates/manage/auth.tpl.html
@@ -1,0 +1,33 @@
+{extends "manage/manage.tpl.html"}
+
+{block "manage_content"}
+<form id="auth_form" method="post">
+    <input type="hidden" name="cat" value="update">
+    <table class="bordered" border="1">
+        <tr class="title">
+            <th colspan="2">
+                {t}Authentication Setup{/t}
+            </th>
+        </tr>
+
+        <tr>
+            <th width="120">
+                {t}Auth Adapter{/t}
+            </th>
+            <td valign="top">
+                <select name="adapter">
+                    <option value="" label="{t}Please select a backend{/t}">{t}Please select a backend{/t}</option>
+                    {html_options options=$adapters selected=$adapter}
+                </select>
+            </td>
+        </tr>
+
+        <tr class="buttons">
+            <td colspan="2">
+                <input class="button" type="submit" value="{t}Update Setup{/t}">
+                <input class="button" type="reset" value="{t}Reset{/t}">
+            </td>
+        </tr>
+    </table>
+</form>
+{/block}

--- a/templates/manage/ldap.tpl.html
+++ b/templates/manage/ldap.tpl.html
@@ -54,7 +54,7 @@
 {/function}
 
 {block "manage_content"}
-  {if $auth_backend == 'ldap_auth_backend'}
+  {if $ldap_auth}
     <form id="ldap_form" method="post">
     <input type="hidden" name="cat" value="update">
     <table class="bordered">

--- a/templates/manage/manage.tpl.html
+++ b/templates/manage/manage.tpl.html
@@ -24,7 +24,7 @@
                     <li><a href="{$core.rel_url}manage/custom_fields.php">{t}Manage Custom Fields{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/status_action_date.php">{t}Customize Status Action Dates{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/monitor.php">{t}Customize Monitoring Parameters{/t}</a></li>
-                    {if $auth_backend == 'ldap_auth_backend'}
+                    {if $ldap_auth}
                     <li><a href="{$core.rel_url}manage/ldap.php" class="link">{t}Customize LDAP Config{/t}</a></li>
                     {/if}
                     <li><a href="{$core.rel_url}manage/scm.php" class="link">{t}Customize SCM Integration{/t}</a></li>

--- a/templates/manage/manage.tpl.html
+++ b/templates/manage/manage.tpl.html
@@ -18,15 +18,20 @@
                 <td nowrap>
                   <ul>
                     <li><a href="{$core.rel_url}manage/general.php">{t}General Setup{/t}</a></li>
+                    <li>
+                      <a href="{$core.rel_url}manage/auth.php" class="link">{t}Setup Authentication{/t}</a>
+                      <ul>
+                        {if $ldap_auth}
+                        <li><a href="{$core.rel_url}manage/ldap.php" class="link">{t}Customize LDAP Config{/t}</a></li>
+                        {/if}
+                      </ul>
+                    </li>
                     <li><a href="{$core.rel_url}manage/private_key.php">{t}Private Key{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/encryption.php">{t}Encryption{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/email_accounts.php">{t}Manage Email Accounts{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/custom_fields.php">{t}Manage Custom Fields{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/status_action_date.php">{t}Customize Status Action Dates{/t}</a></li>
                     <li><a href="{$core.rel_url}manage/monitor.php">{t}Customize Monitoring Parameters{/t}</a></li>
-                    {if $ldap_auth}
-                    <li><a href="{$core.rel_url}manage/ldap.php" class="link">{t}Customize LDAP Config{/t}</a></li>
-                    {/if}
                     <li><a href="{$core.rel_url}manage/scm.php" class="link">{t}Customize SCM Integration{/t}</a></li>
                   </ul>
                 </td>

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -14,9 +14,7 @@
 namespace Eventum\Test;
 
 use Eventum\Auth\PasswordHash;
-use InvalidArgumentException;
 use Misc;
-use stdClass;
 
 class PasswordAuthTest extends TestCase
 {
@@ -39,29 +37,6 @@ class PasswordAuthTest extends TestCase
         $password = 'meh';
         $res = PasswordHash::verify($password, $this->hashes['password_hash']);
         $this->assertFalse($res);
-    }
-
-    /**
-     * @expectedException InvalidArgumentException
-     * @dataProvider AuthPasswordInvalidArgumentData
-     */
-    public function testAuthPasswordInvalidArguments($password, $hash): void
-    {
-        PasswordHash::verify($password, $hash);
-    }
-
-    public function AuthPasswordInvalidArgumentData(): array
-    {
-        return [
-            [null, '123'],
-            ['a', null],
-            ['a', 10],
-            [-1, '10'],
-            ['', []],
-            [[], ''],
-            ['', new stdClass()],
-            [new stdClass(), ''],
-        ];
     }
 
     public function testPasswordHash(): void

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Test;
 
-use AuthPassword;
+use Eventum\Auth\PasswordHash;
 use InvalidArgumentException;
 use Misc;
 use stdClass;
@@ -32,12 +32,12 @@ class PasswordAuthTest extends TestCase
     public function testAuthPassword(): void
     {
         // success
-        $res = AuthPassword::verify($this->password, $this->hashes['password_hash']);
+        $res = PasswordHash::verify($this->password, $this->hashes['password_hash']);
         $this->assertTrue($res);
 
         // failures
         $password = 'meh';
-        $res = AuthPassword::verify($password, $this->hashes['password_hash']);
+        $res = PasswordHash::verify($password, $this->hashes['password_hash']);
         $this->assertFalse($res);
     }
 
@@ -47,7 +47,7 @@ class PasswordAuthTest extends TestCase
      */
     public function testAuthPasswordInvalidArguments($password, $hash): void
     {
-        AuthPassword::verify($password, $hash);
+        PasswordHash::verify($password, $hash);
     }
 
     public function AuthPasswordInvalidArgumentData(): array

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,7 +46,6 @@ define('APP_LOCAL_PATH', APP_CONFIG_PATH);
 define('APP_TPL_COMPILE_PATH', APP_CONFIG_PATH . '/tpl_c');
 define('APP_TPL_PATH', APP_PATH . '/templates');
 define('APP_NAME', 'Eventum Tests');
-define('APP_AUTH_BACKEND', 'Eventum\Auth\Adapter\MysqlAdapter');
 define('APP_SITE_NAME', 'Eventum');
 
 require_once APP_PATH . '/autoload.php';

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -46,7 +46,7 @@ define('APP_LOCAL_PATH', APP_CONFIG_PATH);
 define('APP_TPL_COMPILE_PATH', APP_CONFIG_PATH . '/tpl_c');
 define('APP_TPL_PATH', APP_PATH . '/templates');
 define('APP_NAME', 'Eventum Tests');
-define('APP_AUTH_BACKEND', 'mysql_auth_backend');
+define('APP_AUTH_BACKEND', 'Eventum\Auth\Adapter\MysqlAdapter');
 define('APP_SITE_NAME', 'Eventum');
 
 require_once APP_PATH . '/autoload.php';


### PR DESCRIPTION
Allow auth adapters setup from config:

the default:
```php
    'auth' => [
        'adapter' => MysqlAdapter::class,
    ],
```

with chain adapter with ldap and mysql:
```php
    'auth' => [
        'adapter' => ChainAdapter::class,
        'options' => [
            ChainAdapter::class => [
                0 => [
                    LdapAdapter::class,
                    MysqlAdapter::class,
                ],
            ],
        ],
    ],
```

## tasks

- [x] drop `APP_AUTH_BACKEND` and `APP_AUTH_BACKEND_ALLOW_FALLBACK`; add migration
- [ ] (optional) strict typing to new classes
- [x] move out `LdapAdapter::getDefaults`
- [x] test `LdapSyncCommand`
- [x] manage (admin interface): ensure it's usable (and help page too)
- [ ] check what redundant, duplicate methods could be moved out of adapter (traits, other classes?)