### PR TITLE
Remove email parser overhead on search

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -29,4 +29,5 @@ Vlad Safronov
 
 Copyright (c) 2003 - 2008 MySQL AB
 Copyright (c) 2008 - 2010 Sun Microsystem Inc
+Copyright (c) 2019 - Oracle and/or its affiliates
 Copyright (c) 2010 - 2019 Eventum Team

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 - Match better merge request title from GitLab event (@glensc, #475)
 - TextMessage: Handle mails without content-type headers created by Emacs Gnus 5.11 (@glensc, #477)
 - Replace `Mime_Helper::decodeFlowedBodies` with Horde version (@glensc, #480, #478)
+- Remove email parser overhead on Sphinx search (@vladsf, #487)
 
 [3.6.1]: https://github.com/eventum/eventum/compare/v3.6.0...master
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1457,7 +1457,7 @@ class Support
      * @param   int $sup_id The support email ID
      * @return  array The email entry summary
      */
-    public static function getEmailSummary($sup_id)
+    public static function getEmailSummary($sup_id): array
     {
         $stmt = 'SELECT
                     `support_email`.sup_subject,

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1457,7 +1457,7 @@ class Support
      * @param   int $sup_id The support email ID
      * @return  array The email entry summary
      */
-    public static function getEmailSummary($sup_id): array
+    public static function getEmailSummary(int $sup_id): array
     {
         $stmt = 'SELECT
                     `support_email`.sup_subject,

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1452,6 +1452,34 @@ class Support
     }
 
     /**
+     * Method used to get the support email body and subject.
+     *
+     * @param   int $sup_id The support email ID
+     * @return  array The email entry summary
+     */
+    public static function getEmailSummary($sup_id)
+    {
+        $stmt = 'SELECT
+                    `support_email`.sup_subject,
+                    `support_email_body`.seb_body
+                 FROM
+                    `support_email`,
+                    `support_email_body`
+                 WHERE
+                    sup_id=seb_sup_id AND
+                    sup_id=?';
+
+        $res = DB_Helper::getInstance()->getRow($stmt, [$sup_id]);
+        if (!$res) {
+            throw new InvalidArgumentException("Could not fetch email: $sup_id");
+        }
+
+        $res['message'] = $res['seb_body'];
+
+        return $res;
+    }
+
+    /**
      * Returns the nth note for a specific issue. The sequence starts at 1.
      *
      * @param   int $issue_id the id of the issue

--- a/lib/eventum/search/class.sphinx_fulltext_search.php
+++ b/lib/eventum/search/class.sphinx_fulltext_search.php
@@ -141,7 +141,7 @@ class Sphinx_Fulltext_Search extends Abstract_Fulltext_Search
                     }
                 } elseif ($match['index'] == 'email') {
                     try {
-                        $email = Support::getEmailDetails($match['match_id']);
+                        $email = Support::getEmailSummary($match['match_id']);
                         $documents = [$email['sup_subject'] . "\n" . $email['message']];
                         $res = $this->sphinx->BuildExcerpts($documents, 'email_stemmed', $this->keywords, $excerpt_options);
                         $excerpt['email'][Support::getSequenceByID($match['match_id'])] = self::cleanUpExcerpt($res[0]);


### PR DESCRIPTION
Loading a full email body, parsing headers, attachments is
irrelevant for the search results. This change improves speed
and eliminates possible exceptions thrown on a full email load.

IMPORTANT:
As a contributor I must add Oracle Copyright notice to the place designated for such notices (AUTHORS).