### PR TITLE
TextMessage: do not parse subparts if no content-type given

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ first, also the PHP version required is 7.1, see [#426].
 - Drop MD5 and MD5-64 password support (@glensc, #444)
 - Drop outdated PEAR packages (@glensc, #443)
 - Add `SystemEvents::NOTIFICATION_NOTIFY_ADDRESS` event handling (@glensc, #438)
+- TextMessage: do not parse subparts if no content-type given (@glensc, #452)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -44,7 +44,7 @@ class TextMessage
         }
 
         // if no parts were extracted, process main message itself
-        if (!$isMultipart && !$this->hasText()) {
+        if (!$isMultipart && !$this->hasText() && $this->hasContentType()) {
             $this->processPart($this->message);
         }
 
@@ -70,9 +70,14 @@ class TextMessage
         return '';
     }
 
-    private function hasText()
+    private function hasText(): bool
     {
         return $this->html || $this->text || $this->alttext;
+    }
+
+    private function hasContentType(): bool
+    {
+        return $this->message->getHeaders()->has('Content-Type');
     }
 
     /**

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -618,8 +618,9 @@ class MailMessage extends Message
         }
 
         // process patterns
+        $array = $headers->toArray();
         array_walk(
-            $headers->toArray(), function ($value, $name) use ($headers) {
+            $array, function ($value, $name) use ($headers) {
                 if (preg_match('/^resent.*/i', $name)) {
                     $headers->removeHeader($name);
                 }

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -18,7 +18,7 @@ use Eventum\Test\TestCase;
 
 class TextMessageTest extends TestCase
 {
-    const UNICODE_NBSP = "\xC2\xA0";
+    private const UNICODE_NBSP = "\xC2\xA0";
 
     /**
      * @dataProvider dataProvider
@@ -57,6 +57,10 @@ class TextMessageTest extends TestCase
             'test downloading html emails extracts body from source' => [
                 'htmltext_emailsource.eml',
                 "This is a sample email to test Eventum html parsing.\n\n" . self::UNICODE_NBSP,
+            ],
+            'mail with no mime headers, should be plain text' => [
+                'email-106251.txt',
+                "here\nbe\ndragons",
             ],
         ];
     }

--- a/tests/data/email-106251.txt
+++ b/tests/data/email-106251.txt
@@ -1,0 +1,10 @@
+Return-Path: <root@hamlet.example.com>
+Date: Tue, 22 Jan 2019 05:02:01 +0200
+To: issue-57086@eventum.example.net
+Subject: Tue Jan 22 05:02:01 EET 2019 error.log
+Message-Id: <20190122030201.7EC5F85D1A6@hamlet.example.com>
+From: root@hamlet.example.com (root)
+
+here
+be
+dragons


### PR DESCRIPTION
Thus it's a mail without any mime extensions.

cc @astabing