### PR TITLE
xmlrpc: verify token first to avoid incrementing failed logins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ first, also the PHP version required is 7.1, see [#426].
 - Use `symfony/var-exporter` for writing config files (@glensc, #456)
 - Add support to fill Mentioned on data (@glensc, #447, #449)
 - Listen for Issue/Note GitLab events (@glensc, #337, #448)
+- xmlrpc: verify token first to avoid incrementing failed logins (@glensc, #463)
 
 [3.6.0]: https://github.com/eventum/eventum/compare/v3.5.6...master
 [#426]: https://github.com/eventum/eventum/pull/426

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -988,7 +988,7 @@ class User
     public static function updatePassword($usr_id, $password, $send_notification = false)
     {
         // reject setting empty password
-        if ($password == '') {
+        if ($password === '') {
             throw new InvalidArgumentException("Can't set empty password");
         }
 

--- a/src/RPC/XmlRpcServer.php
+++ b/src/RPC/XmlRpcServer.php
@@ -295,15 +295,9 @@ class XmlRpcServer
         return $res;
     }
 
-    /**
-     * @param string $email
-     * @param string $password
-     * @return bool
-     */
-    private function isValidLogin($email, $password)
+    private function isValidLogin(string $email, string $password): bool
     {
-        return Auth::isCorrectPassword($email, $password)
-            || APIAuthToken::isTokenValidForEmail($password, $email);
+        return APIAuthToken::isTokenValidForEmail($password, $email) || Auth::isCorrectPassword($email, $password);
     }
 
     /**


### PR DESCRIPTION
Resolves problem that system user failed login count keeps increasing:
- https://github.com/eventum/eventum/pull/455#issuecomment-460016804

altho there are no logs why it fail.

I also thought to disable `usr_last_login`/`usr_last_failed_login`/`usr_failed_logins` updating as these were added for login backoff functionality: 796a62d.

But then thought these are useful for audit purposes anyway. But then again, these aren't updated for non-mysql backends, sigh...