### PR TITLE
Move Login-Back-Off logic to MySQL adapter only

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ first, also the PHP version required is 7.1, see [#426].
 - TextMessage: do not parse subparts if no content-type given (@glensc, #452)
 - Allow auth adapters to be chained (@glensc, #441)
 - Remove Legacy CLI application (@glensc, #453)
+- Move Login-Back-Off logic to MySQL adapter only (@glensc, #455)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/db/migrations/20190127204900_eventum_login_back_off_config.php
+++ b/db/migrations/20190127204900_eventum_login_back_off_config.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumLoginBackOffConfig extends AbstractMigration
+{
+    public function up(): void
+    {
+        $config = Setup::get()['auth'];
+        $config['login_backoff'] = [
+            'count' => $this->getBackoffCount(),
+            'minutes' => $this->getBackoffMinutes(),
+        ];
+        Setup::save();
+    }
+
+    /**
+     * Get number of failed attempts before Back-Off locking kicks in.
+     * If set to null do not use Back-Off locking.
+     */
+    private function getBackoffCount(): ?int
+    {
+        if (!defined('APP_FAILED_LOGIN_BACKOFF_COUNT')) {
+            return null;
+        }
+
+        $count = APP_FAILED_LOGIN_BACKOFF_COUNT;
+        if ($count === false) {
+            return null;
+        }
+
+        return $count;
+    }
+
+    /**
+     * How many minutes to lock account for during Back-Off
+     */
+    private function getBackoffMinutes(): ?int
+    {
+        if (!defined('APP_FAILED_LOGIN_BACKOFF_MINUTES')) {
+            return 15;
+        }
+
+        return APP_FAILED_LOGIN_BACKOFF_MINUTES;
+    }
+
+    public function down(): void
+    {
+    }
+}

--- a/init.php
+++ b/init.php
@@ -80,12 +80,6 @@ if (!defined('APP_EMAIL_ENCODING')) {
     }
 }
 
-// Number of failed attempts before Back-Off locking kicks in.
-// If set to false do not use Back-Off locking.
-$define('APP_FAILED_LOGIN_BACKOFF_COUNT', false);
-// How many minutes to lock account for during Back-Off
-$define('APP_FAILED_LOGIN_BACKOFF_MINUTES', 15);
-
 $define('APP_HIDE_CLOSED_STATS_COOKIE', 'eventum_hide_closed_stats');
 
 // if set, normal calls to eventum are redirected to a maintenance page while

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -181,34 +181,6 @@ class Auth
     }
 
     /**
-     * Performs standard checks when a user logins
-     * @param string $login
-     */
-    public static function login($login)
-    {
-        // handle aliases since the user is now authenticated
-        $login = User::getEmail(self::getUserIDByLogin($login));
-
-        // check if this user did already confirm his account
-        if (self::isPendingUser($login)) {
-            self::saveLoginAttempt($login, 'failure', 'pending user');
-            self::redirect('index.php?err=9');
-        }
-        // check if this user is really an active one
-        if (!self::isActiveUser($login)) {
-            self::saveLoginAttempt($login, 'failure', 'inactive user');
-            self::redirect('index.php?err=7');
-        }
-
-        self::saveLoginAttempt($login, 'success');
-
-        $remember = !empty($_POST['remember']);
-        AuthCookie::setAuthCookie($login, $remember);
-
-        Session::init(User::getUserIDByEmail($login));
-    }
-
-    /**
      * Method for logging out the currently logged in user. Called after the normal logout process has completed.
      *
      * @returns void
@@ -231,14 +203,11 @@ class Auth
      * @param   string $email The email address to be checked
      * @return  bool
      */
-    public static function isPendingUser($email)
+    public static function isPendingUser($email): bool
     {
         $status = User::getStatusByEmail($email);
-        if ($status != 'pending') {
-            return false;
-        }
 
-        return true;
+        return $status === 'pending';
     }
 
     /**
@@ -247,7 +216,7 @@ class Auth
      * @param   string $email The email address to be checked
      * @return  bool
      */
-    public static function isActiveUser($email)
+    public static function isActiveUser($email): bool
     {
         $status = User::getStatusByEmail($email);
 

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -336,17 +336,6 @@ class Auth
     }
 
     /**
-     * Returns the true if the account is currently locked becouse of Back-Off lock
-     *
-     * @param   string $usr_id The user id to check for
-     * @return  bool
-     */
-    public static function isUserBackOffLocked($usr_id)
-    {
-        return self::getAuthBackend()->isUserBackOffLocked($usr_id);
-    }
-
-    /**
      * Gets the current user ID.
      *
      * @return  int The ID of the user

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -476,7 +476,7 @@ class Auth
      */
     public static function getUserIDByLogin($login)
     {
-        return self::getAuthBackend()->getUserIDByLogin($login);
+        return self::getAuthBackend()->getUserId($login);
     }
 
     /**

--- a/src/Auth/Adapter/AdapterInterface.php
+++ b/src/Auth/Adapter/AdapterInterface.php
@@ -52,7 +52,7 @@ interface AdapterInterface
      * @param $login
      * @return  int|null The user id or null
      */
-    public function getUserIDByLogin(string $login): ?int;
+    public function getUserId(string $login): ?int;
 
     /**
      * If this backend allows the user to update their name.

--- a/src/Auth/Adapter/AdapterInterface.php
+++ b/src/Auth/Adapter/AdapterInterface.php
@@ -13,9 +13,6 @@
 
 namespace Eventum\Auth\Adapter;
 
-/**
- * Auth Backend Interface
- */
 interface AdapterInterface
 {
     /**
@@ -80,30 +77,6 @@ interface AdapterInterface
      * @return bool
      */
     public function canUserUpdatePassword($usr_id);
-
-    /**
-     * Increment the failed logins attempts for this user
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function incrementFailedLogins($usr_id);
-
-    /**
-     * Reset the failed logins attempts for this user
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function resetFailedLogins($usr_id);
-
-    /**
-     * Returns the true if the account is currently locked because of Back-Off locking
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function isUserBackOffLocked($usr_id);
 
     /**
      * Returns a URL to redirect the user to when they attempt to login or null if the native login pages

--- a/src/Auth/Adapter/AdapterInterface.php
+++ b/src/Auth/Adapter/AdapterInterface.php
@@ -23,7 +23,7 @@ interface AdapterInterface
      * @param   string $password The password of the user to check for
      * @return  bool
      */
-    public function verifyPassword($login, $password);
+    public function verifyPassword(string $login, string $password): bool;
 
     /**
      * Method used to update the account password for a specific user.
@@ -32,7 +32,7 @@ interface AdapterInterface
      * @param   string $password the password
      * @return  bool true if update worked, false otherwise
      */
-    public function updatePassword($usr_id, $password);
+    public function updatePassword(int $usr_id, string $password): bool;
 
     /**
      * Returns true if User Id exists.
@@ -43,7 +43,7 @@ interface AdapterInterface
      * @return bool
      * @since 3.0.8
      */
-    public function userExists($login);
+    public function userExists(string $login): bool;
 
     /**
      * Returns the user ID for the specified login. This can be the email address, an alias,
@@ -52,7 +52,7 @@ interface AdapterInterface
      * @param $login
      * @return  int|null The user id or null
      */
-    public function getUserIDByLogin($login);
+    public function getUserIDByLogin(string $login): ?int;
 
     /**
      * If this backend allows the user to update their name.
@@ -60,7 +60,7 @@ interface AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdateName($usr_id);
+    public function canUserUpdateName(int $usr_id): bool;
 
     /**
      * If this backend allows the user to update their email.
@@ -68,7 +68,7 @@ interface AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdateEmail($usr_id);
+    public function canUserUpdateEmail(int $usr_id): bool;
 
     /**
      * If this backend allows the user to update their password.
@@ -76,7 +76,7 @@ interface AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdatePassword($usr_id);
+    public function canUserUpdatePassword(int $usr_id): bool;
 
     /**
      * Returns a URL to redirect the user to when they attempt to login or null if the native login pages
@@ -84,23 +84,23 @@ interface AdapterInterface
      *
      * @return  string The login url or null
      */
-    public function getExternalLoginURL();
+    public function getExternalLoginURL(): ?string;
 
     /**
      * Returns true if the user should automatically be redirected to the external login URL, false otherwise
      *
      * @return  bool
      */
-    public function autoRedirectToExternalLogin();
+    public function autoRedirectToExternalLogin(): bool;
 
     /**
      * Called on every page load and can be used to process external authentication checks before the rest of the
      * authentication process happens.
      */
-    public function checkAuthentication();
+    public function checkAuthentication(): void;
 
     /**
      * Called when a user logs out.
      */
-    public function logout();
+    public function logout(): void;
 }

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -186,7 +186,7 @@ class CasAdapter implements AdapterInterface
 
     public function userExists(string $login): bool
     {
-        $usr_id = $this->getUserIDByLogin($login);
+        $usr_id = $this->getUserId($login);
 
         return $usr_id > 0;
     }
@@ -200,7 +200,7 @@ class CasAdapter implements AdapterInterface
      * @param string $login
      * @return  int|null The user id or null
      */
-    public function getUserIDByLogin(string $login): ?int
+    public function getUserId(string $login): ?int
     {
         return User::getUserIDByEmail($login, true);
     }

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -42,11 +42,10 @@ class CasAdapter implements AdapterInterface
 
         // For simplicities sake at the moment we are not validating the server auth.
         phpCAS::setNoCasServerValidation();
-
         phpCAS::setPostAuthenticateCallback([$this, 'loginCallback']);
     }
 
-    public function checkAuthentication()
+    public function checkAuthentication(): void
     {
         if (phpCAS::isAuthenticated() && !AuthCookie::hasAuthCookie()) {
             $this->loginCallback();
@@ -56,12 +55,12 @@ class CasAdapter implements AdapterInterface
         phpCAS::forceAuthentication();
     }
 
-    public function logout()
+    public function logout(): void
     {
         phpCAS::logoutWithRedirectService(APP_BASE_URL);
     }
 
-    public function loginCallback()
+    public function loginCallback(): void
     {
         $attributes = phpCAS::getAttributes();
 
@@ -73,7 +72,7 @@ class CasAdapter implements AdapterInterface
         AuthCookie::setAuthCookie($user['usr_email'], true);
     }
 
-    public function updateLocalUserFromBackend($remote)
+    public function updateLocalUserFromBackend(array $remote): int
     {
         $setup = self::loadSetup();
 
@@ -127,7 +126,7 @@ class CasAdapter implements AdapterInterface
 
         // create new local user
         $setup = self::loadSetup();
-        if ($setup['create_users'] == false) {
+        if ($setup['create_users'] === false) {
             throw new AuthException('User does not exist and will not be created.');
         }
         $data['role'] = $setup['default_role'];
@@ -153,10 +152,7 @@ class CasAdapter implements AdapterInterface
         return $usr_id;
     }
 
-    /**
-     * @param int $usr_id
-     */
-    private function updateAliases($usr_id, $aliases)
+    private function updateAliases(int $usr_id, array $aliases): void
     {
         foreach ($aliases as $alias) {
             User::addAlias($usr_id, $alias);
@@ -171,7 +167,7 @@ class CasAdapter implements AdapterInterface
      * @param   string $password The password of the user to check for
      * @return  bool
      */
-    public function verifyPassword($login, $password)
+    public function verifyPassword(string $login, string $password): bool
     {
         return false;
     }
@@ -183,12 +179,12 @@ class CasAdapter implements AdapterInterface
      * @param   string $password the password
      * @return  bool true if update worked, false otherwise
      */
-    public function updatePassword($usr_id, $password)
+    public function updatePassword(int $usr_id, string $password): bool
     {
         return true;
     }
 
-    public function userExists($login)
+    public function userExists(string $login): bool
     {
         $usr_id = $this->getUserIDByLogin($login);
 
@@ -204,7 +200,7 @@ class CasAdapter implements AdapterInterface
      * @param string $login
      * @return  int|null The user id or null
      */
-    public function getUserIDByLogin($login)
+    public function getUserIDByLogin(string $login): ?int
     {
         return User::getUserIDByEmail($login, true);
     }
@@ -215,7 +211,7 @@ class CasAdapter implements AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdateName($usr_id)
+    public function canUserUpdateName(int $usr_id): bool
     {
         return false;
     }
@@ -226,7 +222,7 @@ class CasAdapter implements AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdateEmail($usr_id)
+    public function canUserUpdateEmail(int $usr_id): bool
     {
         return false;
     }
@@ -237,7 +233,7 @@ class CasAdapter implements AdapterInterface
      * @param int $usr_id
      * @return bool
      */
-    public function canUserUpdatePassword($usr_id)
+    public function canUserUpdatePassword(int $usr_id): bool
     {
         return false;
     }
@@ -247,15 +243,15 @@ class CasAdapter implements AdapterInterface
      *
      * @return  string The login url or null
      */
-    public function getExternalLoginURL()
+    public function getExternalLoginURL(): ?string
     {
         return APP_RELATIVE_URL . 'main.php';
     }
 
-    public static function loadSetup($force = false)
+    public static function loadSetup($force = false): array
     {
         static $setup;
-        if (empty($setup) || $force == true) {
+        if (empty($setup) || $force === true) {
             $setup = [];
             $configfile = Setup::getConfigPath() . '/cas.php';
 
@@ -303,7 +299,7 @@ class CasAdapter implements AdapterInterface
      *
      * @return  bool
      */
-    public function autoRedirectToExternalLogin()
+    public function autoRedirectToExternalLogin(): bool
     {
         return false;
     }

--- a/src/Auth/Adapter/CasAdapter.php
+++ b/src/Auth/Adapter/CasAdapter.php
@@ -243,39 +243,6 @@ class CasAdapter implements AdapterInterface
     }
 
     /**
-     * Increment the failed logins attempts for this user
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function incrementFailedLogins($usr_id)
-    {
-        return true;
-    }
-
-    /**
-     * Reset the failed logins attempts for this user
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function resetFailedLogins($usr_id)
-    {
-        return true;
-    }
-
-    /**
-     * Returns the true if the account is currently locked because of Back-Off locking
-     *
-     * @param   int $usr_id The ID of the user
-     * @return  bool
-     */
-    public function isUserBackOffLocked($usr_id)
-    {
-        return false;
-    }
-
-    /**
      * Just return the main eventum page since that will prompt a CAS login.
      *
      * @return  string The login url or null
@@ -307,9 +274,9 @@ class CasAdapter implements AdapterInterface
     /**
      * Method used to get the system-wide defaults.
      *
-     * @return  string array of the default parameters
+     * @return array of the default parameters
      */
-    public static function getDefaults()
+    public static function getDefaults(): array
     {
         $defaults = [
             'host' => 'localhost',

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -33,7 +33,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function verifyPassword($login, $password)
+    public function verifyPassword(string $login, string $password): bool
     {
         foreach ($this->adapters as $adapter) {
             if ($adapter->verifyPassword($login, $password)) {
@@ -47,7 +47,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function updatePassword($usr_id, $password)
+    public function updatePassword(int $usr_id, string $password): bool
     {
         $result = false;
         foreach ($this->adapters as $adapter) {
@@ -62,7 +62,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function userExists($login)
+    public function userExists(string $login): bool
     {
         foreach ($this->adapters as $adapter) {
             if ($adapter->userExists($login)) {
@@ -76,7 +76,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getUserIDByLogin($login)
+    public function getUserIDByLogin(string $login): ?int
     {
         foreach ($this->adapters as $adapter) {
             $usr_id = $adapter->getUserIDByLogin($login);
@@ -91,7 +91,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdateName($usr_id)
+    public function canUserUpdateName(int $usr_id): bool
     {
         foreach ($this->adapters as $adapter) {
             if ($adapter->canUserUpdateName($usr_id)) {
@@ -105,7 +105,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdateEmail($usr_id)
+    public function canUserUpdateEmail(int $usr_id): bool
     {
         foreach ($this->adapters as $adapter) {
             if ($adapter->canUserUpdateEmail($usr_id)) {
@@ -119,7 +119,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdatePassword($usr_id)
+    public function canUserUpdatePassword(int $usr_id): bool
     {
         foreach ($this->adapters as $adapter) {
             if ($adapter->canUserUpdatePassword($usr_id)) {
@@ -133,7 +133,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalLoginURL()
+    public function getExternalLoginURL(): ?string
     {
         foreach ($this->adapters as $adapter) {
             $url = $adapter->getExternalLoginURL();
@@ -148,7 +148,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function autoRedirectToExternalLogin()
+    public function autoRedirectToExternalLogin(): bool
     {
         foreach ($this->adapters as $adapter) {
             $redirect = $adapter->autoRedirectToExternalLogin();
@@ -163,7 +163,7 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function checkAuthentication()
+    public function checkAuthentication(): void
     {
         foreach ($this->adapters as $adapter) {
             $adapter->checkAuthentication();
@@ -173,12 +173,10 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function logout()
+    public function logout(): void
     {
         foreach ($this->adapters as $adapter) {
             $adapter->logout();
         }
-
-        return null;
     }
 }

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -76,10 +76,10 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getUserIDByLogin(string $login): ?int
+    public function getUserId(string $login): ?int
     {
         foreach ($this->adapters as $adapter) {
-            $usr_id = $adapter->getUserIDByLogin($login);
+            $usr_id = $adapter->getUserId($login);
             if ($usr_id !== null) {
                 return $usr_id;
             }

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -133,50 +133,6 @@ class ChainAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function incrementFailedLogins($usr_id)
-    {
-        $result = false;
-        foreach ($this->adapters as $adapter) {
-            if ($adapter->incrementFailedLogins($usr_id)) {
-                $result = true;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resetFailedLogins($usr_id)
-    {
-        $result = false;
-        foreach ($this->adapters as $adapter) {
-            if ($adapter->resetFailedLogins($usr_id)) {
-                $result = true;
-            }
-        }
-
-        return $result;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isUserBackOffLocked($usr_id)
-    {
-        foreach ($this->adapters as $adapter) {
-            if ($adapter->isUserBackOffLocked($usr_id)) {
-                return true;
-            }
-        }
-
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getExternalLoginURL()
     {
         foreach ($this->adapters as $adapter) {

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -20,6 +20,7 @@ use Eventum\Auth\Ldap\UserEntry;
 use Eventum\Monolog\Logger;
 use Setup;
 use Symfony\Component\Ldap\Entry;
+use Symfony\Component\Ldap\Exception\ConnectionException;
 use User;
 
 /**
@@ -394,7 +395,13 @@ class LdapAdapter implements AdapterInterface
      */
     public function userExists(string $login): bool
     {
-        $usr_id = $this->getUserIDByLogin($login);
+        try {
+            $usr_id = $this->getUserIDByLogin($login);
+        } catch (ConnectionException $e) {
+            $this->logger->critical($e->getMessage(), ['exception' => $e]);
+
+            return false;
+        }
 
         return $usr_id > 0;
     }

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -369,7 +369,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getUserIDByLogin(string $login): ?int
+    public function getUserId(string $login): ?int
     {
         $usr_id = User::getUserIDByEmail($login, true);
         if (!$usr_id) {
@@ -396,7 +396,7 @@ class LdapAdapter implements AdapterInterface
     public function userExists(string $login): bool
     {
         try {
-            $usr_id = $this->getUserIDByLogin($login);
+            $usr_id = $this->getUserId($login);
         } catch (ConnectionException $e) {
             $this->logger->critical($e->getMessage(), ['exception' => $e]);
 
@@ -419,7 +419,7 @@ class LdapAdapter implements AdapterInterface
     public function verifyPassword(string $login, string $password): bool
     {
         // check if this is an ldap or internal
-        $usr_id = $this->getUserIDByLogin($login);
+        $usr_id = $this->getUserId($login);
         $external_id = User::getExternalID($usr_id) ?? null;
 
         if (!$external_id) {

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -207,13 +207,13 @@ class LdapAdapter implements AdapterInterface
      * Creates or updates local user entry for the specified ID.
      *
      * @param string $login The login or email of the user to create or update
-     * @return  bool True if the user was created or updated, false otherwise
+     * @return int the user id that was created or updated, null otherwise
      */
-    public function updateLocalUserFromBackend(string $login): bool
+    public function updateLocalUserFromBackend(string $login): ?int
     {
         $remote = $this->getLdapUser($login);
         if (!$remote) {
-            return false;
+            return null;
         }
 
         $usr_id = $this->getLocalUserId($login, $remote->getEmails());
@@ -299,7 +299,7 @@ class LdapAdapter implements AdapterInterface
         }
 
         if (!$this->create_users) {
-            return false;
+            return null;
         }
 
         return $this->createUser($remote);

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -80,7 +80,7 @@ class LdapAdapter implements AdapterInterface
      * @return UserEntry[]
      * @internal Public for use by LdapSyncCommand
      */
-    public function getUserListing($dn)
+    public function getUserListing(string $dn): array
     {
         return $this->ldap->listUsers($dn);
     }
@@ -106,7 +106,7 @@ class LdapAdapter implements AdapterInterface
      * @return UserEntry|null
      * @internal Public for use by LdapSyncCommand
      */
-    public function getLdapUser($uid)
+    public function getLdapUser(string $uid): ?UserEntry
     {
         return $this->ldap->findUser($uid);
     }
@@ -119,7 +119,7 @@ class LdapAdapter implements AdapterInterface
      * @return int|null
      * @internal Public for use by LdapSyncCommand
      */
-    public function getLocalUserId($login, $emails)
+    public function getLocalUserId(string $login, array $emails): ?int
     {
         // try by login name
         $usr_id = User::getUserIDByExternalID($login);
@@ -146,7 +146,7 @@ class LdapAdapter implements AdapterInterface
      * @return bool
      * @internal Public for use by LdapSyncCommand
      */
-    public function disableAccount($uid)
+    public function disableAccount(string $uid): bool
     {
         $usr_id = User::getUserIDByExternalID($uid);
         if ($usr_id <= 0) {
@@ -168,7 +168,7 @@ class LdapAdapter implements AdapterInterface
      * @return null|bool
      * @internal Public for use by LdapSyncCommand
      */
-    public function accountActive($uid)
+    public function accountActive(string $uid): ?bool
     {
         $usr_id = User::getUserIDByExternalID($uid);
         if ($usr_id <= 0) {
@@ -189,7 +189,7 @@ class LdapAdapter implements AdapterInterface
      * @param array $emails
      * @return string[]
      */
-    private function sortEmails($usr_id, $emails)
+    private function sortEmails(int $usr_id, array $emails): array
     {
         $email = User::getEmail($usr_id);
 
@@ -208,7 +208,7 @@ class LdapAdapter implements AdapterInterface
      * @param string $login The login or email of the user to create or update
      * @return  bool True if the user was created or updated, false otherwise
      */
-    public function updateLocalUserFromBackend($login)
+    public function updateLocalUserFromBackend(string $login): bool
     {
         $remote = $this->getLdapUser($login);
         if (!$remote) {
@@ -368,7 +368,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getUserIDByLogin($login)
+    public function getUserIDByLogin(string $login): ?int
     {
         $usr_id = User::getUserIDByEmail($login, true);
         if (!$usr_id) {
@@ -392,7 +392,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function userExists($login)
+    public function userExists(string $login): bool
     {
         $usr_id = $this->getUserIDByLogin($login);
 
@@ -409,7 +409,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function verifyPassword($login, $password)
+    public function verifyPassword(string $login, string $password): bool
     {
         // check if this is an ldap or internal
         $usr_id = $this->getUserIDByLogin($login);
@@ -425,7 +425,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdateName($usr_id): bool
+    public function canUserUpdateName(int $usr_id): bool
     {
         return $this->hasExternalId($usr_id);
     }
@@ -433,7 +433,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdateEmail($usr_id)
+    public function canUserUpdateEmail(int $usr_id): bool
     {
         return $this->hasExternalId($usr_id);
     }
@@ -441,7 +441,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function canUserUpdatePassword($usr_id)
+    public function canUserUpdatePassword(int $usr_id): bool
     {
         return $this->hasExternalId($usr_id);
     }
@@ -449,7 +449,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function updatePassword($usr_id, $password)
+    public function updatePassword(int $usr_id, string $password): bool
     {
         return false;
     }
@@ -457,7 +457,7 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function getExternalLoginURL()
+    public function getExternalLoginURL(): ?string
     {
         return null;
     }
@@ -465,23 +465,21 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function checkAuthentication()
+    public function checkAuthentication(): void
     {
-        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function logout()
+    public function logout(): void
     {
-        return null;
     }
 
     /**
      * {@inheritdoc}
      */
-    public function autoRedirectToExternalLogin()
+    public function autoRedirectToExternalLogin(): bool
     {
         return false;
     }

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -457,30 +457,6 @@ class LdapAdapter implements AdapterInterface
     /**
      * {@inheritdoc}
      */
-    public function incrementFailedLogins($usr_id)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function resetFailedLogins($usr_id)
-    {
-        return true;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function isUserBackOffLocked($usr_id)
-    {
-        return false;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
     public function getExternalLoginURL()
     {
         return null;

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -35,7 +35,7 @@ class MysqlAdapter implements AdapterInterface
      * @param   string $password The password of the user to check for
      * @return  bool
      */
-    public function verifyPassword($login, $password): bool
+    public function verifyPassword(string $login, string $password): bool
     {
         $usr_id = $this->getUserIDByLogin($login);
         if (!$usr_id) {
@@ -73,7 +73,7 @@ class MysqlAdapter implements AdapterInterface
      * @param   string $password the password
      * @return  bool
      */
-    public function updatePassword($usr_id, $password)
+    public function updatePassword(int $usr_id, string $password): bool
     {
         $stmt = 'UPDATE
                     `user`
@@ -91,14 +91,14 @@ class MysqlAdapter implements AdapterInterface
         return true;
     }
 
-    public function userExists($login)
+    public function userExists(string $login): bool
     {
         $usr_id = $this->getUserIDByLogin($login);
 
         return $usr_id > 0;
     }
 
-    public function getUserIDByLogin($login)
+    public function getUserIDByLogin(string $login): ?int
     {
         return User::getUserIDByEmail($login, true);
     }
@@ -107,9 +107,8 @@ class MysqlAdapter implements AdapterInterface
      * Increment the failed logins attempts for this user
      *
      * @param   int $usr_id The ID of the user
-     * @return  bool
      */
-    public function incrementFailedLogins($usr_id)
+    public function incrementFailedLogins(int $usr_id): void
     {
         $stmt = 'UPDATE
                     `user`
@@ -118,22 +117,15 @@ class MysqlAdapter implements AdapterInterface
                     usr_last_failed_login = NOW()
                  WHERE
                     usr_id=?';
-        try {
-            DB_Helper::getInstance()->query($stmt, [$usr_id]);
-        } catch (DatabaseException $e) {
-            return false;
-        }
-
-        return true;
+        DB_Helper::getInstance()->query($stmt, [$usr_id]);
     }
 
     /**
      * Reset the failed logins attempts for this user
      *
      * @param   int $usr_id The ID of the user
-     * @return  bool
      */
-    private function resetFailedLogins($usr_id)
+    private function resetFailedLogins(int $usr_id): void
     {
         $stmt = 'UPDATE
                     `user`
@@ -143,13 +135,7 @@ class MysqlAdapter implements AdapterInterface
                     usr_last_failed_login = NULL
                  WHERE
                     usr_id=?';
-        try {
-            DB_Helper::getInstance()->query($stmt, [$usr_id]);
-        } catch (DatabaseException $e) {
-            return false;
-        }
-
-        return true;
+        DB_Helper::getInstance()->query($stmt, [$usr_id]);
     }
 
     /**
@@ -158,11 +144,12 @@ class MysqlAdapter implements AdapterInterface
      * @param   string $usr_id The email address to check for
      * @return  bool
      */
-    public function isUserBackOffLocked($usr_id)
+    public function isUserBackOffLocked(int $usr_id): bool
     {
         if (!is_int(APP_FAILED_LOGIN_BACKOFF_COUNT)) {
             return false;
         }
+
         $stmt = 'SELECT
                     IF( usr_failed_logins >= ?, NOW() < DATE_ADD(usr_last_failed_login, INTERVAL ' . APP_FAILED_LOGIN_BACKOFF_MINUTES . ' MINUTE), 0)
                  FROM
@@ -179,17 +166,17 @@ class MysqlAdapter implements AdapterInterface
         return $res == 1;
     }
 
-    public function canUserUpdateName($usr_id)
+    public function canUserUpdateName(int $usr_id): bool
     {
         return true;
     }
 
-    public function canUserUpdateEmail($usr_id)
+    public function canUserUpdateEmail(int $usr_id): bool
     {
         return true;
     }
 
-    public function canUserUpdatePassword($usr_id)
+    public function canUserUpdatePassword(int $usr_id): bool
     {
         return true;
     }
@@ -200,7 +187,7 @@ class MysqlAdapter implements AdapterInterface
      *
      * @return  string The login url or null
      */
-    public function getExternalLoginURL()
+    public function getExternalLoginURL(): ?string
     {
         return null;
     }
@@ -209,19 +196,15 @@ class MysqlAdapter implements AdapterInterface
      * Called on every page load and can be used to process external authentication checks before the rest of the
      * authentication process happens.
      */
-    public function checkAuthentication()
+    public function checkAuthentication(): void
     {
-        return null;
     }
 
     /**
      * Called when a user logs out.
-     *
-     * @return mixed
      */
-    public function logout()
+    public function logout(): void
     {
-        return null;
     }
 
     /**
@@ -229,7 +212,7 @@ class MysqlAdapter implements AdapterInterface
      *
      * @return  bool
      */
-    public function autoRedirectToExternalLogin()
+    public function autoRedirectToExternalLogin(): bool
     {
         return false;
     }

--- a/src/Auth/Adapter/MysqlAdapter.php
+++ b/src/Auth/Adapter/MysqlAdapter.php
@@ -38,7 +38,7 @@ class MysqlAdapter implements AdapterInterface
      */
     public function verifyPassword(string $login, string $password): bool
     {
-        $usr_id = $this->getUserIDByLogin($login);
+        $usr_id = $this->getUserId($login);
         if (!$usr_id) {
             return false;
         }
@@ -94,12 +94,12 @@ class MysqlAdapter implements AdapterInterface
 
     public function userExists(string $login): bool
     {
-        $usr_id = $this->getUserIDByLogin($login);
+        $usr_id = $this->getUserId($login);
 
         return $usr_id > 0;
     }
 
-    public function getUserIDByLogin(string $login): ?int
+    public function getUserId(string $login): ?int
     {
         return User::getUserIDByEmail($login, true);
     }

--- a/src/Auth/AuthException.php
+++ b/src/Auth/AuthException.php
@@ -14,6 +14,7 @@
 namespace Eventum\Auth;
 
 use RuntimeException;
+use Throwable;
 
 class AuthException extends RuntimeException
 {
@@ -24,4 +25,12 @@ class AuthException extends RuntimeException
     public const INACTIVE_USER = 7;
     public const PENDING_USER = 9;
     public const ACCOUNT_BACKOFF_LOCKED = 13;
+
+    // use message that's most suitable
+    public const UNKNOWN_ERROR = 3;
+
+    public function __construct($message = 'Unknown error', $code = 0, Throwable $previous = null)
+    {
+        parent::__construct($message, $code ?: self::UNKNOWN_ERROR, $previous);
+    }
 }

--- a/src/Auth/AuthException.php
+++ b/src/Auth/AuthException.php
@@ -17,5 +17,9 @@ use RuntimeException;
 
 class AuthException extends RuntimeException
 {
+    public const EMPTY_LOGIN = 1;
+    public const EMPTY_PASSWORD = 2;
+    public const UNKNOWN_USER = 3;
+    public const WRONG_PASSWORD = 3;
     public const ACCOUNT_BACKOFF_LOCKED = 13;
 }

--- a/src/Auth/AuthException.php
+++ b/src/Auth/AuthException.php
@@ -21,5 +21,7 @@ class AuthException extends RuntimeException
     public const EMPTY_PASSWORD = 2;
     public const UNKNOWN_USER = 3;
     public const WRONG_PASSWORD = 3;
+    public const INACTIVE_USER = 7;
+    public const PENDING_USER = 9;
     public const ACCOUNT_BACKOFF_LOCKED = 13;
 }

--- a/src/Auth/AuthException.php
+++ b/src/Auth/AuthException.php
@@ -17,4 +17,5 @@ use RuntimeException;
 
 class AuthException extends RuntimeException
 {
+    public const ACCOUNT_BACKOFF_LOCKED = 13;
 }

--- a/src/Controller/LoginController.php
+++ b/src/Controller/LoginController.php
@@ -14,6 +14,7 @@
 namespace Eventum\Controller;
 
 use Auth;
+use Eventum\Auth\AuthException;
 use Validation;
 
 class LoginController extends BaseController
@@ -65,15 +66,13 @@ class LoginController extends BaseController
             $this->loginFailure(3, 'unknown user');
         }
 
-        // check if user is locked
-        $usr_id = Auth::getUserIDByLogin($this->login);
-        if (Auth::isUserBackOffLocked($usr_id)) {
-            $this->loginFailure(13, 'account back-off locked');
-        }
-
         // check if the password matches
-        if (!Auth::isCorrectPassword($this->login, $this->passwd)) {
-            $this->loginFailure(3, 'wrong password', ['email' => $this->login]);
+        try {
+            if (!Auth::isCorrectPassword($this->login, $this->passwd)) {
+                $this->loginFailure(3, 'wrong password', ['email' => $this->login]);
+            }
+        } catch (AuthException $e) {
+            $this->loginFailure($e->getCode(), $e->getMessage(), ['email' => $this->login]);
         }
 
         Auth::login($this->login);

--- a/src/Controller/RssController.php
+++ b/src/Controller/RssController.php
@@ -95,6 +95,7 @@ class RssController extends BaseController
      * TODO: translations
      * TODO: ip based control
      * FIXME: duplicates logic that should be in Auth::checkAuthentication method
+     * TODO: use LoginController
      *
      * @throw InvalidArgumentException
      */


### PR DESCRIPTION
Move Login-Back-Off logic to MySQL adapter only: It makes no sense for other adapters than MySQL and they've implemented methods as dummy anyway. The external systems likely account themselves such logic.

The major concern was that the accounting was `usr_id` based, meaning unknown users are not accounted, to resolve that would need another table, which seems too much for now.

This also moves constants to setup config:
- `APP_FAILED_LOGIN_BACKOFF_COUNT`
- `APP_FAILED_LOGIN_BACKOFF_MINUTES`

refs:
- https://github.com/eventum/eventum/commit/780ddaa822866c432b97d92adfff3934a70eaa01
- https://github.com/eventum/eventum/pull/441#issuecomment-455273425
- https://github.com/eventum/eventum/pull/441#issuecomment-456530674




cc @balsdorf 
