### PR TITLE
use Horde_Text_Flowed to unflow text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 - Add TaskListMatcher with example to update issue complete percentage (@glensc, #473)
 - Match better merge request title from GitLab event (@glensc, #475)
 - TextMessage: Handle mails without content-type headers created by Emacs Gnus 5.11 (@glensc, #477)
+- Replace `Mime_Helper::decodeFlowedBodies` with Horde version (@glensc, #480, #478)
 
 [3.6.1]: https://github.com/eventum/eventum/compare/v3.6.0...master
 

--- a/composer.json
+++ b/composer.json
@@ -74,6 +74,8 @@
 		"enrise/urihelper": "^1.0",
 		"fonts/liberation": "*",
 		"glen/filename-normalizer": "^2.0",
+		"horde/text-flowed": "dev-patch-1 as 2.0.3",
+		"horde/util": "dev-patch-1 as 2.5.8",
 		"ircmaxell/random-lib": "~1.1.0",
 		"league/flysystem": "^1.0",
 		"malkusch/lock": "^0.4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "96c0c84cf48fa2986a4ab9be04162f6e",
+    "content-hash": "8900c210f6eb48cf1f9dbaf2ecae210e",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -1433,6 +1433,120 @@
             "time": "2018-03-14T18:57:52+00:00"
         },
         {
+            "name": "horde/text-flowed",
+            "version": "dev-patch-1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/glensc/php-Horde_Text_Flowed.git",
+                "reference": "ad30eea8e427aba1219d3b8b52750b7d04a60a91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/glensc/php-Horde_Text_Flowed/zipball/ad30eea8e427aba1219d3b8b52750b7d04a60a91",
+                "reference": "ad30eea8e427aba1219d3b8b52750b7d04a60a91",
+                "shasum": ""
+            },
+            "require": {
+                "pear-pear.horde.org/horde_util": "^2",
+                "php": "^5.3 || ^7"
+            },
+            "replace": {
+                "pear-horde/horde_text_flowed": "self.version",
+                "pear-pear.horde.org/horde_text_flowed": "self.version"
+            },
+            "suggest": {
+                "pear-pear.horde.org/Horde_Test": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Horde_Text_Flowed": "lib/"
+                }
+            },
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Michael Slusarz",
+                    "email": "slusarz@horde.org",
+                    "role": "lead"
+                }
+            ],
+            "description": "Flowed text library",
+            "homepage": "https://www.horde.org/libraries/Horde_Text_Flowed",
+            "support": {
+                "source": "https://github.com/glensc/php-Horde_Text_Flowed/tree/patch-1"
+            },
+            "time": "2019-02-25T12:54:19+00:00"
+        },
+        {
+            "name": "horde/util",
+            "version": "dev-patch-1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/glensc/php-Horde_Util.git",
+                "reference": "b9e6f35a9b503469afe3f25e7d78c8b8dc7e1666"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/glensc/php-Horde_Util/zipball/b9e6f35a9b503469afe3f25e7d78c8b8dc7e1666",
+                "reference": "b9e6f35a9b503469afe3f25e7d78c8b8dc7e1666",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "php": "^5.3 || ^7"
+            },
+            "replace": {
+                "pear-horde/horde_util": "self.version",
+                "pear-pear.horde.org/horde_util": "self.version"
+            },
+            "suggest": {
+                "ext-ctype": "*",
+                "ext-filter": "*",
+                "ext-iconv": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-xml": "*",
+                "pear-pear.horde.org/Horde_Imap_Client": "^2",
+                "pear-pear.horde.org/Horde_Test": "^2.1"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Horde": "lib/"
+                }
+            },
+            "license": [
+                "LGPL-2.1"
+            ],
+            "authors": [
+                {
+                    "name": "Chuck Hagenbuch",
+                    "email": "chuck@horde.org",
+                    "role": "lead"
+                },
+                {
+                    "name": "Jan Schneider",
+                    "email": "jan@horde.org",
+                    "role": "lead"
+                },
+                {
+                    "name": "Michael Slusarz",
+                    "email": "slusarz@horde.org",
+                    "role": "developer"
+                }
+            ],
+            "description": "Utility library",
+            "homepage": "https://www.horde.org/libraries/Horde_Util",
+            "support": {
+                "source": "https://github.com/glensc/php-Horde_Util/tree/patch-1"
+            },
+            "time": "2019-02-25T14:19:00+00:00"
+        },
+        {
             "name": "ircmaxell/random-lib",
             "version": "v1.1.0",
             "source": {
@@ -1799,9 +1913,9 @@
             "version": "0.9.1",
             "dist": {
                 "type": "file",
-                "url": "https://distfiles.pld-linux.org/distfiles/by-md5/a/f/afb06c6975bd1a53c97a8db4fd5d3546/Math_Stats-0.9.1.tgz",
+                "url": "https://pear.php.net/get/Math_Stats-0.9.1.tgz",
                 "reference": null,
-                "shasum": "12ff82808594f51179b6c2f267efa97e807165cc"
+                "shasum": null
             },
             "require": {
                 "php": ">=4.2.0.0"
@@ -1829,9 +1943,9 @@
             "version": "1.2.2",
             "dist": {
                 "type": "file",
-                "url": "https://distfiles.pld-linux.org/distfiles/by-md5/2/d/2d66f40c8e0c8298281260d33e838b41/Text_Diff-1.2.2.tgz",
+                "url": "https://pear.php.net/get/Text_Diff-1.2.2.tgz",
                 "reference": null,
-                "shasum": "3a0416343badd44e5a911546080eee0d5f8d0109"
+                "shasum": null
             },
             "require": {
                 "php": ">=5.3.0.0"
@@ -4885,9 +4999,24 @@
             ]
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "alias": "2.0.3",
+            "alias_normalized": "2.0.3.0",
+            "version": "dev-patch-1",
+            "package": "horde/text-flowed"
+        },
+        {
+            "alias": "2.5.8",
+            "alias_normalized": "2.5.8.0",
+            "version": "dev-patch-1",
+            "package": "horde/util"
+        }
+    ],
     "minimum-stability": "dev",
     "stability-flags": {
+        "horde/text-flowed": 20,
+        "horde/util": 20,
         "zendframework/zend-mail": 20,
         "components/jquery-blockui": 20
     },

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Mail\Helper;
 
+use Horde_Text_Flowed;
 use LogicException;
 use Mime_Helper;
 use Zend\Mail\Storage\Part\PartInterface;
@@ -110,11 +111,13 @@ class TextMessage
             case 'text/plain':
                 if (!$is_attachment) {
                     $format = $part->getHeaderField('Content-Type', 'format');
-                    $delsp = $part->getHeaderField('Content-Type', 'delsp');
 
                     $content = Mime_Helper::convertString((new DecodePart($part))->decode(), $charset);
                     if ($format === 'flowed') {
-                        $content = Mime_Helper::decodeFlowedBodies($content, $delsp);
+                        $delsp = $part->getHeaderField('Content-Type', 'delsp');
+                        $flowed = new Horde_Text_Flowed($content, 'UTF-8');
+                        $flowed->setDelSp($delsp === 'yes');
+                        $content = $flowed->toFixed();
                     }
                     $this->text[] = $content;
                 }

--- a/tests/data/message-chopped.txt
+++ b/tests/data/message-chopped.txt
@@ -1,11 +1,15 @@
 Hi,
 
 On 2/12/19 9:47 AM, [Eventum] Aleandra Polar wrote:
-> Hi Bob,
+>Hi Bob,
 >
->     I was aaaaaaaa aa aaaaaaaaa aaa cccccc aaaaaaa aaaaaaa aaaar > taaaaa baaaaaae aa aaaaa-0.0 aa aaaaaaa. Then aaaaaaa and aaaa aaaa of > tps.  I taaaa  aaaaaaaaaa aa  aaaaa-0.0 dddld dd ddne ddd do ddt ddde > to take ccccccc bbb aaaaa also.This dddl dddd dd aa mdddddd dde iddddt > waaaaat aaaaaaaaag cccccccccc cccccc.
+>    I was aaaaaaaa aa aaaaaaaaa aaa cccccc aaaaaaa aaaaaaa aaaar 
+>taaaaa baaaaaae aa aaaaa-0.0 aa aaaaaaa. Then aaaaaaa and aaaa aaaa of 
+>tps.  I taaaa  aaaaaaaaaa aa  aaaaa-0.0 dddld dd ddne ddd do ddt ddde 
+>to take ccccccc bbb aaaaa also.This dddl dddd dd aa mdddddd dde iddddt 
+>waaaaat aaaaaaaaag cccccccccc cccccc.
 >
-> Is taaa aaaa?
+>Is taaa aaaa?
 
 Best,
 /Bob


### PR DESCRIPTION
While the horde one formats without spaces: `">"` instead of expected `"> "`, this is better than current, as current seems broken.

See: https://github.com/eventum/eventum/issues/478#issuecomment-466972484

cc @vladsf 