### PR TITLE
use DateTime::ATOM as DateTime::ISO8601 is not iso8601 compatible

### DIFF
--- a/lib/eventum/class.date_helper.php
+++ b/lib/eventum/class.date_helper.php
@@ -160,7 +160,7 @@ class Date_Helper
         if ($omit_offset) {
             $fmt = 'Y-m-d\TH:i:s';
         } else {
-            $fmt = DateTime::ISO8601;
+            $fmt = DateTime::ATOM;
         }
 
         return $date->format($fmt);


### PR DESCRIPTION
- https://www.reddit.com/r/ISO8601/comments/8lkcns/the_php_iso8601_date_format_is_not_actually/
- http://php.net/manual/en/class.datetimeinterface.php#datetime.constants.iso8601

the differences are:
```php
    const ISO8601 = 'Y-m-d\TH:i:sO';
    const ATOM    = 'Y-m-d\TH:i:sP';
```

http://ee1.php.net/manual/en/function.date.php#refsect1-function.date-parameters


format character | Description | Example returned values
-- | -- | --
O | Difference to Greenwich time (GMT) in hours  | Example: +0200
P | Difference to Greenwich time (GMT) with colon between hours and minutes (added in PHP 5.1.3)  | Example: +02:00
