### PR TITLE
Add buggy email message from Emacs Gnus 5.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Add TaskListMatcher with example to update issue complete percentage (@glensc, #473)
 - Match better merge request title from GitLab event (@glensc, #475)
+- Handle mails without content-type headers created by Emacs Gnus 5.11 (@glensc, #477)
 
 [3.6.1]: https://github.com/eventum/eventum/compare/v3.6.0...master
 

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -35,7 +35,7 @@ class TextMessage
         $this->message = $message;
     }
 
-    public function getMessageBody()
+    public function getMessageBody(): string
     {
         $isMultipart = $this->message->isMultipart();
 
@@ -63,8 +63,7 @@ class TextMessage
 
         if (!$isMultipart) {
             // fallback to read just main part
-            // NOTE: this is likely dead code after #429
-            return (new DecodePart($this->message))->decode();
+            return trim((new DecodePart($this->message))->decode());
         }
 
         return '';
@@ -149,7 +148,7 @@ class TextMessage
 
     private function getText()
     {
-        return implode("\n\n", $this->text);
+        return trim(implode("\n\n", $this->text));
     }
 
     private function getHtml()
@@ -164,6 +163,6 @@ class TextMessage
         // convert html entities. this should be done after strip tags
         $str = html_entity_decode($str, ENT_QUOTES, APP_CHARSET);
 
-        return $str;
+        return trim($str);
     }
 }

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -234,9 +234,8 @@ class MailMessage extends Message
      * Returns the text message body.
      *
      * @return string|null The message body
-     * @deprecated use TextMessage class
      */
-    public function getMessageBody()
+    public function getMessageBody(): ?string
     {
         return (new TextMessage($this))->getMessageBody();
     }

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -26,7 +26,7 @@ class TextMessageTest extends TestCase
     public function testTextMessage($dataFile, $expectedText): void
     {
         $mail = MailMessage::createFromFile($this->getDataFile($dataFile));
-        $textBody = trim($mail->getMessageBody());
+        $textBody = $mail->getMessageBody();
         $this->assertEquals($expectedText, $textBody);
     }
 

--- a/tests/Mail/TextMessageTest.php
+++ b/tests/Mail/TextMessageTest.php
@@ -62,6 +62,10 @@ class TextMessageTest extends TestCase
                 'email-106251.txt',
                 "here\nbe\ndragons",
             ],
+            'pull request #477' => [
+                'gnus511.txt',
+                'Body text',
+            ],
         ];
     }
 }

--- a/tests/data/gnus511.txt
+++ b/tests/data/gnus511.txt
@@ -1,0 +1,23 @@
+Received: from localhost (/10.111.111.116)
+	by default (Boring Booring Gateway v4.0)
+        with ESMTP ; Thu, 21 Feb 2010 02:41:04 -0800
+To: issue-61545@hoste01.us.boring.com
+Subject: Test patch file
+From: John Smithz <john.smithz@boring.com>
+Date: Thu, 21 Feb 2010 11:41:02 +0100
+Message-ID: <m1bm35mnk1.fsf@johnsmbp123016.lan>
+User-Agent: Gnus/5.11 (Gnus v5.11) Emacs/22.1 (darwin)
+MIME-Version: 1.0
+Content-Type: multipart/mixed; boundary="=-=-="
+
+--=-=-=
+
+Body text
+
+--=-=-=
+Content-Type: text/x-patch
+Content-Disposition: attachment; filename=some-attachment.patch
+
+Attachment text
+
+--=-=-=--


### PR DESCRIPTION
Emacs Gnus 5.11 mail messages with attachments are bounced. Eventum
fails to parse it correctly. This PR provide a sample email message.