### PR TITLE
mnapoli/silly: fix for boolean commandline arguments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ first, also the PHP version required is 7.1, see [#426].
 
 - Update Phinx to 0.10 (@glensc, #388)
 - Detect invalid mail header starting with "From " and replace it with a correct custom one. (@vladsf, #439, #427)
-- Require PHP 7.1 (@glensc, #426)
+- Require PHP 7.1 (@glensc, #426, #450)
 - Drop Yii2 adapter; Improvements to AbstractMigration (@glensc, #442)
 - Secure unserialize: control `allowed_classes` options (@glensc, #445)
 - Drop MD5 and MD5-64 password support (@glensc, #444)

--- a/src/Console/Command/MailDownloadCommand.php
+++ b/src/Console/Command/MailDownloadCommand.php
@@ -44,12 +44,7 @@ class MailDownloadCommand
         $this->logger = Logger::app();
     }
 
-    /**
-     * @param string $username
-     * @param string $hostname
-     * @param string $mailbox
-     */
-    public function execute($username, $hostname, $mailbox, $limit = 0, $noLock = false)
+    public function execute(?string $username, ?string $hostname, ?string $mailbox, bool $noLock, int $limit = 0)
     {
         $account_id = $this->getAccountId($username, $hostname, $mailbox);
         $this->limit = $limit;

--- a/tests/Mail/MailHelperTest.php
+++ b/tests/Mail/MailHelperTest.php
@@ -61,11 +61,13 @@ class MailHelperTest extends TestCase
         $this->assertEquals($exp, $msgid, 'msg-id header with newline, following next header');
     }
 
-    public function testGenerateMessageId()
+    public function testGenerateMessageId(): void
     {
         $msgid = Mail_Helper::generateMessageID();
         // <eventum.md5.54hebbwge.myyt4c@eventum.example.org>
-        $exp = '<eventum\.md5\.[0-9a-z]{8,64}\.[0-9a-z]{8,64}@' . APP_HOSTNAME . '>';
+        // <eventum.md5.741zcol.2ib1drbh4bqcc@eventum.example.org>
+        // 741zcol = 1548267006.9 = Wed Jan 23 20:10:06 2019 +0200
+        $exp = '<eventum\.md5\.[0-9a-z]{7,64}\.[0-9a-z]{8,64}@' . APP_HOSTNAME . '>';
         $this->assertRegExp($exp, $msgid, 'Missing msg-id header');
     }
 


### PR DESCRIPTION
> Cannot set a default value when using `InputOption::VALUE_NONE` mode

Fixes: https://github.com/mnapoli/silly/issues/51