### PR TITLE
Tests: update to work with phpunit 8.x deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ cache:
   apt: true
   directories:
     - $HOME/.composer/cache
+    - $HOME/.composer/vendor
     - cache
     - vendor
 
@@ -68,7 +69,7 @@ install:
   - composer install --no-interaction --prefer-dist
 
 script:
-  - phpunit --version
+  - PATH=$HOME/.composer/vendor/bin:$PATH
   - phpunit --verbose --exclude-group ldap,imap,logger,mail,api,locale,date,db,crypto
 
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ first, also the PHP version required is 7.1, see [#426].
 
 - Update Phinx to 0.10 (@glensc, #388)
 - Detect invalid mail header starting with "From " and replace it with a correct custom one. (@vladsf, #439, #427)
-- Require PHP 7.1 and `ctype`, `mbstring`, `filter`, `fileinfo` extensions (@glensc, #426, #450, #446)
+- Require PHP 7.1 and `ctype`, `mbstring`, `filter`, `fileinfo` extensions (@glensc, #426, #450, #446, #468)
 - Drop Yii2 adapter; Improvements to AbstractMigration (@glensc, #442)
 - Secure unserialize: control `allowed_classes` options (@glensc, #445)
 - Drop MD5 and MD5-64 password support (@glensc, #444)

--- a/bin/ci/configure.sh
+++ b/bin/ci/configure.sh
@@ -8,6 +8,10 @@ install -d $PHP_INI_DIR
 #echo "extension=ldap.so" >> $PHP_INI_DIR/php.ini
 composer config platform.ext-ldap '0'
 
+# no gd for php 8.0
+# https://travis-ci.org/glensc/eventum/jobs/490544010
+composer config platform.ext-gd '0'
+
 # disable xdebug
 phpenv config-rm xdebug.ini || :
 

--- a/bin/ci/configure.sh
+++ b/bin/ci/configure.sh
@@ -21,3 +21,9 @@ composer config platform.ext-mcrypt '0'
 
 # disable secure-http because sourceforge redirects to http:// urls
 composer config secure-http false
+
+# install as global, because via composer autoloading is broken
+# due the way _setlocal gets defined based on context
+# $ vendor/bin/phpunit
+# PHP Fatal error:  Uncaught Error: Call to undefined function _setlocale() in /home/travis/build/glensc/eventum/lib/eventum/class.language.php:158
+composer global require "phpunit/phpunit" "^7.5 || ^8.0"

--- a/bin/ci/configure.sh
+++ b/bin/ci/configure.sh
@@ -26,4 +26,4 @@ composer config secure-http false
 # due the way _setlocal gets defined based on context
 # $ vendor/bin/phpunit
 # PHP Fatal error:  Uncaught Error: Call to undefined function _setlocale() in /home/travis/build/glensc/eventum/lib/eventum/class.language.php:158
-composer global require "phpunit/phpunit" "^7.5 || ^8.0"
+composer global require "phpunit/phpunit" "^7.5"

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
 	"minimum-stability": "dev",
 	"prefer-stable": true,
 	"require": {
-		"php": "^7.1.3",
+		"php": "^7.1.3 || ^8.0",
 		"ext-ctype": "*",
 		"ext-fileinfo": "*",
 		"ext-filter": "*",

--- a/tests/ActivateLinksTest.php
+++ b/tests/ActivateLinksTest.php
@@ -21,7 +21,7 @@ use Misc;
  */
 class ActivateLinksTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         Link_Filter::markdownEnabled(true);
     }
@@ -30,12 +30,12 @@ class ActivateLinksTest extends TestCase
      * @dataProvider ActivateLinksData
      * @see Misc::activateLinks
      */
-    public function testActivateLinks($text, $exp)
+    public function testActivateLinks($text, $exp): void
     {
         $this->assertEquals($exp, Misc::activateLinks($text));
     }
 
-    public function ActivateLinksData()
+    public function ActivateLinksData(): array
     {
         return [
             [

--- a/tests/AuthCookieTest.php
+++ b/tests/AuthCookieTest.php
@@ -30,14 +30,14 @@ class AuthCookieTest extends TestCase
         Auth::generatePrivateKey();
     }
 
-    public function testAuthCookie()
+    public function testAuthCookie(): void
     {
         $usr_id = APP_ADMIN_USER_ID;
         AuthCookie::setAuthCookie($usr_id);
         $this->assertNotEmpty(Auth::getUserID());
     }
 
-    public function testProjectCookie()
+    public function testProjectCookie(): void
     {
         $prj_id = 1;
         AuthCookie::setProjectCookie($prj_id);

--- a/tests/AuthCookieTest.php
+++ b/tests/AuthCookieTest.php
@@ -22,7 +22,7 @@ use Setup;
  */
 class AuthCookieTest extends TestCase
 {
-    public static function setupBeforeClass()
+    public static function setupBeforeClass(): void
     {
         if (file_exists(Setup::getConfigPath() . '/private_key.php')) {
             return;

--- a/tests/Config/ConfigPersistenceTest.php
+++ b/tests/Config/ConfigPersistenceTest.php
@@ -21,7 +21,7 @@ class ConfigPersistenceTest extends TestCase
     /** @var ConfigPersistence */
     private $handler;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->handler = new ConfigPersistence();
     }

--- a/tests/Config/ConfigPersistenceTest.php
+++ b/tests/Config/ConfigPersistenceTest.php
@@ -32,7 +32,7 @@ class ConfigPersistenceTest extends TestCase
         $configFile = $configDir . '/setup.php';
 
         $config = $this->handler->load($configFile);
-        $this->assertInternalType('array', $config, 'Loading missing file yelds empty config');
+        $this->assertIsArray($config, 'Loading missing file yelds empty config');
 
         $this->handler->store($configFile, $config);
         $contents = $this->readFile($configFile);

--- a/tests/Config/ConfigTest.php
+++ b/tests/Config/ConfigTest.php
@@ -18,7 +18,7 @@ use Setup;
 
 class ConfigTest extends TestCase
 {
-    public function testConfig()
+    public function testConfig(): void
     {
         $config = Setup::get();
 
@@ -66,7 +66,7 @@ class ConfigTest extends TestCase
      * that does not work (Indirect modification error),
      * so test version that works
      */
-    public function testSetType()
+    public function testSetType(): void
     {
         $config = Setup::get();
 
@@ -83,7 +83,7 @@ class ConfigTest extends TestCase
         $this->assertFalse($config['smtp']['auth']);
     }
 
-    public function testArrayEmpty()
+    public function testArrayEmpty(): void
     {
         $setup = Setup::get();
 
@@ -95,17 +95,17 @@ class ConfigTest extends TestCase
         $this->assertNull($setup['email_reminder']['addresses']);
 
         // check that this is false and does not trigger errors/notices
-        $this->assertFalse($setup['email_reminder']['status'] == 'enabled' && $setup['email_reminder']['addresses']);
+        $this->assertFalse($setup['email_reminder']['status'] === 'enabled' && $setup['email_reminder']['addresses']);
 
         $setup['email_reminder'] = [
             'status' => 'enabled',
             'aadresses' => [],
         ];
         // that empty addresses list is also false
-        $this->assertFalse($setup['email_reminder']['status'] == 'enabled' && $setup['email_reminder']['addresses']);
+        $this->assertFalse($setup['email_reminder']['status'] === 'enabled' && $setup['email_reminder']['addresses']);
     }
 
-    public function testArrayMerge()
+    public function testArrayMerge(): void
     {
         $defaults = [
             'email_routing' => [

--- a/tests/Crypto/CryptoTest.php
+++ b/tests/Crypto/CryptoTest.php
@@ -148,13 +148,13 @@ class CryptoTest extends TestCase
         $value = new EncryptedValue($encrypted);
 
         $f = function ($e) {
-            $f = function () {
+            $f2 = function ($e2) {
                 $e = new Exception('boo');
 
                 return $e->getTraceAsString();
             };
 
-            return $f($e);
+            return $f2($e);
         };
 
         $trace = $f($value);

--- a/tests/Crypto/CryptoTest.php
+++ b/tests/Crypto/CryptoTest.php
@@ -25,16 +25,16 @@ use InvalidArgumentException;
  */
 class CryptoTest extends TestCase
 {
-    public function testCanEncrypt()
+    public function testCanEncrypt(): void
     {
         $res = CryptoManager::canEncrypt();
         $this->assertTrue($res);
     }
 
     /**
-     * @test static encrypt and decrypt methods
+     * test static encrypt and decrypt methods
      */
-    public function testEncryptStatic()
+    public function testEncryptStatic(): void
     {
         $plaintext = 'tore';
         $encrypted = CryptoManager::encrypt($plaintext);
@@ -45,7 +45,7 @@ class CryptoTest extends TestCase
     /**
      * Test object instance which behaves as string, i.e __toString will return decrypted value
      */
-    public function testEncryptedValue()
+    public function testEncryptedValue(): void
     {
         $plaintext = 'tore';
         $encrypted = CryptoManager::encrypt($plaintext);
@@ -61,7 +61,7 @@ class CryptoTest extends TestCase
     /**
      * @expectedException Eventum\Crypto\CryptoException
      */
-    public function testCorruptedData()
+    public function testCorruptedData(): void
     {
         $plaintext = 'tore';
         $encrypted = CryptoManager::encrypt($plaintext);
@@ -73,7 +73,7 @@ class CryptoTest extends TestCase
         $value->getValue();
     }
 
-    public function testExport()
+    public function testExport(): void
     {
         $plaintext = 'tore';
         $encrypted = CryptoManager::encrypt($plaintext);
@@ -97,7 +97,7 @@ class CryptoTest extends TestCase
     /**
      * encrypt empty string is ok
      */
-    public function testEncryptEmptyString()
+    public function testEncryptEmptyString(): void
     {
         CryptoManager::encrypt('');
     }
@@ -107,7 +107,7 @@ class CryptoTest extends TestCase
      *
      * @expectedException InvalidArgumentException
      */
-    public function testEncryptNull()
+    public function testEncryptNull(): void
     {
         CryptoManager::encrypt(null);
     }
@@ -117,7 +117,7 @@ class CryptoTest extends TestCase
      *
      * @expectedException InvalidArgumentException
      */
-    public function testEncryptFalse()
+    public function testEncryptFalse(): void
     {
         CryptoManager::encrypt(false);
     }
@@ -125,7 +125,7 @@ class CryptoTest extends TestCase
     /**
      * encrypt "0" is ok
      */
-    public function testEncryptZeroString()
+    public function testEncryptZeroString(): void
     {
         CryptoManager::encrypt('0');
     }
@@ -133,7 +133,7 @@ class CryptoTest extends TestCase
     /**
      * encrypt 0 is ok
      */
-    public function testEncryptZero()
+    public function testEncryptZero(): void
     {
         CryptoManager::encrypt(0);
     }
@@ -141,7 +141,7 @@ class CryptoTest extends TestCase
     /**
      * Test that the object plain text value is not visible in backtraces
      */
-    public function testTraceVisibility()
+    public function testTraceVisibility(): void
     {
         $plaintext = 'tore';
         $encrypted = CryptoManager::encrypt($plaintext);
@@ -161,7 +161,7 @@ class CryptoTest extends TestCase
         $this->assertNotContains($plaintext, $trace);
     }
 
-    public function testZendCrypt()
+    public function testZendCrypt(): void
     {
         $key = 'secretkeyvalue';
         $method = 'aes-128-cbc';

--- a/tests/Date/DateHelperTest.php
+++ b/tests/Date/DateHelperTest.php
@@ -109,16 +109,16 @@ class DateHelperTest extends TestCase
      * @covers       Date_Helper::getRFC822Date
      * @dataProvider dataTestGetRFC822Date
      */
-    public function testGetRFC822Date($ts, $tz, $exp): void
+    public function testGetRFC822Date($ts, $exp): void
     {
-        $res = Date_Helper::getRFC822Date($ts, $tz);
+        $res = Date_Helper::getRFC822Date($ts);
         $this->assertEquals($exp, $res);
     }
 
     public function dataTestGetRFC822Date(): array
     {
         return [
-            [1411842757, false, 'Sat, 27 Sep 2014 18:32:37 GMT'],
+            [1411842757, 'Sat, 27 Sep 2014 18:32:37 GMT'],
         ];
     }
 

--- a/tests/Date/DateHelperTest.php
+++ b/tests/Date/DateHelperTest.php
@@ -28,15 +28,15 @@ class DateHelperTest extends TestCase
 {
     /**
      * @covers       Date_Helper::isAM
-     * @dataProvider testIsAM_data
+     * @dataProvider dataTestIsAM
      */
-    public function testIsAM($input, $exp)
+    public function testIsAM($input, $exp): void
     {
         $res = Date_Helper::isAM($input);
         $this->assertEquals($exp, $res);
     }
 
-    public function testIsAM_data()
+    public function dataTestIsAM(): array
     {
         return [
             [0, true],
@@ -48,15 +48,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::isPM
-     * @dataProvider testIsPM_data
+     * @dataProvider dataTestIsPM
      */
-    public function testIsPM($input, $exp)
+    public function testIsPM($input, $exp): void
     {
         $res = Date_Helper::isPM($input);
         $this->assertEquals($exp, $res);
     }
 
-    public function testIsPM_data()
+    public function dataTestIsPM(): array
     {
         return [
             [0, false],
@@ -68,15 +68,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::getFormattedDateDiff
-     * @dataProvider testGetFormattedDateDiff_data
+     * @dataProvider dataTestGetFormattedDateDiff
      */
-    public function testGetFormattedDateDiff($ts1, $ts2, $exp)
+    public function testGetFormattedDateDiff($ts1, $ts2, $exp): void
     {
         $res = Date_Helper::getFormattedDateDiff($ts1, $ts2);
         $this->assertEquals($exp, $res);
     }
 
-    public function testGetFormattedDateDiff_data()
+    public function dataTestGetFormattedDateDiff(): array
     {
         return [
             [0, 10, '0d 0h'],
@@ -88,15 +88,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::getUnixTimestamp
-     * @dataProvider testGetUnixTimestamp_data
+     * @dataProvider dataTestGetUnixTimestamp
      */
-    public function testGetUnixTimestamp($ts, $tz, $exp)
+    public function testGetUnixTimestamp($ts, $tz, $exp): void
     {
         $res = Date_Helper::getUnixTimestamp($ts, $tz);
         $this->assertEquals($exp, $res);
     }
 
-    public function testGetUnixTimestamp_data()
+    public function dataTestGetUnixTimestamp(): array
     {
         return [
             // unix timestamps are timezoneless
@@ -107,15 +107,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::getRFC822Date
-     * @dataProvider testGetRFC822Date_data
+     * @dataProvider dataTestGetRFC822Date
      */
-    public function testGetRFC822Date($ts, $tz, $exp)
+    public function testGetRFC822Date($ts, $tz, $exp): void
     {
         $res = Date_Helper::getRFC822Date($ts, $tz);
         $this->assertEquals($exp, $res);
     }
 
-    public function testGetRFC822Date_data()
+    public function dataTestGetRFC822Date(): array
     {
         return [
             [1411842757, false, 'Sat, 27 Sep 2014 18:32:37 GMT'],
@@ -124,15 +124,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::getFormattedDate
-     * @dataProvider testGetFormattedDate_data
+     * @dataProvider dataTestGetFormattedDate
      */
-    public function testGetFormattedDate($input, $exp)
+    public function testGetFormattedDate($input, $exp): void
     {
         $res = Date_Helper::getFormattedDate($input);
         $this->assertEquals($exp, $res);
     }
 
-    public function testGetFormattedDate_data()
+    public function dataTestGetFormattedDate(): array
     {
         return [
             [0, 'Thu, 01 Jan 1970, 00:00:00 GMT'],
@@ -142,15 +142,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::getSimpleDate
-     * @dataProvider testGetSimpleDate_data
+     * @dataProvider dataTestGetSimpleDate
      */
-    public function testGetSimpleDate($ts, $convert, $exp)
+    public function testGetSimpleDate($ts, $convert, $exp): void
     {
         $res = Date_Helper::getSimpleDate($ts, $convert);
         $this->assertEquals($exp, $res);
     }
 
-    public function testGetSimpleDate_data()
+    public function dataTestGetSimpleDate(): array
     {
         return [
             [1391212800, false, '01 Feb 2014'],
@@ -162,15 +162,15 @@ class DateHelperTest extends TestCase
 
     /**
      * @covers       Date_Helper::convertDateGMT
-     * @dataProvider testConvertDateGMT_data
+     * @dataProvider dataTestConvertDateGMT
      */
-    public function testConvertDateGMT($date, $exp)
+    public function testConvertDateGMT($date, $exp): void
     {
         $res = Date_Helper::convertDateGMT($date);
         $this->assertEquals($exp, $res);
     }
 
-    public function testConvertDateGMT_data()
+    public function dataTestConvertDateGMT(): array
     {
         return [
             ['2014-09-27 00:00:00', '2014-09-27 00:00:00'],
@@ -180,15 +180,15 @@ class DateHelperTest extends TestCase
     }
 
     /**
-     * @dataProvider testInvalidTimezone_data
+     * @dataProvider dataTestInvalidTimezone
      */
-    public function testInvalidTimezone($ts, $tz, $exp)
+    public function testInvalidTimezone($ts, $tz, $exp): void
     {
         $date = Date_Helper::getFormattedDate($ts, $tz);
         $this->assertEquals($exp, $date);
     }
 
-    public function testInvalidTimezone_data()
+    public function dataTestInvalidTimezone(): array
     {
         return [
             ['Sat Oct 11 11:51:12 EEST 2014', 'Europe/Tallinn', 'Sat, 11 Oct 2014, 11:51:12 EEST'],
@@ -199,7 +199,7 @@ class DateHelperTest extends TestCase
         ];
     }
 
-    public function testGetTimezoneList()
+    public function testGetTimezoneList(): void
     {
         $pear_timezones = require __DIR__ . '/../data/timezones.php';
         $timezones = Date_Helper::getTimezoneList();
@@ -211,7 +211,7 @@ class DateHelperTest extends TestCase
 //        print_r($diff);
     }
 
-    public function testTzNamingDifferences()
+    public function testTzNamingDifferences(): void
     {
         $created_date = Date_Helper::convertDateGMT('2015-05-19 12:22:24 EET');
         $this->assertEquals('2015-05-19 10:22:24', $created_date);
@@ -226,7 +226,7 @@ class DateHelperTest extends TestCase
     /**
      * @see https://github.com/eventum/eventum/issues/204
      */
-    public function testBug_204()
+    public function testBug_204(): void
     {
         try {
             Date_Helper::convertDateGMT('2016-10-03 10:20:00 US/Central');

--- a/tests/Date/DateHelperUserTest.php
+++ b/tests/Date/DateHelperUserTest.php
@@ -28,16 +28,16 @@ class DateHelperUserTest extends TestCase
     /**
      * timezone used for preferred user timezone tests
      */
-    const USER_TIMEZONE = 'Europe/Tallinn';
-    const ADMIN_TIMEZONE = 'UTC';
+    private const USER_TIMEZONE = 'Europe/Tallinn';
+    private const ADMIN_TIMEZONE = 'UTC';
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::setTimezone(APP_ADMIN_USER_ID, self::USER_TIMEZONE);
         self::setTimezone(APP_SYSTEM_USER_ID, self::ADMIN_TIMEZONE);
     }
 
-    private function setTimezone($usr_id, $timezone)
+    private static function setTimezone($usr_id, $timezone): void
     {
         $prefs = Prefs::get($usr_id);
         $prefs['timezone'] = $timezone;
@@ -47,9 +47,9 @@ class DateHelperUserTest extends TestCase
     }
 
     /**
-     * @covers  Date_Helper::getTimezoneShortNameByUser
+     * @covers Date_Helper::getTimezoneShortNameByUser
      */
-    public function testGetTimezoneShortNameByUser()
+    public function testGetTimezoneShortNameByUser(): void
     {
         $res = Date_Helper::getTimezoneShortNameByUser(APP_SYSTEM_USER_ID);
         $this->assertEquals('UTC', $res);
@@ -59,9 +59,9 @@ class DateHelperUserTest extends TestCase
     }
 
     /**
-     * @covers  Date_Helper::getPreferredTimezone
+     * @covers Date_Helper::getPreferredTimezone
      */
-    public function testGetPreferredTimezone()
+    public function testGetPreferredTimezone(): void
     {
         $res = Date_Helper::getPreferredTimezone();
         $this->assertEquals('UTC', $res);

--- a/tests/Db/DbApiTest.php
+++ b/tests/Db/DbApiTest.php
@@ -22,7 +22,7 @@ use Eventum\Test\TestCase;
  */
 class DbApiTest extends TestCase
 {
-    public function testNullApi()
+    public function testNullApi(): void
     {
         $config = DB_Helper::getConfig();
         $instance = new NullAdapter($config);

--- a/tests/Db/DbExceptionTest.php
+++ b/tests/Db/DbExceptionTest.php
@@ -15,12 +15,13 @@ namespace Eventum\Test\Db;
 
 use Eventum\Db\DatabaseException;
 use Eventum\Test\TestCase;
+use Exception;
 use PDOException;
 use ReflectionClass;
 
 class DbExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException(): void
     {
         $message = "SQLSTATE[HY000]: General error: 144 Table './eventum/mail_queue' is marked as crashed and last (automatic?) repair failed";
         $code = 'HY000';
@@ -40,13 +41,8 @@ class DbExceptionTest extends TestCase
      * because it expects integer (PDOException extends Exception).
      *
      * Fill the value with Reflection.
-     *
-     * @param string $class
-     * @param string $message
-     * @param string $code
-     * @return object
      */
-    private function createException($class, $message, $code)
+    private function createException(string $class, string $message, string $code): Exception
     {
         $e = new $class($message);
         $class = new ReflectionClass($e);

--- a/tests/Db/DbHelperTest.php
+++ b/tests/Db/DbHelperTest.php
@@ -18,7 +18,7 @@ use Eventum\Test\TestCase;
 
 class DbHelperTest extends TestCase
 {
-    public function testBuildSet()
+    public function testBuildSet(): void
     {
         $params = [
             'a' => 'b',
@@ -39,7 +39,7 @@ class DbHelperTest extends TestCase
         $this->assertEquals($exp, $res);
     }
 
-    public function testBuildList()
+    public function testBuildList(): void
     {
         // simple test
         $ids = [
@@ -72,7 +72,7 @@ class DbHelperTest extends TestCase
         $this->assertEquals($exp, $res);
     }
 
-    public function testOrderBy()
+    public function testOrderBy(): void
     {
         $res = DB_Helper::orderBy('ASC');
         $this->assertEquals('ASC', $res);

--- a/tests/Db/DbTest.php
+++ b/tests/Db/DbTest.php
@@ -29,7 +29,7 @@ class DbTest extends TestCase
      */
     private $db;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->db = DB_Helper::getInstance(false);
     }
@@ -37,13 +37,13 @@ class DbTest extends TestCase
     /**
      * @dataProvider quoteData
      */
-    public function testQuote($input, $exp)
+    public function testQuote($input, $exp): void
     {
         $res = $this->db->escapeSimple($input);
         $this->assertEquals($exp, $res);
     }
 
-    public function quoteData()
+    public function quoteData(): array
     {
         return [
             ["C'est La Vie", "C\\'est La Vie"],
@@ -52,14 +52,14 @@ class DbTest extends TestCase
     }
 
     /** @group query */
-    public function testQuery()
+    public function testQuery(): void
     {
         $res = $this->db->query('update `user` set usr_lang=? where 1=0', ['en_US']);
         $this->assertEquals(true, $res);
     }
 
     /** @group getAll */
-    public function testGetAllDefault()
+    public function testGetAllDefault(): void
     {
         $res = $this->db->getAll(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?', [2],
@@ -84,7 +84,7 @@ class DbTest extends TestCase
     }
 
     /** @group getAll */
-    public function testGetAllAssoc()
+    public function testGetAllAssoc(): void
     {
         $res = $this->db->getAll(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=? AND usr_id!=42', [2],
@@ -109,7 +109,7 @@ class DbTest extends TestCase
     }
 
     /** @group fetchAssoc */
-    public function testFetchAssocDefault()
+    public function testFetchAssocDefault(): void
     {
         $res = $this->db->fetchAssoc(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?',
@@ -134,7 +134,7 @@ class DbTest extends TestCase
     }
 
     /** @group fetchAssoc */
-    public function testFetchAssocAssoc()
+    public function testFetchAssocAssoc(): void
     {
         $res = $this->db->fetchAssoc(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?',
@@ -164,7 +164,7 @@ class DbTest extends TestCase
      *
      * @group fetchAssoc
      */
-    public function testFetchAssoc()
+    public function testFetchAssoc(): void
     {
         $stmt = 'SELECT sta_id, sta_title FROM `status` ORDER BY sta_rank ASC';
         $res = $this->db->getPair($stmt);
@@ -180,7 +180,7 @@ class DbTest extends TestCase
     }
 
     /** @group getColumn */
-    public function testGetColumn()
+    public function testGetColumn(): void
     {
         $res = $this->db->getColumn(
             'SELECT usr_full_name FROM `user` WHERE usr_id<=?',
@@ -196,7 +196,7 @@ class DbTest extends TestCase
     }
 
     /** @group getOne */
-    public function testGetOne()
+    public function testGetOne(): void
     {
         $res = $this->db->getOne(
             'SELECT usr_id FROM `user` WHERE usr_email=?', ['nosuchemail@.-']
@@ -210,7 +210,7 @@ class DbTest extends TestCase
     }
 
     /** @group getPair */
-    public function testGetPair()
+    public function testGetPair(): void
     {
         $res = $this->db->getPair(
             'SELECT usr_id,usr_full_name FROM `user` WHERE usr_email=?', ['nosuchemail@.-']
@@ -227,7 +227,7 @@ class DbTest extends TestCase
     }
 
     /** @group getRow */
-    public function testGetRowDefault()
+    public function testGetRowDefault(): void
     {
         $res = $this->db->getRow(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?',
@@ -245,7 +245,7 @@ class DbTest extends TestCase
     }
 
     /** @group getRow */
-    public function testGetRowAssoc()
+    public function testGetRowAssoc(): void
     {
         $res = $this->db->getRow(
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?',
@@ -262,7 +262,7 @@ class DbTest extends TestCase
         $this->assertEquals($exp, $res);
     }
 
-    public function testBuildSet()
+    public function testBuildSet(): void
     {
         $table = 'test_' . __FUNCTION__;
         $this->db->query("CREATE TEMPORARY TABLE $table (id INT, v1 CHAR(1), v2 CHAR(2))");

--- a/tests/Db/DbTest.php
+++ b/tests/Db/DbTest.php
@@ -65,7 +65,7 @@ class DbTest extends TestCase
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=?', [2],
             AdapterInterface::DB_FETCHMODE_DEFAULT
         );
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             0 => [
                 0 => 1,
@@ -90,7 +90,7 @@ class DbTest extends TestCase
             'SELECT usr_id,usr_full_name,usr_email,usr_lang FROM `user` WHERE usr_id<=? AND usr_id!=42', [2],
             AdapterInterface::DB_FETCHMODE_ASSOC
         );
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             0 => [
                 'usr_id' => 1,
@@ -117,7 +117,7 @@ class DbTest extends TestCase
             AdapterInterface::DB_FETCHMODE_DEFAULT
         );
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             1 => [
                 0 => 'system',
@@ -142,7 +142,7 @@ class DbTest extends TestCase
             AdapterInterface::DB_FETCHMODE_ASSOC
         );
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             1 => [
                 'usr_full_name' => 'system',
@@ -187,7 +187,7 @@ class DbTest extends TestCase
             [2]
         );
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             0 => 'system',
             1 => 'Admin User',
@@ -215,13 +215,13 @@ class DbTest extends TestCase
         $res = $this->db->getPair(
             'SELECT usr_id,usr_full_name FROM `user` WHERE usr_email=?', ['nosuchemail@.-']
         );
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertEmpty($res);
 
         $res = $this->db->getPair(
             'SELECT usr_id,usr_full_name FROM `user` WHERE usr_id<=2'
         );
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [1 => 'system', 2 => 'Admin User'];
         $this->assertEquals($exp, $res);
     }
@@ -234,7 +234,7 @@ class DbTest extends TestCase
             [2], AdapterInterface::DB_FETCHMODE_DEFAULT
         );
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             0 => '1',
             1 => 'system',
@@ -252,7 +252,7 @@ class DbTest extends TestCase
             [2], AdapterInterface::DB_FETCHMODE_ASSOC
         );
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $exp = [
             'usr_id' => '1',
             'usr_full_name' => 'system',

--- a/tests/Db/DoctrineTest.php
+++ b/tests/Db/DoctrineTest.php
@@ -27,7 +27,7 @@ use Eventum\Test\TestCase;
  */
 class DoctrineTest extends TestCase
 {
-    public function testFindAll()
+    public function testFindAll(): void
     {
         $repo = $this->getEntityManager()->getRepository(Entity\Project::class);
         $projects = $repo->findAll();
@@ -40,7 +40,7 @@ class DoctrineTest extends TestCase
         }
     }
 
-    public function test2()
+    public function test2(): void
     {
         $repo = Doctrine::getCommitRepository();
         $items = $repo->findBy([], null, 10);
@@ -53,7 +53,7 @@ class DoctrineTest extends TestCase
         }
     }
 
-    public function test3()
+    public function test3(): void
     {
         $repo = Doctrine::getCommitRepository();
         $qb = $repo->createQueryBuilder('commit');
@@ -66,7 +66,7 @@ class DoctrineTest extends TestCase
         print_r($items);
     }
 
-    public function testDeleteByQuery()
+    public function testDeleteByQuery(): void
     {
         $issue_id = 13;
         $associated_issue_id = 12;
@@ -92,7 +92,7 @@ class DoctrineTest extends TestCase
     /**
      * @throws \Doctrine\ORM\EntityNotFoundException
      */
-    public function testProjectStatusId()
+    public function testProjectStatusId(): void
     {
         /** @var ProjectRepository $repo */
         $repo = $this->getEntityManager()->getRepository(Entity\Project::class);
@@ -104,7 +104,7 @@ class DoctrineTest extends TestCase
         dump($status_id);
     }
 
-    public function testUserModel()
+    public function testUserModel(): void
     {
         $repo = $this->getEntityManager()->getRepository(Entity\User::class);
         $items = $repo->findBy([], null, 1);
@@ -112,7 +112,7 @@ class DoctrineTest extends TestCase
         dump($items);
     }
 
-    public function testIssueRepository()
+    public function testIssueRepository(): void
     {
         $em = Doctrine::getEntityManager();
         $repo = $em->getRepository(Entity\Issue::class);
@@ -137,7 +137,7 @@ class DoctrineTest extends TestCase
         $this->assertInstanceOf(Entity\CommitFile::class, $file);
     }
 
-    public function testIssueAddCommit()
+    public function testIssueAddCommit(): void
     {
         $em = Doctrine::getEntityManager();
         $repo = $em->getRepository(Entity\Issue::class);
@@ -166,7 +166,7 @@ class DoctrineTest extends TestCase
         $em->flush();
     }
 
-    public function testAddCommit()
+    public function testAddCommit(): void
     {
         $issue_id = 1;
 
@@ -174,7 +174,7 @@ class DoctrineTest extends TestCase
         $issue->setId(1);
     }
 
-    public function testUserRepository()
+    public function testUserRepository(): void
     {
         /** @var UserRepository $repo */
         $repo = $this->getEntityManager()->getRepository(Entity\User::class);

--- a/tests/Dispatcher/ExtensionSubscribeTest.php
+++ b/tests/Dispatcher/ExtensionSubscribeTest.php
@@ -24,7 +24,7 @@ class ExtensionSubscribeTest extends TestCase
     const RESPONSE = 'response';
     const NAME = 'response';
 
-    public function testExtensionEvents()
+    public function testExtensionEvents(): void
     {
         $config = [
             Extension1::class => __FILE__,

--- a/tests/Dispatcher/ExtensionSubscribeTest.php
+++ b/tests/Dispatcher/ExtensionSubscribeTest.php
@@ -21,8 +21,8 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class ExtensionSubscribeTest extends TestCase
 {
-    const RESPONSE = 'response';
-    const NAME = 'response';
+    public const RESPONSE = 'eventum_event_response';
+    public const NAME = 'eventum_event_name';
 
     public function testExtensionEvents(): void
     {
@@ -39,8 +39,8 @@ class ExtensionSubscribeTest extends TestCase
         }
 
         $event = new Event();
-        $dispatcher->dispatch('response', $event);
-        $dispatcher->dispatch('name', $event);
+        $dispatcher->dispatch(self::RESPONSE, $event);
+        $dispatcher->dispatch(self::NAME, $event);
 
         $id = StoreSubscriber::class;
         $res = $event->{$id};
@@ -60,7 +60,7 @@ class Extension1 extends AbstractExtension
 
 class Extension2 extends AbstractExtension
 {
-    public function getSubscribers()
+    public function getSubscribers(): array
     {
         return [
             StoreSubscriber::class,
@@ -77,28 +77,28 @@ class StoreSubscriber implements EventSubscriberInterface
         $this->id = __CLASS__;
     }
 
-    public static function getSubscribedEvents()
+    public static function getSubscribedEvents(): array
     {
         return [
-            'response' => [
+            ExtensionSubscribeTest::RESPONSE => [
                 ['onKernelResponsePre', 10],
                 ['onKernelResponsePost', -10],
             ],
-            'name' => 'onStoreOrder',
+            ExtensionSubscribeTest::NAME => 'onStoreOrder',
         ];
     }
 
-    public function onKernelResponsePre(Event $event)
+    public function onKernelResponsePre(Event $event): void
     {
         $event->{$this->id}[] = __FUNCTION__;
     }
 
-    public function onKernelResponsePost(Event $event)
+    public function onKernelResponsePost(Event $event): void
     {
         $event->{$this->id}[] = __FUNCTION__;
     }
 
-    public function onStoreOrder(Event $event)
+    public function onStoreOrder(Event $event): void
     {
         $event->{$this->id}[] = __FUNCTION__;
     }

--- a/tests/Extension/ExtensionManagerTest.php
+++ b/tests/Extension/ExtensionManagerTest.php
@@ -14,7 +14,6 @@
 namespace Eventum\Test\Extension;
 
 use Eventum\Extension\AbstractExtension;
-use Eventum\Extension\ExtensionInterface;
 use Eventum\Test\TestCase;
 
 /**
@@ -37,9 +36,9 @@ class ExtensionManagerTest extends TestCase
     }
 }
 
-class TestExtension1 extends AbstractExtension implements ExtensionInterface
+class TestExtension1 extends AbstractExtension
 {
-    public function getAvailableWorkflows()
+    public function getAvailableWorkflows(): array
     {
         return [
             __CLASS__,
@@ -47,16 +46,16 @@ class TestExtension1 extends AbstractExtension implements ExtensionInterface
     }
 }
 
-class TestExtension2 extends AbstractExtension implements ExtensionInterface
+class TestExtension2 extends AbstractExtension
 {
-    public function registerAutoloader($loader)
+    public function registerAutoloader($loader): void
     {
         $baseDir = __DIR__ . '/../../docs/examples/workflow';
         $classMap = ['Example_Workflow_Backend' => $baseDir . '/class.example.php'];
         $loader->addClassMap($classMap);
     }
 
-    public function getAvailableWorkflows()
+    public function getAvailableWorkflows(): array
     {
         return [
             'Example_Workflow_Backend',

--- a/tests/Extension/ExtensionManagerTest.php
+++ b/tests/Extension/ExtensionManagerTest.php
@@ -24,10 +24,7 @@ use Eventum\Test\TestCase;
  */
 class ExtensionManagerTest extends TestCase
 {
-    /**
-     * @requires PHPUnit 4.8
-     */
-    public function testWorkflowList()
+    public function testWorkflowList(): void
     {
         $config = [
             TestExtension1::class => __FILE__,

--- a/tests/Extension/LegacyExtensionTest.php
+++ b/tests/Extension/LegacyExtensionTest.php
@@ -23,14 +23,14 @@ use Workflow;
  */
 class LegacyExtensionTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         // ExtensionManager needs to be booted
         // for the getBackend methods to succeed
         ExtensionManager::getManager();
     }
 
-    public function testGetWorkflow()
+    public function testGetWorkflow(): void
     {
         $prj_id = 1;
         Workflow::_getBackend($prj_id);

--- a/tests/FlysystemTest.php
+++ b/tests/FlysystemTest.php
@@ -21,7 +21,7 @@ use Phlib\Flysystem\Pdo\PdoAdapter;
 
 class FlysystemTest extends TestCase
 {
-    public function testLocalAdapter()
+    public function testLocalAdapter(): void
     {
         $adapter = new Local(__DIR__ . '/data');
         $filesystem = new Filesystem($adapter);
@@ -41,7 +41,7 @@ class FlysystemTest extends TestCase
     /**
      * @group db
      */
-    public function testPhlibFlysystemPdo()
+    public function testPhlibFlysystemPdo(): void
     {
         /** @var PdoAdapter $db */
         $db = DB_Helper::getInstance();

--- a/tests/HistoryTest.php
+++ b/tests/HistoryTest.php
@@ -17,7 +17,7 @@ use Misc;
 
 class HistoryTest extends TestCase
 {
-    public function testHistoryContext()
+    public function testHistoryContext(): void
     {
         $message = "Issue updated to status '{status}' by {actor}";
         $context = [

--- a/tests/IssueAssociationTest.php
+++ b/tests/IssueAssociationTest.php
@@ -25,7 +25,7 @@ class IssueAssociationTest extends TestCase
     /** @var \Doctrine\ORM\EntityRepository|IssueAssociationRepository */
     private $repo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $em = $this->getEntityManager();
         $this->repo = Doctrine::getIssueAssociationRepository();
@@ -34,7 +34,7 @@ class IssueAssociationTest extends TestCase
         $this->repo->deleteAllRelations($issues);
     }
 
-    public function testAssociateIssue()
+    public function testAssociateIssue(): void
     {
         $usr_id = APP_SYSTEM_USER_ID;
         $iss1_id = 12;
@@ -79,7 +79,7 @@ class IssueAssociationTest extends TestCase
         }
     }
 
-    public function testBulkUpdate()
+    public function testBulkUpdate(): void
     {
         $usr_id = APP_SYSTEM_USER_ID;
         $issue_id = 12;
@@ -108,7 +108,7 @@ class IssueAssociationTest extends TestCase
      * @see \Issue::getAssociatedIssuesDetails();
      * @see \Issue::getAssociatedIssues();
      */
-    public function testGetDetails()
+    public function testGetDetails(): void
     {
         $usr_id = APP_SYSTEM_USER_ID;
         $iss1_id = 12;

--- a/tests/IssueLockTest.php
+++ b/tests/IssueLockTest.php
@@ -21,7 +21,7 @@ class IssueLockTest extends TestCase
     /**
      * @group slow
      */
-    public function testLock()
+    public function testLock(): void
     {
         $issue_id = 1;
         $locker = 'admin';

--- a/tests/IssueMatcherTest.php
+++ b/tests/IssueMatcherTest.php
@@ -20,7 +20,7 @@ class IssueMatcherTest extends TestCase
     /** @var IssueMatcher */
     private $matcher;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->matcher = new IssueMatcher('http://eventum.example.lan/');
     }
@@ -34,7 +34,7 @@ class IssueMatcherTest extends TestCase
         $this->assertEquals($expected, $result);
     }
 
-    public function dataProvider()
+    public function dataProvider(): array
     {
         return [
             'no match' => [

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -21,10 +21,10 @@ use Link_Filter;
 class LinkFilterTest extends TestCase
 {
     /**
-     * @dataProvider testIssueLinking_data
+     * @dataProvider dataTestIssueLinking
      * @see          Link_Filter::proccessText
      */
-    public function testIssueLinking($text, $exp)
+    public function testIssueLinking($text, $exp): void
     {
         $filters = Link_Filter::getFilters();
 
@@ -41,7 +41,7 @@ class LinkFilterTest extends TestCase
         $this->assertRegExp($exp, $text);
     }
 
-    public function testIssueLinking_data()
+    public function dataTestIssueLinking(): array
     {
         return [
             0 => [

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -21,7 +21,7 @@ use RuntimeException;
  */
 class LocaleTest extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         if (!getenv('TRAVIS')) {
             self::markTestSkipped('Tests require full localedb installation');
@@ -34,7 +34,7 @@ class LocaleTest extends TestCase
         }
     }
 
-    private static function installLocales()
+    private static function installLocales(): void
     {
         $localeDir = APP_PATH . '/localization';
 
@@ -45,17 +45,16 @@ class LocaleTest extends TestCase
     }
 
     /**
-     * @test
      * @dataProvider availableLanguages
      * @group locale
      */
-    public function testLocales($code, $language)
+    public function testLocales($code, $language): void
     {
         $enabled = Language::set($code);
         $this->assertTrue($enabled, "Language '$language' ($code) is valid");
     }
 
-    public function availableLanguages()
+    public function availableLanguages(): array
     {
         $langs = Language::getAvailableLanguages(false);
 

--- a/tests/Logger/LoggerTest.php
+++ b/tests/Logger/LoggerTest.php
@@ -27,7 +27,7 @@ use PEAR_Error;
  */
 class LoggerTest extends TestCase
 {
-    public function testLogger()
+    public function testLogger(): void
     {
         // create a log channel
         $log = new Monolog\Logger('eventum');
@@ -39,13 +39,13 @@ class LoggerTest extends TestCase
         $log->addError('Bar');
     }
 
-    public function testLoggerRegistry()
+    public function testLoggerRegistry(): void
     {
         Logger::app()->addError('Sent to $app Logger instance');
         Logger::db()->addError('Sent to $db Logger instance');
     }
 
-    public function testLoggerCreateLogger()
+    public function testLoggerCreateLogger(): void
     {
         $logger = Logger::createLogger('ldap');
         $logger->error('ldap error 1');
@@ -55,7 +55,7 @@ class LoggerTest extends TestCase
     /**
      * @group db
      */
-    public function testDbError()
+    public function testDbError(): void
     {
         try {
             DB_Helper::getInstance()->query('here -->?<-- be dragons?', ['param1', 'param2']);
@@ -64,9 +64,9 @@ class LoggerTest extends TestCase
     }
 
     /**
-     * @test what happens if i just log exception object
+     * test what happens if i just log exception object
      */
-    public function testLogException()
+    public function testLogException(): void
     {
         $e = new Exception('It happened');
 
@@ -74,7 +74,7 @@ class LoggerTest extends TestCase
         Logger::app()->error($e->getMessage(), ['exception' => $e]);
     }
 
-    public function testLogPearException()
+    public function testLogPearException(): void
     {
         $e = new PEAR_Error('It happened');
 
@@ -85,7 +85,7 @@ class LoggerTest extends TestCase
         Logger::app()->error($e->getMessage(), ['debug' => $e->getDebugInfo()]);
     }
 
-    public function testCliLog()
+    public function testCliLog(): void
     {
         Logger::cli()->info('moo');
     }

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -18,7 +18,7 @@ use Eventum\Test\TestCase;
 
 class AttachmentTest extends TestCase
 {
-    public function testHasAttachments()
+    public function testHasAttachments(): void
     {
         $raw = "Message-ID: <33@JON>X-foo: 1\r\n\r\nada";
         $message = MailMessage::createFromString($raw);
@@ -48,7 +48,7 @@ class AttachmentTest extends TestCase
      * Uncaught Exception Zend\Mail\Storage\Exception\InvalidArgumentException:
      * "Header with Name Content-Disposition or content-disposition not found"
      */
-    public function testHasAttachmentPlain()
+    public function testHasAttachmentPlain(): void
     {
         $content = $this->readDataFile('attachment-bug.txt');
         $message = MailMessage::createFromString($content);
@@ -56,7 +56,7 @@ class AttachmentTest extends TestCase
         $this->assertTrue($attachments->hasAttachments());
     }
 
-    public function testGetAttachments()
+    public function testGetAttachments(): void
     {
         $raw = $this->readDataFile('bug684922.txt');
 
@@ -77,7 +77,7 @@ class AttachmentTest extends TestCase
      * Multipart/related contains attachment.
      * Current implementation sees 2 attachments, should see 3.
      */
-    public function testMultipartRelatedAttachments()
+    public function testMultipartRelatedAttachments(): void
     {
         $content = $this->readDataFile('102232.txt');
 
@@ -90,7 +90,7 @@ class AttachmentTest extends TestCase
         $this->assertCount(1, $attachments);
     }
 
-    public function testAttachmentWithDeliveryStatus()
+    public function testAttachmentWithDeliveryStatus(): void
     {
         $content = $this->readDataFile('attachment-bug.txt');
         $mail = MailMessage::createFromString($content);
@@ -104,7 +104,7 @@ class AttachmentTest extends TestCase
     /**
      * it should not account multipart/alternative as an attachment
      */
-    public function testMultipartAlternative()
+    public function testMultipartAlternative(): void
     {
         $content = $this->readDataFile('multipart-mixed-alternative-attachment.eml');
         $mail = MailMessage::createFromString($content);
@@ -119,7 +119,7 @@ class AttachmentTest extends TestCase
      * process multipart/related,
      * should not consider text/plain and multipart/related as attachments.
      */
-    public function testMultipartRelatedWithText()
+    public function testMultipartRelatedWithText(): void
     {
         $content = $this->readDataFile('multipart-related.eml');
         $mail = MailMessage::createFromString($content);

--- a/tests/Mail/ForwardedRoutingTest.php
+++ b/tests/Mail/ForwardedRoutingTest.php
@@ -26,7 +26,7 @@ class ForwardedRoutingTest extends TestCase
      * i.e if mail has Matching In-Reply-To header, but also X-Forwarded-Message-Id header
      * the email is not associated by new issue created
      */
-    public function testForwardedMailRouting()
+    public function testForwardedMailRouting(): void
     {
         $full_message = $this->readDataFile('thunderbird-forwarded.txt');
         $mail = MailMessage::createFromString($full_message);

--- a/tests/Mail/GmailTransportTest.php
+++ b/tests/Mail/GmailTransportTest.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Test\Mail;
 
+use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
 use Eventum\Test\TestCase;
 use Setup;
@@ -36,7 +37,8 @@ class GmailTransportTest extends TestCase
         $address = 'glen@delfi.ee';
         $headers = [];
         $body = 'test';
-        $mail->send($address, $headers, $body);
+        $message = MailMessage::createFromHeaderBody($headers, $body);
+        $mail->send($address, $message);
     }
 
     private function configureSmtp(): void

--- a/tests/Mail/GmailTransportTest.php
+++ b/tests/Mail/GmailTransportTest.php
@@ -28,7 +28,7 @@ use Setup;
  */
 class GmailTransportTest extends TestCase
 {
-    public function testGmailTransport()
+    public function testGmailTransport(): void
     {
         $this->configureSmtp();
 
@@ -39,7 +39,7 @@ class GmailTransportTest extends TestCase
         $mail->send($address, $headers, $body);
     }
 
-    private function configureSmtp()
+    private function configureSmtp(): void
     {
         $smtpSetup = Setup::get()['tests.smtp'];
         if (!$smtpSetup) {

--- a/tests/Mail/LoadEmailTest.php
+++ b/tests/Mail/LoadEmailTest.php
@@ -19,14 +19,14 @@ use Eventum\Test\TestCase;
 
 class LoadEmailTest extends TestCase
 {
-    public function testLoadBrokenReferences1()
+    public function testLoadBrokenReferences1(): void
     {
         $raw = $this->readDataFile('kallenote.eml');
         $mail = MailMessage::createFromString($raw);
         $this->assertTrue($mail->getHeaders()->has('In-Reply-To'));
     }
 
-    public function testLoadCCHeader()
+    public function testLoadCCHeader(): void
     {
         $raw = $this->readDataFile('92367.txt');
         $mail = MailMessage::createFromString($raw);
@@ -37,7 +37,7 @@ class LoadEmailTest extends TestCase
      * The 91f7937b.txt contains broken `Sender` header.
      * MailMessage::createFromString fixes this by renaming header.
      */
-    public function testLoad91f7937b()
+    public function testLoad91f7937b(): void
     {
         $raw = $this->readDataFile('91f7937b.txt');
 
@@ -53,7 +53,7 @@ class LoadEmailTest extends TestCase
         $this->assertTrue($headers->has('X-Broken-Header-Sender'));
     }
 
-    public function testLoadOddMboxHeader()
+    public function testLoadOddMboxHeader(): void
     {
         $raw = $this->readDataFile('from_nocolon.txt');
         $mail = MailMessage::createFromString($raw);

--- a/tests/Mail/MailHandlerTest.php
+++ b/tests/Mail/MailHandlerTest.php
@@ -30,7 +30,7 @@ namespace Eventum\Test\Mail {
      */
     class MailHandlerTest extends TestCase
     {
-        public function testMailHandler()
+        public function testMailHandler(): void
         {
             $logger = $this->configureMailHandler('enabled');
             $logger->error('error');
@@ -39,7 +39,7 @@ namespace Eventum\Test\Mail {
             $this->assertCount(1, $mail);
         }
 
-        public function testMailHandlerDisabled()
+        public function testMailHandlerDisabled(): void
         {
             $logger = $this->configureMailHandler('disabled');
             $logger->error('error');

--- a/tests/Mail/MailHelperTest.php
+++ b/tests/Mail/MailHelperTest.php
@@ -24,7 +24,7 @@ use Zend\Mail\Header\HeaderInterface;
  */
 class MailHelperTest extends TestCase
 {
-    public function testGetMessageID()
+    public function testGetMessageId(): void
     {
         $headers = 'x-foo: 1';
         $body = 'body';
@@ -76,13 +76,13 @@ class MailHelperTest extends TestCase
      *
      * @dataProvider validGetEmailAddressesData
      */
-    public function testGetEmailAddresses($input, $exp)
+    public function testGetEmailAddresses($input, $exp): void
     {
         $res = AddressHeader::fromString($input)->getEmails();
         $this->assertEquals($exp, $res);
     }
 
-    public function validGetEmailAddressesData()
+    public function validGetEmailAddressesData(): array
     {
         return [
             [
@@ -131,13 +131,13 @@ class MailHelperTest extends TestCase
      * @param bool $remove_issue_id
      * @dataProvider RemoveExcessReIssueIdTestData
      */
-    public function testRemoveExcessReIssueId($description, $subject, $exp, $remove_issue_id)
+    public function testRemoveExcessReIssueId($description, $subject, $exp, $remove_issue_id): void
     {
         $res = Mail_Helper::RemoveExcessRe($subject, $remove_issue_id);
         $this->assertEquals($exp, $res, $description);
     }
 
-    public function RemoveExcessReIssueIdTestData()
+    public function RemoveExcessReIssueIdTestData(): array
     {
         return [
             [
@@ -201,7 +201,7 @@ class MailHelperTest extends TestCase
     /**
      * @dataProvider GetAddressInfoTestData
      */
-    public function testGetAddressInfo($input, $sender_name, $email)
+    public function testGetAddressInfo($input, $sender_name, $email): void
     {
         $address = AddressHeader::fromString($input)->getAddress();
 
@@ -209,7 +209,7 @@ class MailHelperTest extends TestCase
         $this->assertEquals($email, $address->getEmail());
     }
 
-    public function GetAddressInfoTestData()
+    public function GetAddressInfoTestData(): array
     {
         return [
             0 => [
@@ -243,7 +243,7 @@ class MailHelperTest extends TestCase
     /**
      * @dataProvider GetAddressInfoMultipleTestData
      */
-    public function testGetAddressInfoMultiple($input, $exp)
+    public function testGetAddressInfoMultiple($input, $exp): void
     {
         $res = AddressHeader::fromString($input)->toString();
 
@@ -253,7 +253,7 @@ class MailHelperTest extends TestCase
         $this->assertEquals($exp, $res);
     }
 
-    public function GetAddressInfoMultipleTestData()
+    public function GetAddressInfoMultipleTestData(): array
     {
         return [
             // test for "addressgroup" with empty list
@@ -288,7 +288,7 @@ class MailHelperTest extends TestCase
      * @param string $exp expected result
      * @dataProvider FormatEmailAddressesTestData
      */
-    public function testFormatEmailAddresses($input, $exp)
+    public function testFormatEmailAddresses($input, $exp): void
     {
         $res = AddressHeader::fromString($input)->toString(HeaderInterface::FORMAT_RAW);
         // spaces are irrelevant
@@ -296,7 +296,7 @@ class MailHelperTest extends TestCase
         $this->assertEquals($exp, $res);
     }
 
-    public function FormatEmailAddressesTestData()
+    public function FormatEmailAddressesTestData(): array
     {
         return [
             [

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -31,7 +31,7 @@ use Zend\Mail\AddressList;
  */
 class MailMessageTest extends TestCase
 {
-    public function testMissingMessageId()
+    public function testMissingMessageId(): void
     {
         $raw = "X-foo: 1\r\n\r\nnada";
         $message = MailMessage::createFromString($raw);
@@ -43,7 +43,7 @@ class MailMessageTest extends TestCase
          *
          * @see Mail_Helper::generateMessageID()
          */
-        if (PHP_INT_SIZE == 4) {
+        if (PHP_INT_SIZE === 4) {
             $exp = '<eventum.md5.68gm8417ga.clqtuo3sklwsgok@eventum.example.org>';
         } else {
             $exp = '<eventum.md5.68gm8417ga.clqtuo3skl4w0gc@eventum.example.org>';
@@ -51,7 +51,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, $message_id);
     }
 
-    public function testDuplicateMessageId()
+    public function testDuplicateMessageId(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-msgid.txt');
         $message_id = $message->messageId;
@@ -59,7 +59,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, $message_id);
     }
 
-    public function testHeaderLine()
+    public function testHeaderLine(): void
     {
         $headers = [
             'Content-Type: text/plain; charset=UTF-8',
@@ -77,14 +77,14 @@ class MailMessageTest extends TestCase
         $this->assertEquals('Re: LVM-i bänner', $message->subject);
     }
 
-    public function testMissingSubject()
+    public function testMissingSubject(): void
     {
         $raw = "Message-ID: 1\r\n\r\n";
         $message = MailMessage::createFromString($raw);
         $this->assertSame('', $message->subject);
     }
 
-    public function testDateHeader()
+    public function testDateHeader(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-msgid.txt');
         $date = Date_Helper::convertDateGMT($message->date);
@@ -92,7 +92,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, $date);
     }
 
-    public function testFrom()
+    public function testFrom(): void
     {
         /**
          * Test what gives similar output:
@@ -114,7 +114,7 @@ class MailMessageTest extends TestCase
 //        $message = MailMessage::createFromFile(__DIR__ . '/data/duplicate-from.txt');
     }
 
-    public function testGetToCc()
+    public function testGetToCc(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -145,7 +145,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, implode(',', $res));
     }
 
-    public function testMultipleToHeaders()
+    public function testMultipleToHeaders(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -159,13 +159,13 @@ class MailMessageTest extends TestCase
         $this->assertEquals("support@example.org,\r\n support-2@example.org", $message->to);
     }
 
-    public function testIsBounceMessage()
+    public function testIsBounceMessage(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/bug684922.txt');
         $this->assertFalse($message->isBounceMessage());
     }
 
-    public function testReferenceMessageId()
+    public function testReferenceMessageId(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/in-reply-to.txt');
         $reference_id = $message->getReferenceMessageId();
@@ -176,7 +176,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals('<4d36173add8b60.67944236@origin.com>', $reference_id);
     }
 
-    public function testReferences()
+    public function testReferences(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/in-reply-to.txt');
 
@@ -204,7 +204,7 @@ class MailMessageTest extends TestCase
     /**
      * @covers Mail_Helper::rewriteThreadingHeaders()
      */
-    public function testRewriteThreadingHeaders()
+    public function testRewriteThreadingHeaders(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/in-reply-to.txt');
         $msg_id = $mail->getReferenceMessageId();
@@ -224,16 +224,16 @@ class MailMessageTest extends TestCase
     }
 
     /**
-     * @test that the result can be assembled after adding generic header!
+     * test that the result can be assembled after adding generic header!
      */
-    public function testInReplyTo()
+    public function testInReplyTo(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/multipart-text-html.txt');
         $mail->setInReplyTo('fu!');
         $mail->getRawContent();
     }
 
-    public function testGetAddresses()
+    public function testGetAddresses(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/bug684922.txt');
         $addresses = $message->getAddresses();
@@ -243,7 +243,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, $addresses);
     }
 
-    public function testGetRawContent()
+    public function testGetRawContent(): void
     {
         $raw = $this->readDataFile('in-reply-to.txt');
         $message = MailMessage::createFromString($raw);
@@ -257,7 +257,7 @@ class MailMessageTest extends TestCase
         $this->assertSame($raw, $content);
     }
 
-    public function testRemoveHeader()
+    public function testRemoveHeader(): void
     {
         // test if header exists
         $message = MailMessage::createFromFile(__DIR__ . '/../data/in-reply-to.txt');
@@ -280,7 +280,7 @@ class MailMessageTest extends TestCase
         $headers->removeHeader('In-Reply-To');
     }
 
-    public function testDuplicateFrom()
+    public function testDuplicateFrom(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -294,7 +294,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals('IT', $address->getName());
     }
 
-    public function testMissingFrom()
+    public function testMissingFrom(): void
     {
         // test with no From header
         $raw = "X-foo: 1\r\n\r\nnada";
@@ -304,7 +304,7 @@ class MailMessageTest extends TestCase
         $this->assertSame(null, $message->getFrom());
     }
 
-    public function testRemoveCc()
+    public function testRemoveCc(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -317,7 +317,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals('abcd@origin.com', $cc);
     }
 
-    public function testReplaceSubject()
+    public function testReplaceSubject(): void
     {
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -333,7 +333,7 @@ class MailMessageTest extends TestCase
      * Checks whether the given headers are from a vacation
      * auto-responder message or not.
      */
-    public function testIsVacationAutoResponder()
+    public function testIsVacationAutoResponder(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
         $this->assertFalse($mail->isVacationAutoResponder());
@@ -342,7 +342,7 @@ class MailMessageTest extends TestCase
         $this->assertTrue($mail->isVacationAutoResponder());
     }
 
-    public function testStripHeaders()
+    public function testStripHeaders(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
         $before = array_keys($mail->getHeaders()->toArray());
@@ -363,7 +363,7 @@ class MailMessageTest extends TestCase
         $this->assertSame($exp, $after);
     }
 
-    public function testSetTo()
+    public function testSetTo(): void
     {
         $mail = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
@@ -376,7 +376,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($to, $mail->to);
     }
 
-    public function testHeadersCloning()
+    public function testHeadersCloning(): void
     {
         $this->markTestSkipped('cloning does not work');
 
@@ -391,7 +391,7 @@ class MailMessageTest extends TestCase
         $this->assertNotEquals($mail->getRawContent(), $clone->getRawContent());
     }
 
-    public function testAddHeaders()
+    public function testAddHeaders(): void
     {
         $raw = "Message-ID: <33@JON>\nX-Eventum-Level: 1\n\nBody";
         $mail = MailMessage::createFromString($raw);
@@ -439,7 +439,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals($exp, $mail->getHeaders()->toString());
     }
 
-    public function testAddHeadersMultiValue()
+    public function testAddHeadersMultiValue(): void
     {
         $raw = "Message-ID: <33@JON>\n\n\nbody";
         $mail = MailMessage::createFromString($raw);
@@ -459,7 +459,7 @@ class MailMessageTest extends TestCase
     /**
      * test different access modes or X-Priority header.
      */
-    public function testXPriority()
+    public function testXPriority(): void
     {
         $content = $this->readDataFile('duplicate-msgid.txt');
         $mail = MailMessage::createFromString($content);
@@ -480,7 +480,7 @@ class MailMessageTest extends TestCase
      * @see Notification::notifyAccountDetails
      * @group db
      */
-    public function testSendSimpleMail()
+    public function testSendSimpleMail(): void
     {
         $text_message = 'text message';
         $info = [
@@ -511,7 +511,7 @@ class MailMessageTest extends TestCase
      *
      * @group db
      */
-    public function testMailSendZF()
+    public function testMailSendZF(): void
     {
         $text_message = 'tere';
         $issue_id = 1;
@@ -530,7 +530,7 @@ class MailMessageTest extends TestCase
         Mail_Queue::queue($mail, $recipient);
     }
 
-    public function testMailFromHeaderBody()
+    public function testMailFromHeaderBody(): void
     {
         $headers = [
             'MIME-Version' => '1.0',
@@ -556,7 +556,7 @@ class MailMessageTest extends TestCase
         MailMessage::createFromHeaderBody($headers, $body);
     }
 
-    public function testSendPlainMail()
+    public function testSendPlainMail(): void
     {
         $text_message = 'zzzxx';
         $issue_id = 1;
@@ -598,7 +598,7 @@ class MailMessageTest extends TestCase
         $transport->send($mail);
     }
 
-    public function testReSetMessageId()
+    public function testReSetMessageId(): void
     {
         $mail = MailMessage::createNew();
         $headers = [];
@@ -606,7 +606,7 @@ class MailMessageTest extends TestCase
         $mail->addHeaders($headers);
     }
 
-    public function testZFPlainMail()
+    public function testZFPlainMail(): void
     {
         $text_message = 'zzzxx';
         $issue_id = 1;
@@ -639,7 +639,7 @@ class MailMessageTest extends TestCase
      *
      * @see https://github.com/zendframework/zend-mail/issues/64
      */
-    public function testParseHeaders()
+    public function testParseHeaders(): void
     {
         $header
             = "Subject: [#77675] New Issue:xxxxxxxxx xxxxxxx xxxxxxxx xxxxxxxxxxxxx xxxxxxxxxx xxxxxxxx, =?utf-8?b?dMOkaHRhZWc=?= xx.xx, xxxx\r\n";
@@ -671,7 +671,7 @@ class MailMessageTest extends TestCase
     /**
      * @see https://github.com/eventum/eventum/issues/155
      */
-    public function testMboxHeader()
+    public function testMboxHeader(): void
     {
         $full_message = $this->readDataFile('from_nocolon.txt');
         $this->assertNotEquals('MIME-Version', substr($full_message, 0, 12));
@@ -682,7 +682,7 @@ class MailMessageTest extends TestCase
     /**
      * @see Mail_Queue::send for getMergedList handling
      */
-    public function testRecipientConcat()
+    public function testRecipientConcat(): void
     {
         $recipients = [
             '"Some Öne" <Some.One@example.org>',

--- a/tests/Mail/MailStorageTest.php
+++ b/tests/Mail/MailStorageTest.php
@@ -30,7 +30,7 @@ class MailStorageTest extends TestCase
     /** @var array */
     private $account;
 
-    public function setUp()
+    public function setUp(): void
     {
         $setup = Setup::get();
 
@@ -52,7 +52,7 @@ class MailStorageTest extends TestCase
         $this->account = $setup['tests.imap-account'];
     }
 
-    public function testNewMails()
+    public function testNewMails(): void
     {
         $mbox = new MailStorage($this->account);
         $flags = [
@@ -62,7 +62,7 @@ class MailStorageTest extends TestCase
         $this->assertEquals(0, $count);
     }
 
-    public function testProcessMessages()
+    public function testProcessMessages(): void
     {
         $mbox = new MailStorage($this->account);
 
@@ -82,7 +82,7 @@ class MailStorageTest extends TestCase
         }
     }
 
-    public function testImapHeaderStructure()
+    public function testImapHeaderStructure(): void
     {
         $mbox = Support::connectEmailServer($this->account);
         $emails = Support::getNewEmails($mbox);
@@ -98,7 +98,7 @@ class MailStorageTest extends TestCase
         die;
     }
 
-    public function testSearch()
+    public function testSearch(): void
     {
         $mbox = new MailStorage($this->account);
 
@@ -114,7 +114,7 @@ class MailStorageTest extends TestCase
         // $matches = @imap_search($mbox, 'TEXT "' . $row['sup_message_id'] . '"');
     }
 
-    public function testMessage()
+    public function testMessage(): void
     {
         $mbox = Support::connectEmailServer($this->account);
         $message1 = $this->readImapMessage($mbox, 1);
@@ -130,7 +130,7 @@ class MailStorageTest extends TestCase
         echo 1;
     }
 
-    public function readImapMessage($mbox, $num)
+    public function readImapMessage($mbox, $num): Mail\Storage\Message
     {
         // check if the current message was already seen
         list($overview) = imap_fetch_overview($mbox, $num);
@@ -155,7 +155,7 @@ class MailStorageTest extends TestCase
             }
         }
 
-        $message = new \Zend\Mail\Storage\Message(['headers' => $header, 'content' => $content, 'flags' => $flags]);
+        $message = new Mail\Storage\Message(['headers' => $header, 'content' => $content, 'flags' => $flags]);
 
         return $message;
     }

--- a/tests/Mail/MailTransportTest.php
+++ b/tests/Mail/MailTransportTest.php
@@ -33,7 +33,7 @@ class MailTransportTest extends TestCase
      * caused ASCII encoding on headers
      * which failed the toString call later.
      */
-    public function testMessageObject()
+    public function testMessageObject(): void
     {
         list($recipient, $headers, $body) = $this->loadMailTrace('zf-mail-591ca27fb27c2.json');
 
@@ -59,7 +59,7 @@ class MailTransportTest extends TestCase
         $this->assertNotEmpty($res);
     }
 
-    public function testSingleRecipient()
+    public function testSingleRecipient(): void
     {
         $recipient = 'root@localhost';
         $from = 'noreply@localhost';
@@ -106,7 +106,7 @@ class MailTransportTest extends TestCase
      *
      * @return MailTransport
      */
-    private function getMailTransport()
+    private function getMailTransport(): MailTransport
     {
         $stub = $this->getMockBuilder(MailTransport::class)
             ->setMethods(['getTransport'])
@@ -121,7 +121,7 @@ class MailTransportTest extends TestCase
     /**
      * @return Transport\Smtp
      */
-    private function getTransportSmtp()
+    private function getTransportSmtp(): Transport\Smtp
     {
         $transport = $this->getMockBuilder(Transport\Smtp::class)
             ->setMethods(['getConnection', 'connect', 'mail'])
@@ -142,7 +142,7 @@ class MailTransportTest extends TestCase
      *
      * @return Protocol\Smtp;
      */
-    private function getProtocolSmtp()
+    private function getProtocolSmtp(): Protocol\Smtp
     {
         $stub = $this->getMockBuilder(Protocol\Smtp::class)
             ->setMethods(['mail', 'rcpt', 'data'])
@@ -196,7 +196,7 @@ class MailTransportTest extends TestCase
      * @param string $traceFile
      * @return array
      */
-    private function loadMailTrace($traceFile)
+    private function loadMailTrace($traceFile): array
     {
         $contents = $this->readDataFile($traceFile);
         $this->assertJson($contents);

--- a/tests/Mail/MimeDecodeTest.php
+++ b/tests/Mail/MimeDecodeTest.php
@@ -26,7 +26,7 @@ use Support;
  */
 class MimeDecodeTest extends TestCase
 {
-    public function testFieldValues()
+    public function testFieldValues(): void
     {
         $message = $this->readDataFile('bug684922.txt');
         $mail = MailMessage::createFromString($message);
@@ -35,7 +35,7 @@ class MimeDecodeTest extends TestCase
         $this->assertEquals('PD: My: Gołblahblah', $mail->subject);
     }
 
-    public function testSupportBuildMail()
+    public function testSupportBuildMail(): void
     {
         $issue_id = null;
         $from = 'rööts <me@localhost>';
@@ -64,7 +64,7 @@ class MimeDecodeTest extends TestCase
     /**
      * Mime_Helper::decode()->body extracts main message body if no parts present
      */
-    public function testBuildMail()
+    public function testBuildMail(): void
     {
         $issue_id = null;
         $from = 'Elan Ruusamäe <root@localhost>';
@@ -80,7 +80,7 @@ class MimeDecodeTest extends TestCase
         $this->assertEquals($body, $mail->getMessageBody());
     }
 
-    public function testBuildMailSave()
+    public function testBuildMailSave(): void
     {
         // this is mail saved by Support::buildMail
         $content = $this->readDataFile('saved_mail.txt');

--- a/tests/Mail/MimeHelperTest.php
+++ b/tests/Mail/MimeHelperTest.php
@@ -25,13 +25,13 @@ class MimeHelperTest extends TestCase
     /**
      * @dataProvider dataDecodeQuotedPrintable
      */
-    public function testDecodeQuotedPrintable($str, $exp)
+    public function testDecodeQuotedPrintable($str, $exp): void
     {
         $res = Mime_Helper::decodeQuotedPrintable($str);
         $this->assertEquals($exp, $res);
     }
 
-    public function dataDecodeQuotedPrintable()
+    public function dataDecodeQuotedPrintable(): array
     {
         return [
             // iconv test from php manual
@@ -56,7 +56,7 @@ class MimeHelperTest extends TestCase
     /**
      * Method used to properly quote the sender of a given email address.
      */
-    public function testQuoteSender()
+    public function testQuoteSender(): void
     {
         $test_data = [
             '<email@example.org>' => 'email@example.org',
@@ -71,7 +71,7 @@ class MimeHelperTest extends TestCase
     /**
      * Method used to remove any unnecessary quoting from an email address.
      */
-    public function testRemoveQuotes()
+    public function testRemoveQuotes(): void
     {
         $test_data = [
             '<email@example.org>' => 'email@example.org',
@@ -83,7 +83,7 @@ class MimeHelperTest extends TestCase
         }
     }
 
-    public function testBug901653()
+    public function testBug901653(): void
     {
         $message = $this->readDataFile('LP901653.txt');
         $mail = MailMessage::createFromString($message);

--- a/tests/Mail/MimeMessageTest.php
+++ b/tests/Mail/MimeMessageTest.php
@@ -31,7 +31,7 @@ class MimeMessageTest extends TestCase
     private $message_id;
     private $date;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->from = '"Admin User " <note-3@eventum.example.org>';
         $this->to = '"Admin User" <admin@example.com>';
@@ -56,7 +56,7 @@ class MimeMessageTest extends TestCase
      * @see http://framework.zend.com/manual/current/en/modules/zend.mail.message.html
      * @see http://framework.zend.com/manual/current/en/modules/zend.mail.attachments.html
      */
-    public function testMimeMessageText()
+    public function testMimeMessageText(): void
     {
         $body = "Hello, bödi tekst\n\nBye";
 
@@ -68,7 +68,7 @@ class MimeMessageTest extends TestCase
         $this->assertEquals($body, $mail->getContent());
     }
 
-    public function testMimeMessageAttachment()
+    public function testMimeMessageAttachment(): void
     {
         $body = "Hello, bödi tekst\n\nBye\n";
 
@@ -111,11 +111,7 @@ class MimeMessageTest extends TestCase
         $this->assertNotEmpty($m);
     }
 
-    /**
-     * @param array $params
-     * @return Attachment
-     */
-    private function createAttachment($params)
+    private function createAttachment(array $params): Attachment
     {
         $attachment = new Attachment($params['iaf_filename'], $params['iaf_filetype']);
         $property = new ReflectionProperty($attachment, 'blob');

--- a/tests/Mail/WarningMessageTest.php
+++ b/tests/Mail/WarningMessageTest.php
@@ -17,11 +17,10 @@ use Eventum\Mail\Helper\WarningMessage;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Test\TestCase;
-use Zend\Mail\Exception\InvalidArgumentException;
 
 class WarningMessageTest extends TestCase
 {
-    public function testAddToPlainText()
+    public function testAddToPlainText(): void
     {
         $issue_id = 1;
         $email = 'root@localhost';
@@ -31,7 +30,7 @@ class WarningMessageTest extends TestCase
         $this->runAddAndRemoveTests($mail, $issue_id, $email);
     }
 
-    public function testMailBuilderText()
+    public function testMailBuilderText(): void
     {
         $issue_id = 1;
         $recipient = $from = 'root@localhost';
@@ -49,7 +48,7 @@ class WarningMessageTest extends TestCase
         $this->runAddAndRemoveTests($mail, $issue_id, $recipient);
     }
 
-    public function testMultipart()
+    public function testMultipart(): void
     {
         $this->markTestIncomplete('Multipart not yet supported');
 
@@ -71,7 +70,7 @@ class WarningMessageTest extends TestCase
         $this->assertEquals($raw1, $raw3);
     }
 
-    public function testAddWarningMessagePlain()
+    public function testAddWarningMessagePlain(): void
     {
         $issue_id = 1;
         $recipient = 'admin@example.com';
@@ -87,7 +86,7 @@ class WarningMessageTest extends TestCase
         $this->assertStringContainsString($body, $fixed_body);
     }
 
-    public function testAddWarningMessageMultipart()
+    public function testAddWarningMessageMultipart(): void
     {
         $this->markTestIncomplete('Multipart not yet supported');
 
@@ -104,7 +103,7 @@ class WarningMessageTest extends TestCase
         $this->assertStringContainsString('Your reply will be sent to the notification list', $fixed_body);
     }
 
-    private function runAddAndRemoveTests(MailMessage $mail, $issue_id, $email)
+    private function runAddAndRemoveTests(MailMessage $mail, $issue_id, $email): void
     {
         $wm = $this->getWarningMessage($mail);
 

--- a/tests/Mail/WarningMessageTest.php
+++ b/tests/Mail/WarningMessageTest.php
@@ -49,14 +49,10 @@ class WarningMessageTest extends TestCase
         $this->runAddAndRemoveTests($mail, $issue_id, $recipient);
     }
 
-    /**
-     * NOT YET
-     *
-     * @expectedException InvalidArgumentException
-     * @expectedExceptionMessage Multipart not supported
-     */
     public function testMultipart()
     {
+        $this->markTestIncomplete('Multipart not yet supported');
+
         $issue_id = 1;
         $email = 'root@localhost';
 
@@ -93,10 +89,10 @@ class WarningMessageTest extends TestCase
 
     public function testAddWarningMessageMultipart()
     {
+        $this->markTestIncomplete('Multipart not yet supported');
+
         $issue_id = 1;
         $recipient = 'admin@example.com';
-
-        $this->markTestSkipped('multipart yet not supported');
 
         $content = $this->readDataFile('attachment-bug.txt');
         $m = MailMessage::createFromString($content);

--- a/tests/Mail/WarningMessageTest.php
+++ b/tests/Mail/WarningMessageTest.php
@@ -88,7 +88,7 @@ class WarningMessageTest extends TestCase
         $wm->add($issue_id, $recipient);
 
         $fixed_body = $m->getContent();
-        $this->assertContains($body, $fixed_body);
+        $this->assertStringContainsString($body, $fixed_body);
     }
 
     public function testAddWarningMessageMultipart()
@@ -105,7 +105,7 @@ class WarningMessageTest extends TestCase
         $wm->add($issue_id, $recipient);
 
         $fixed_body = $m->getContent();
-        $this->assertContains('Your reply will be sent to the notification list', $fixed_body);
+        $this->assertStringContainsString('Your reply will be sent to the notification list', $fixed_body);
     }
 
     private function runAddAndRemoveTests(MailMessage $mail, $issue_id, $email)

--- a/tests/MemoizedTest.php
+++ b/tests/MemoizedTest.php
@@ -17,7 +17,7 @@ use Eventum\MemoizeDecorator;
 
 class MemoizeTest extends TestCase
 {
-    public function test1()
+    public function test1(): void
     {
         /** @var MemoizedTestClass $instance */
         $instance = new MemoizeDecorator(new MemoizedTestClass());

--- a/tests/MiscTest.php
+++ b/tests/MiscTest.php
@@ -23,7 +23,7 @@ class MiscTest extends TestCase
     /**
      * @dataProvider caseData
      */
-    public function testLowercase($str, $exp)
+    public function testLowercase($str, $exp): void
     {
         $res = Misc::lowercase($str);
         $this->assertSame($exp, $res);
@@ -36,7 +36,7 @@ class MiscTest extends TestCase
      * @return  string The escaped (or not) string
      * @dataProvider StripHTMLData
      */
-    public function testStripHTML($str, $exp)
+    public function testStripHTML($str, $exp): void
     {
         $this->assertEquals($exp, Misc::stripHTML($str));
     }
@@ -46,13 +46,13 @@ class MiscTest extends TestCase
      * @return  string The escaped (or not) string
      * @dataProvider StripInputData
      */
-    public function testStripInput($str, $exp)
+    public function testStripInput($str, $exp): void
     {
         Misc::stripInput($str);
         $this->assertEquals($exp, $str);
     }
 
-    public function StripHTMLData()
+    public function StripHTMLData(): array
     {
         return [
             ['plain', 'plain'],
@@ -61,7 +61,7 @@ class MiscTest extends TestCase
         ];
     }
 
-    public function StripInputData()
+    public function StripInputData(): array
     {
         return [
             ['plain', 'plain'],
@@ -80,7 +80,7 @@ class MiscTest extends TestCase
         ];
     }
 
-    public function caseData()
+    public function caseData(): array
     {
         return [
             [null, null],
@@ -101,7 +101,7 @@ class MiscTest extends TestCase
      * @param int $u
      * @return string
      */
-    private function unichr($u)
+    private function unichr($u): string
     {
         return mb_convert_encoding('&#' . intval($u) . ';', 'UTF-8', 'HTML-ENTITIES');
     }

--- a/tests/PasswordAuthTest.php
+++ b/tests/PasswordAuthTest.php
@@ -68,16 +68,16 @@ class PasswordAuthTest extends TestCase
 
     private function assertPasswordInfoArray($res, $algo = 1, $algoName = 'unknown'): void
     {
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('algo', $res);
         $this->assertInternalType(gettype($algo), $res['algo']);
         $this->assertEquals($algo, $res['algo']);
 
         $this->assertArrayHasKey('algoName', $res);
-        $this->assertInternalType('string', $res['algoName']);
+        $this->assertIsString($res['algoName']);
         $this->assertEquals($algoName, $res['algoName']);
 
         $this->assertArrayHasKey('options', $res);
-        $this->assertInternalType('array', $res['options']);
+        $this->assertIsArray($res['options']);
     }
 }

--- a/tests/RandomLibTest.php
+++ b/tests/RandomLibTest.php
@@ -17,14 +17,14 @@ use Misc;
 
 class RandomLibTest extends TestCase
 {
-    public function testRandom()
+    public function testRandom(): void
     {
         $res = Misc::generateRandom(32);
         $this->assertNotNull($res);
         $this->assertEquals(32, Misc::countBytes($res));
     }
 
-    public function testPasswordGen()
+    public function testPasswordGen(): void
     {
         $hash = md5(Misc::generateRandom(32));
         $password = substr($hash, 0, 12);

--- a/tests/RemoteApiTest.php
+++ b/tests/RemoteApiTest.php
@@ -28,7 +28,7 @@ class RemoteApiTest extends TestCase
     /** @var RemoteApi */
     private static $client;
 
-    public static function setupBeforeClass()
+    public static function setupBeforeClass(): void
     {
         $setup = Setup::get();
         if (!isset($setup['tests.xmlrpc_url'])) {
@@ -51,7 +51,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getDeveloperList
      */
-    public function testGetDeveloperList()
+    public function testGetDeveloperList(): void
     {
         $prj_id = 1;
         $res = self::$client->getDeveloperList($prj_id);
@@ -63,7 +63,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getSimpleIssueDetails
      */
-    public function testGetSimpleIssueDetails()
+    public function testGetSimpleIssueDetails(): void
     {
         $issue_id = 1;
         $res = self::$client->getSimpleIssueDetails($issue_id);
@@ -78,7 +78,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getOpenIssues
      */
-    public function testGetOpenIssues()
+    public function testGetOpenIssues(): void
     {
         $prj_id = 1;
         $show_all_issues = true;
@@ -99,7 +99,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getUserAssignedProjects
      */
-    public function testGetUserAssignedProjects()
+    public function testGetUserAssignedProjects(): void
     {
         $only_customer_projects = false;
         $res = self::$client->getUserAssignedProjects($only_customer_projects);
@@ -115,7 +115,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getIssueDetails
      */
-    public function testGetIssueDetails()
+    public function testGetIssueDetails(): void
     {
         $issue_id = 1;
         $res = self::$client->getIssueDetails($issue_id);
@@ -127,7 +127,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getTimeTrackingCategories
      */
-    public function testGetTimeTrackingCategories()
+    public function testGetTimeTrackingCategories(): void
     {
         $issue_id = 1;
         $res = self::$client->getTimeTrackingCategories($issue_id);
@@ -138,7 +138,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::recordTimeWorked
      */
-    public function testRecordTimeWorked()
+    public function testRecordTimeWorked(): void
     {
         $issue_id = 1;
         $cat_id = 1;
@@ -152,7 +152,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::setIssueStatus
      */
-    public function testSetIssueStatus()
+    public function testSetIssueStatus(): void
     {
         $issue_id = 1;
         $new_status = 'implementation';
@@ -164,7 +164,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::assignIssue
      */
-    public function testAssignIssue()
+    public function testAssignIssue(): void
     {
         $issue_id = 1;
         $prj_id = 1;
@@ -177,7 +177,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::takeIssue
      */
-    public function testTakeIssue()
+    public function testTakeIssue(): void
     {
         $issue_id = 1;
         $prj_id = 1;
@@ -193,7 +193,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::addAuthorizedReplier
      */
-    public function testAddAuthorizedReplier()
+    public function testAddAuthorizedReplier(): void
     {
         $issue_id = 1;
         $prj_id = 1;
@@ -206,7 +206,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getFileList
      */
-    public function testGetFileList()
+    public function testGetFileList(): void
     {
         $issue_id = 1;
 
@@ -229,7 +229,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getFile
      */
-    public function testGetFile()
+    public function testGetFile(): void
     {
         $file_id = 1;
 
@@ -244,7 +244,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::lookupCustomer
      */
-    public function testLookupCustomer()
+    public function testLookupCustomer(): void
     {
         $prj_id = 1;
         $field = 'email';
@@ -263,7 +263,7 @@ class RemoteApiTest extends TestCase
      *
      * @covers RemoteApi::closeIssue
      */
-    public function testCloseIssue()
+    public function testCloseIssue(): void
     {
         $issue_id = 1;
         $new_status = 'closed';
@@ -279,7 +279,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getClosedAbbreviationAssocList
      */
-    public function testGetClosedAbbreviationAssocList()
+    public function testGetClosedAbbreviationAssocList(): void
     {
         $prj_id = 1;
         $res = self::$client->getClosedAbbreviationAssocList($prj_id);
@@ -293,7 +293,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getAbbreviationAssocList
      */
-    public function testGetAbbreviationAssocList()
+    public function testGetAbbreviationAssocList(): void
     {
         $prj_id = 1;
         $show_closed = false;
@@ -310,7 +310,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getEmailListing
      */
-    public function testGetEmailListing()
+    public function testGetEmailListing(): void
     {
         $issue_id = 1;
         $res = self::$client->getEmailListing($issue_id);
@@ -326,7 +326,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getEmail
      */
-    public function testGetEmail()
+    public function testGetEmail(): void
     {
         $issue_id = 1;
         $emai_id = 1;
@@ -340,7 +340,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getNoteListing
      */
-    public function testGetNoteListing()
+    public function testGetNoteListing(): void
     {
         $issue_id = 1;
         $res = self::$client->getNoteListing($issue_id);
@@ -356,7 +356,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getNote
      */
-    public function testGetNote()
+    public function testGetNote(): void
     {
         $issue_id = 1;
         $note_id = 1;
@@ -371,7 +371,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::convertNote
      */
-    public function testConvertNote()
+    public function testConvertNote(): void
     {
         $issue_id = 1;
         $note_id = 1;
@@ -386,7 +386,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::mayChangeIssue
      */
-    public function testMayChangeIssue()
+    public function testMayChangeIssue(): void
     {
         $issue_id = 1;
         $res = self::$client->mayChangeIssue($issue_id);
@@ -396,7 +396,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getWeeklyReport
      */
-    public function testGetWeeklyReport()
+    public function testGetWeeklyReport(): void
     {
         $week = 1;
         $start = '';
@@ -409,7 +409,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getResolutionAssocList
      */
-    public function testGetResolutionAssocList()
+    public function testGetResolutionAssocList(): void
     {
         $res = self::$client->getResolutionAssocList();
         $exp = [
@@ -427,7 +427,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::timeClock
      */
-    public function testTimeClock()
+    public function testTimeClock(): void
     {
         $action = 'out';
         $res = self::$client->timeClock($action);
@@ -437,7 +437,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getDraftListing
      */
-    public function testGetDraftListing()
+    public function testGetDraftListing(): void
     {
         $issue_id = 1;
         $res = self::$client->getDraftListing($issue_id);
@@ -453,7 +453,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getDraft
      */
-    public function testGetDraft()
+    public function testGetDraft(): void
     {
         $issue_id = 1;
         $draft_id = 1;
@@ -467,7 +467,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::sendDraft
      */
-    public function testSendDraft()
+    public function testSendDraft(): void
     {
         $issue_id = 1;
         $draft_id = 1;
@@ -480,7 +480,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::redeemIssue
      */
-    public function testRedeemIssue()
+    public function testRedeemIssue(): void
     {
         $issue_id = 1;
         $types = [];
@@ -495,7 +495,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::unredeemIssue
      */
-    public function testUnredeemIssue()
+    public function testUnredeemIssue(): void
     {
         $issue_id = 1;
         $types = [];
@@ -510,7 +510,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::getIncidentTypes
      */
-    public function testGetIncidentTypes()
+    public function testGetIncidentTypes(): void
     {
         $issue_id = 1;
         $redeemed_only = false;
@@ -525,7 +525,7 @@ class RemoteApiTest extends TestCase
     /**
      * @covers RemoteApi::logCommand
      */
-    public function testLogCommand()
+    public function testLogCommand(): void
     {
         $command = 'hello world';
         $res = self::$client->logCommand($command);

--- a/tests/RemoteApiTest.php
+++ b/tests/RemoteApiTest.php
@@ -55,7 +55,7 @@ class RemoteApiTest extends TestCase
     {
         $prj_id = 1;
         $res = self::$client->getDeveloperList($prj_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('Admin User', $res);
         $this->assertEquals('admin@example.com', $res['Admin User']);
     }
@@ -67,7 +67,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getSimpleIssueDetails($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('summary', $res);
         $this->assertArrayHasKey('customer', $res);
         $this->assertArrayHasKey('status', $res);
@@ -85,7 +85,7 @@ class RemoteApiTest extends TestCase
         $status = '';
         $res = self::$client->getOpenIssues($prj_id, $show_all_issues, $status);
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('0', $res);
         $issue = $res[0];
 
@@ -119,7 +119,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getIssueDetails($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('iss_id', $res);
         $this->assertEquals(1, $res['iss_id']);
     }
@@ -131,7 +131,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getTimeTrackingCategories($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertContains('Tech-Support', $res);
     }
 
@@ -213,11 +213,11 @@ class RemoteApiTest extends TestCase
         try {
             $res = self::$client->getFileList($issue_id);
 
-            $this->assertInternalType('array', $res);
+            $this->assertIsArray($res);
             $this->assertArrayHasKey('0', $res);
 
             $file = $res[0];
-            $this->assertInternalType('array', $file);
+            $this->assertIsArray($file);
             $this->assertArrayHasKey('iat_id', $file);
             $this->assertArrayHasKey('iat_status', $file);
             $this->assertEquals('internal', $file['iat_status']);
@@ -235,7 +235,7 @@ class RemoteApiTest extends TestCase
 
         $res = self::$client->getFile($file_id);
 
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('iat_id', $res);
         $this->assertArrayHasKey('iat_status', $res);
         $this->assertEquals('internal', $res['iat_status']);
@@ -252,7 +252,7 @@ class RemoteApiTest extends TestCase
 
         try {
             $res = self::$client->lookupCustomer($prj_id, $field, $value);
-            $this->assertInternalType('string', $res);
+            $this->assertIsString($res);
         } catch (Exception $e) {
             $this->assertEquals("Customer Integration not enabled for project $prj_id", $e->getMessage());
         }
@@ -314,7 +314,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getEmailListing($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('0', $res);
 
         $email = $res[0];
@@ -344,7 +344,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getNoteListing($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->arrayHasKey('0', $res);
 
         $note = $res[0];
@@ -361,7 +361,7 @@ class RemoteApiTest extends TestCase
         $issue_id = 1;
         $note_id = 1;
         $res = self::$client->getNote($issue_id, $note_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
 
         $this->assertArrayHasKey('not_id', $res);
         $this->assertArrayHasKey('not_title', $res);
@@ -441,7 +441,7 @@ class RemoteApiTest extends TestCase
     {
         $issue_id = 1;
         $res = self::$client->getDraftListing($issue_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->arrayHasKey('0', $res);
 
         $draft = $res[0];
@@ -458,7 +458,7 @@ class RemoteApiTest extends TestCase
         $issue_id = 1;
         $draft_id = 1;
         $res = self::$client->getDraft($issue_id, $draft_id);
-        $this->assertInternalType('array', $res);
+        $this->assertIsArray($res);
         $this->assertArrayHasKey('emd_id', $res);
         $this->assertArrayHasKey('emd_status', $res);
         $this->assertEquals('pending', $res['emd_status']);

--- a/tests/RemoteLinkTest.php
+++ b/tests/RemoteLinkTest.php
@@ -24,7 +24,7 @@ class RemoteLinkTest extends TestCase
     /** @var \Doctrine\ORM\EntityRepository|RemoteLinkRepository */
     private $repo;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->repo = Doctrine::getRemoteLinkRepository();
     }

--- a/tests/Scm/ScmApiCommitTest.php
+++ b/tests/Scm/ScmApiCommitTest.php
@@ -31,7 +31,7 @@ class ScmApiCommitTest extends ScmTestCase
     /**
      * Test commit push over Api
      */
-    public function testGitlabCommitApi()
+    public function testGitlabCommitApi(): void
     {
         $request = $this->createApiRequest('gitlab/push/project-commit.json');
         $request->headers->set(Gitlab::GITLAB_HEADER, 'Push Hook');
@@ -47,7 +47,7 @@ class ScmApiCommitTest extends ScmTestCase
         $this->assertEquals(['bla'], $files);
     }
 
-    public function testCvsCommitApi()
+    public function testCvsCommitApi(): void
     {
         $this->markTestIncomplete('lacks cleanup, so will fail on second run');
         $request = $this->createApiRequest('cvs-commit.json');
@@ -67,7 +67,7 @@ class ScmApiCommitTest extends ScmTestCase
     /**
      * Test commit push over http
      */
-    public function testGitlabCommitUrl()
+    public function testGitlabCommitUrl(): void
     {
         $api_url = $this->getCommitUrl();
 
@@ -76,7 +76,7 @@ class ScmApiCommitTest extends ScmTestCase
         $this->POST($api_url, $payload, $headers);
     }
 
-    private function getCommitUrl()
+    private function getCommitUrl(): string
     {
         $setup = Setup::get();
         $api_url = $setup['tests.commit_url'];
@@ -85,12 +85,12 @@ class ScmApiCommitTest extends ScmTestCase
         return $api_url;
     }
 
-    private function POST($url, $payload, $headers = '')
+    private function POST($url, $payload, $headers = ''): string
     {
         return shell_exec("curl -Ss $headers -X POST --data @{$payload} {$url}");
     }
 
-    private function createApiRequest($filename)
+    private function createApiRequest($filename): Request
     {
         $api_url = $this->getCommitUrl();
         $payload = $this->readDataFile($filename);
@@ -98,7 +98,7 @@ class ScmApiCommitTest extends ScmTestCase
         return Request::create($api_url, 'POST', [], [], [], [], $payload);
     }
 
-    private function addFilesListener(&$files)
+    private function addFilesListener(&$files): void
     {
         $listener = function (GenericEvent $event) use (&$files) {
             /** @var Entity\Commit $commit */

--- a/tests/Scm/ScmCommitTest.php
+++ b/tests/Scm/ScmCommitTest.php
@@ -30,14 +30,14 @@ class ScmCommitTest extends ScmTestCase
     /** @var Commit */
     private $commit;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->issueRepo = Doctrine::getIssueRepository();
         $this->commitRepo = Doctrine::getCommitRepository();
         $this->commit = $this->flushCommit($this->createCommit());
     }
 
-    public function testFindByCommit()
+    public function testFindByCommit(): void
     {
         $c = $this->commitRepo->findOneByChangeset($this->commit->getChangeset());
         $this->assertNotNull($c);
@@ -47,7 +47,7 @@ class ScmCommitTest extends ScmTestCase
         $this->assertNull($c);
     }
 
-    public function testFindCommitsByIssueId()
+    public function testFindCommitsByIssueId(): void
     {
         $c = $this->issueRepo->getCommits($this->commit->getIssue()->getId());
         $this->assertNotEmpty($c, 'can find commits to issue');

--- a/tests/Scm/ScmTestCase.php
+++ b/tests/Scm/ScmTestCase.php
@@ -22,7 +22,7 @@ use Workflow;
 
 class ScmTestCase extends TestCase
 {
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::setUpConfig();
 
@@ -33,10 +33,8 @@ class ScmTestCase extends TestCase
 
     /**
      * Create commit associated to new issue
-     *
-     * @return Entity\Commit
      */
-    protected function createCommit($scm = 'cvs')
+    protected function createCommit(string $scm = 'cvs'): Entity\Commit
     {
         $changeset = uniqid('z1', false);
 
@@ -59,7 +57,7 @@ class ScmTestCase extends TestCase
         return $ci;
     }
 
-    protected function flushCommit(Entity\Commit $commit)
+    protected function flushCommit(Entity\Commit $commit): Entity\Commit
     {
         $em = $this->getEntityManager();
 
@@ -77,7 +75,7 @@ class ScmTestCase extends TestCase
         return $commit;
     }
 
-    private static function setUpConfig()
+    private static function setUpConfig(): void
     {
         $scm = [
             'cvs' => [
@@ -99,6 +97,7 @@ class ScmTestCase extends TestCase
                 'log_url' => 'http://localhost:10080/{PROJECT}/commits/{VERSION}/{FILE}',
             ],
         ];
+
         Setup::set(['scm' => $scm]);
     }
 }

--- a/tests/src/TestCase.php
+++ b/tests/src/TestCase.php
@@ -20,6 +20,7 @@ namespace Eventum\Test;
  * Load PHPUnit_Framework_TestCase wrapper if using older PHPUnit.
  */
 
+use Doctrine\ORM\EntityManager;
 use Eventum\Db\Doctrine;
 use Eventum\Extension\ExtensionManager;
 
@@ -30,7 +31,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @return ExtensionManager
      */
-    protected function getExtensionManager($config)
+    protected function getExtensionManager($config): ExtensionManager
     {
         /** @var ExtensionManager $stub */
         $stub = $this->getMockBuilder(ExtensionManager::class)
@@ -48,7 +49,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         return $stub;
     }
 
-    protected function getDataFile($fileName)
+    protected function getDataFile($fileName): string
     {
         $dataFile = dirname(__DIR__) . '/data/' . $fileName;
         $this->assertFileExists($dataFile);
@@ -62,7 +63,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param string $filename
      * @return string
      */
-    protected function readDataFile($filename)
+    protected function readDataFile($filename): string
     {
         return $this->readFile($this->getDataFile($filename));
     }
@@ -71,7 +72,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
      * @param string $filename
      * @return string
      */
-    protected function readFile($filename)
+    protected function readFile($filename): string
     {
         $this->assertFileExists($filename);
         $content = file_get_contents($filename);
@@ -80,7 +81,7 @@ class TestCase extends \PHPUnit\Framework\TestCase
         return $content;
     }
 
-    protected function getEntityManager()
+    protected function getEntityManager(): EntityManager
     {
         return Doctrine::getEntityManager();
     }


### PR DESCRIPTION
While it works with phpunit 8, was not able to make non-fatal either due zendframework deprecations or due skipped/incomplete tests

so, all versions run with phpunit 7.5 for now