### PR TITLE
Use symfony/var-exporter for writing config files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ first, also the PHP version required is 7.1, see [#426].
 - Allow auth adapters to be chained (@glensc, #441)
 - Remove Legacy CLI application (@glensc, #453)
 - Move Login-Back-Off logic to MySQL adapter only (@glensc, #455)
+- Use `symfony/var-exporter` for writing config files (@glensc, #456)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/composer.json
+++ b/composer.json
@@ -96,6 +96,7 @@
 		"symfony/http-foundation": "^2.7 || ^3.0 || ^4.0",
 		"symfony/ldap": "^2.7 || ^3.3 || ^4.0",
 		"symfony/security-csrf": "^3.4 || ^4.0",
+		"symfony/var-exporter": "^4.2",
 		"theorchard/monolog-cascade": "^0.5.0",
 		"willdurand/email-reply-parser": "^2.7.0",
 		"zendframework/zend-config": "2.4.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "20f817ff9ce99f0e55d995c8a33d19fd",
+    "content-hash": "aaafe17af84481c8beb19d23b2d5871d",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -3174,6 +3174,66 @@
             "description": "Symfony Serializer Component",
             "homepage": "https://symfony.com",
             "time": "2019-01-03T09:07:35+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v4.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "51bd782120fa2bfed89452f142d2a47c4b51101c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/51bd782120fa2bfed89452f142d2a47c4b51101c",
+                "reference": "51bd782120fa2bfed89452f142d2a47c4b51101c",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "require-dev": {
+                "symfony/var-dumper": "^4.1.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.2-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A blend of var_export() + serialize() to turn any serializable data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "serialize"
+            ],
+            "time": "2019-01-03T09:09:06+00:00"
         },
         {
             "name": "symfony/yaml",

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -28,7 +28,7 @@ class Setup
      *
      * @return Config The system-wide preferences
      */
-    public static function get()
+    public static function get(): Config
     {
         static $config;
         if (!$config) {
@@ -45,7 +45,7 @@ class Setup
      * @param array $options
      * @return Config returns the root config object
      */
-    public static function set($options)
+    public static function set($options): Config
     {
         $config = self::get();
         $config->merge(new Config($options));
@@ -60,7 +60,7 @@ class Setup
      * @param array $defaults
      * @return Config returns section that was just configured
      */
-    public static function setDefaults($section, array $defaults)
+    public static function setDefaults($section, array $defaults): Config
     {
         $config = self::get();
         $existing = $config[$section]->toArray();
@@ -104,29 +104,25 @@ class Setup
     }
 
     /**
-     * @return string
      * @since 3.5.0
      */
-    public static function getConfigPath()
+    public static function getConfigPath(): string
     {
-        return dirname(dirname(__DIR__)) . '/config';
+        return dirname(__DIR__, 2) . '/config';
     }
 
     /**
-     * @return string
      * @since 3.5.0
      */
-    public static function getSetupFile()
+    public static function getSetupFile(): string
     {
         return self::getConfigPath() . '/setup.php';
     }
 
     /**
      * Initialize config object, load it from setup files, merge defaults.
-     *
-     * @return Config
      */
-    private static function initialize()
+    private static function initialize(): Config
     {
         $config = new Config(self::getDefaults(), true);
         $config->merge(new Config(self::loadConfigFile(self::getSetupFile())));
@@ -157,7 +153,7 @@ class Setup
      * @param string $path
      * @return array
      */
-    private static function loadConfigFile($path)
+    private static function loadConfigFile($path): array
     {
         // return empty array if the file is empty
         // this is to help eventum installation wizard to proceed
@@ -176,7 +172,7 @@ class Setup
      * @param string $path
      * @param Config $config
      */
-    private static function saveConfig($path, Config $config)
+    private static function saveConfig($path, Config $config): void
     {
         $contents = self::dumpConfig($config);
 
@@ -190,11 +186,8 @@ class Setup
 
     /**
      * Export config in a format to be stored to config file
-     *
-     * @param Config $config
-     * @return string
      */
-    private static function dumpConfig(Config $config)
+    private static function dumpConfig(Config $config): string
     {
         return '<' . "?php\nreturn " . var_export($config->toArray(), 1) . ";\n";
     }
@@ -204,9 +197,9 @@ class Setup
      *
      * @return array of the default preferences
      */
-    private static function getDefaults()
+    private static function getDefaults(): array
     {
-        $appPath = dirname(dirname(__DIR__));
+        $appPath = dirname(__DIR__, 2);
 
         // at minimum should define top level array elements
         // so that fluent access works without errors and notices

--- a/src/Config/ConfigPersistence.php
+++ b/src/Config/ConfigPersistence.php
@@ -15,9 +15,13 @@ namespace Eventum\Config;
 
 use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
+use Symfony\Component\VarExporter\VarExporter;
 
 class ConfigPersistence
 {
+    public const PREFIX = "<?php\nreturn ";
+    public const SUFFIX = ";\n";
+
     /**
      * Load config from $path.
      * Config file should return configuration array.
@@ -60,7 +64,6 @@ class ConfigPersistence
      */
     private function serialize(array $config): string
     {
-        return '<' . "?php\nreturn " . var_export($config, true) . ";\n";
+        return self::PREFIX . VarExporter::export($config) . self::SUFFIX;
     }
-
 }

--- a/src/Config/ConfigPersistence.php
+++ b/src/Config/ConfigPersistence.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Config;
+
+use InvalidArgumentException;
+use Symfony\Component\Filesystem\Filesystem;
+
+class ConfigPersistence
+{
+    /**
+     * Load config from $path.
+     * Config file should return configuration array.
+     *
+     * @param string $path
+     * @return array
+     */
+    public function load(string $path): array
+    {
+        // return empty array if the file is empty
+        // this is to help eventum installation wizard to proceed
+        if (!file_exists($path) || !filesize($path)) {
+            return [];
+        }
+
+        /** @noinspection PhpIncludeInspection */
+        $config = require $path;
+
+        if (!is_array($config)) {
+            throw new InvalidArgumentException(
+                sprintf('The file "%s" did not return a valid PHP array when included', $path)
+            );
+        }
+
+        return $config;
+    }
+
+    /**
+     * @param string $path
+     * @param array $config
+     */
+    public function store($path, array $config): void
+    {
+        $fs = new Filesystem();
+        $fs->dumpFile($path, $this->serialize($config));
+    }
+
+    /**
+     * Export config in a format to be stored to config file
+     */
+    private function serialize(array $config): string
+    {
+        return '<' . "?php\nreturn " . var_export($config, true) . ";\n";
+    }
+
+}

--- a/tests/Config/ConfigPersistenceTest.php
+++ b/tests/Config/ConfigPersistenceTest.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Test\Config;
+
+use Eventum\Config\ConfigPersistence;
+use Eventum\Test\TestCase;
+
+class ConfigPersistenceTest extends TestCase
+{
+    /** @var ConfigPersistence */
+    private $handler;
+
+    public function setUp()
+    {
+        $this->handler = new ConfigPersistence();
+    }
+
+    public function testLoadStore(): void
+    {
+        $configDir = sys_get_temp_dir() . '/eventum_test';
+        $configFile = $configDir . '/setup.php';
+
+        $config = $this->handler->load($configFile);
+        $this->assertInternalType('array', $config, 'Loading missing file yelds empty config');
+
+        $this->handler->store($configFile, $config);
+        $contents = $this->readFile($configFile);
+        $expected = implode('', [ConfigPersistence::PREFIX, '[]', ConfigPersistence::SUFFIX]);
+        $this->assertEquals($expected, $contents, 'Stored config is valid PHP script');
+    }
+}


### PR DESCRIPTION
Benefit: writes configs with short PHP array syntax. More compact and readable result.

- [x] test simple config write
- [x] test config write with encryption enabled

cc @balsdorf 