### PR TITLE
Secure unserialize: control allowed_classes options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ first, also the PHP version required is 7.1, see [#426].
 - Detect invalid mail header starting with "From " and replace it with a correct custom one. (@vladsf, #439, #427)
 - Require PHP 7.1 (@glensc, #426)
 - Drop Yii2 adapter; Improvements to AbstractMigration (@glensc, #442)
+- Secure unserialize: control `allowed_classes` options (@glensc, #445)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/lib/eventum/auth/AuthCookie.php
+++ b/lib/eventum/auth/AuthCookie.php
@@ -111,7 +111,7 @@ class AuthCookie
         // try to preserve "remember" from existing cookie
         if ($remember === null) {
             $cookie = self::getProjectCookie();
-            $remember = $cookie ? (bool) $cookie['remember'] : false;
+            $remember = $cookie ? (bool)$cookie['remember'] : false;
         }
 
         $cookie = self::generateProjectCookie($prj_id, $remember);
@@ -176,7 +176,7 @@ class AuthCookie
         $cookie = [
             'prj_id' => $prj_id,
             // it's stored as number, probably to save bytes in cookie size
-            'remember' => (int) $remember,
+            'remember' => (int)$remember,
         ];
 
         return base64_encode(serialize($cookie));
@@ -199,7 +199,7 @@ class AuthCookie
             return null;
         }
 
-        return unserialize($data);
+        return Misc::unserialize($data);
     }
 
     /**

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -38,7 +38,7 @@ class Email_Account
             $res = (string)$res;
         }
 
-        return unserialize($res);
+        return Misc::unserialize($res);
     }
 
     /**
@@ -165,7 +165,7 @@ class Email_Account
             throw new RuntimeException('email account not found');
         }
 
-        $res['ema_issue_auto_creation_options'] = @unserialize($res['ema_issue_auto_creation_options']);
+        $res['ema_issue_auto_creation_options'] = Misc::unserialize($res['ema_issue_auto_creation_options']);
         if ($include_password) {
             $res['ema_password'] = new EncryptedValue($res['ema_password']);
         } else {

--- a/lib/eventum/class.issue_lock.php
+++ b/lib/eventum/class.issue_lock.php
@@ -85,7 +85,7 @@ class Issue_Lock
             return false;
         }
 
-        return unserialize($info);
+        return Misc::unserialize($info);
     }
 
     /**

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -697,11 +697,12 @@ class Misc
      * This specifies that no classes may be instantiated.
      *
      * @param string $data
+     * @param array $allowedClasses
      * @return mixed
      */
-    public static function unserialize($data)
+    public static function unserialize($data, $allowedClasses = [])
     {
-        return unserialize($data, ['allowed_classes' => false]);
+        return unserialize($data, ['allowed_classes' => $allowedClasses ?: false]);
     }
 
     /**

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -244,7 +244,7 @@ class Misc
             // no break
             case 'm':
                 $val *= 1024;
-                // no break
+            // no break
             case 'k':
                 $val *= 1024;
         }
@@ -690,6 +690,18 @@ class Misc
         $generator = $factory->getMediumStrengthGenerator();
 
         return $generator->generate($size);
+    }
+
+    /**
+     * Wrapper to call unserialize safe way.
+     * This specifies that no classes may be instantiated.
+     *
+     * @param string $data
+     * @return mixed
+     */
+    public static function unserialize($data)
+    {
+        return unserialize($data, ['allowed_classes' => false]);
     }
 
     /**

--- a/lib/eventum/class.project.php
+++ b/lib/eventum/class.project.php
@@ -99,7 +99,7 @@ class Project
             return '';
         }
 
-        return @unserialize($res);
+        return Misc::unserialize($res);
     }
 
     /**

--- a/lib/eventum/class.search_profile.php
+++ b/lib/eventum/class.search_profile.php
@@ -76,9 +76,7 @@ class Search_Profile
             return [];
         }
 
-        $returns[$usr_id][$prj_id][$type] = unserialize($res);
-
-        return unserialize($res);
+        return $returns[$usr_id][$prj_id][$type] = Misc::unserialize($res);
     }
 
     /**

--- a/src/RPC/XmlRpcServer.php
+++ b/src/RPC/XmlRpcServer.php
@@ -16,8 +16,10 @@ namespace Eventum\RPC;
 use APIAuthToken;
 use Auth;
 use AuthCookie;
+use DateTime;
 use Eventum\Monolog\Logger;
 use Exception;
+use Misc;
 use PhpXmlRpc;
 use Psr\Log\LoggerInterface;
 use ReflectionClass;
@@ -25,6 +27,15 @@ use ReflectionMethod;
 
 class XmlRpcServer
 {
+    /**
+     * Classes allowed to be unserialized
+     *
+     * @var string[]
+     */
+    const SERIALIZE_ALLOWED_CLASSES = [
+        DateTime::class,
+    ];
+
     /** @var RemoteApi */
     protected $api;
 
@@ -213,8 +224,8 @@ class XmlRpcServer
             $type = $description[$i][0];
             $has_type = $this->getXmlRpcType($type, null);
             // if there is no internal type, and type exists as class, unserialize it
-            if (!$has_type && class_exists($type)) {
-                $param = unserialize($param);
+            if (!$has_type && in_array($type, self::SERIALIZE_ALLOWED_CLASSES, true)) {
+                $param = Misc::unserialize($param, self::SERIALIZE_ALLOWED_CLASSES);
             }
         }
     }


### PR DESCRIPTION
PHP 7.0 adds `allowed_classes` element of options to be able to specify which classes may be instantiated.

See:
- http://php.net/unserialize

# test
- [x] test `DateTime` objects with XMLRPC

cc @balsdorf 