### PR TITLE
Fix open issues report: set default number of days to exclude

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ first, also the PHP version required is 7.1, see [#426].
 - xmlrpc: verify token first to avoid incrementing failed logins (@glensc, #463)
 - Do issue duplication and close in same step (@glensc, #127)
 - Fixed bug when remove authorized replier removed only first user (@glensc, #464)
+- Fix open issues report: set default number of days to exclude (#458)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/src/Controller/Report/OpenIssuesController.php
+++ b/src/Controller/Report/OpenIssuesController.php
@@ -35,7 +35,7 @@ class OpenIssuesController extends ReportBaseController
         $post = $request->request;
         $get = $request->query;
 
-        $this->cutoff_days = $get->get('cutoff_days');
+        $this->cutoff_days = $get->getInt('cutoff_days', 7);
         $this->group_by_reporter = $post->getBoolean('group_by_reporter') ?: $get->getBoolean('group_by_reporter');
     }
 
@@ -51,7 +51,7 @@ class OpenIssuesController extends ReportBaseController
      */
     protected function prepareTemplate()
     {
-        $res = Report::getOpenIssuesByUser($this->prj_id, $this->cutoff_days ?: 7, $this->group_by_reporter);
+        $res = Report::getOpenIssuesByUser($this->prj_id, $this->cutoff_days, $this->group_by_reporter);
         $this->tpl->assign(
             [
                 'cutoff_days' => $this->cutoff_days,


### PR DESCRIPTION
Fix open issues reports generated by open_issues.php. Set default number of days to be excluded to zero and sanitize human input with casting to integer.