### PR TITLE
Add more events to handle Workflow calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 - Add jQuery chosen to quick filter (@glensc, #493)
 - Refactor Custom Fields to use Interfaces and Doctrine Models (@glensc, #466)
 - Initialize `usr_id`, needed for preferences (@glensc, #498, #499, #500)
+- Add more events to handle Workflow calls (@glensc, #497)
 
 [3.6.3]: https://github.com/eventum/eventum/compare/v3.6.2...master
 

--- a/composer.json
+++ b/composer.json
@@ -84,6 +84,7 @@
 		"pear-pear.php.net/math_stats": "^0.9.1",
 		"pear/pear-core-minimal": "^1.10",
 		"phlib/flysystem-pdo": "^1.1",
+		"php-ds/php-ds": "^1.2",
 		"php-gettext/php-gettext": "1.0.*",
 		"phplot/phplot": "~6.1.0",
 		"phpxmlrpc/phpxmlrpc": "^4.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0f433ada3eb58725b0eb909614d0cb96",
+    "content-hash": "04083746b66a165bcbec0d326fe6b3f4",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -2169,6 +2169,53 @@
                 "invoker"
             ],
             "time": "2017-03-20T19:28:22+00:00"
+        },
+        {
+            "name": "php-ds/php-ds",
+            "version": "v1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-ds/polyfill.git",
+                "reference": "27bed3897f9c801604f5bdcb65b71eb61ec80099"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-ds/polyfill/zipball/27bed3897f9c801604f5bdcb65b71eb61ec80099",
+                "reference": "27bed3897f9c801604f5bdcb65b71eb61ec80099",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0.0"
+            },
+            "require-dev": {
+                "php-ds/tests": "^1.2"
+            },
+            "suggest": {
+                "ext-ds": "to improve performance and reduce memory usage"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Ds\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Rudi Theunissen",
+                    "email": "rudolf.theunissen@gmail.com"
+                }
+            ],
+            "keywords": [
+                "data structures",
+                "ds",
+                "php",
+                "polyfill"
+            ],
+            "time": "2017-08-03T02:03:34+00:00"
         },
         {
             "name": "php-gettext/php-gettext",

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -11,6 +11,7 @@
  * that were distributed with this source code.
  */
 
+use Ds\Set;
 use Eventum\Attachment\AttachmentGroup;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
@@ -891,30 +892,25 @@ class Workflow
     }
 
     /**
-     * Returns an array of patterns and replacements.
+     * Updates filters in $filters.
      *
-     * @param   int $prj_id The ID of the project
-     * @return  array An array of patterns and replacements
      * @since 3.6.3 emits ATTACHMENT_ATTACH_FILE event
      * @deprecated
      */
-    public static function getLinkFilters($prj_id): array
+    public static function addLinkFilters(Set $filters, int $prj_id): void
     {
         $arguments = [
             'prj_id' => $prj_id,
         ];
-        $event = new ResultableEvent(null, $arguments);
+        $event = new GenericEvent($filters, $arguments);
         EventManager::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
-        if ($event->hasResult()) {
-            return $event->getResult();
-        }
 
         if (!self::hasWorkflowIntegration($prj_id)) {
-            return [];
+            return;
         }
-        $backend = self::_getBackend($prj_id);
 
-        return $backend->getLinkFilters($prj_id);
+        $backend = self::_getBackend($prj_id);
+        $filters->add(...$backend->getLinkFilters($prj_id));
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -17,6 +17,7 @@ use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionLoader;
+use Eventum\LinkFilter\LinkFilter;
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailMessage;
@@ -897,12 +898,12 @@ class Workflow
      * @since 3.6.3 emits ATTACHMENT_ATTACH_FILE event
      * @deprecated
      */
-    public static function addLinkFilters(Set $filters, int $prj_id): void
+    public static function addLinkFilters(LinkFilter $linkFilter, int $prj_id): void
     {
         $arguments = [
             'prj_id' => $prj_id,
         ];
-        $event = new GenericEvent($filters, $arguments);
+        $event = new GenericEvent($linkFilter, $arguments);
         EventManager::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
 
         if (!self::hasWorkflowIntegration($prj_id)) {
@@ -910,7 +911,7 @@ class Workflow
         }
 
         $backend = self::_getBackend($prj_id);
-        $filters->add(...$backend->getLinkFilters($prj_id));
+        $linkFilter->addRules($backend->getLinkFilters($prj_id));
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -895,9 +895,20 @@ class Workflow
      *
      * @param   int $prj_id The ID of the project
      * @return  array An array of patterns and replacements
+     * @since 3.6.3 emits ATTACHMENT_ATTACH_FILE event
+     * @deprecated
      */
-    public static function getLinkFilters($prj_id)
+    public static function getLinkFilters($prj_id): array
     {
+        $arguments = [
+            'prj_id' => $prj_id,
+        ];
+        $event = new ResultableEvent(null, $arguments);
+        EventManager::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
+        if ($event->hasResult()) {
+            return $event->getResult();
+        }
+
         if (!self::hasWorkflowIntegration($prj_id)) {
             return [];
         }

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -192,9 +192,22 @@ class Workflow
      * @param   int $usr_id The id of the user who attached the file
      * @param   array $attachment attachment object
      * @return  bool
+     * @since 3.6.3 emits ATTACHMENT_ATTACH_FILE event
+     * @deprecated
      */
-    public static function shouldAttachFile($prj_id, $issue_id, $usr_id, $attachment)
+    public static function shouldAttachFile(int $prj_id, int $issue_id, $usr_id, array $attachment): bool
     {
+        $arguments = [
+            'prj_id' => $prj_id,
+            'issue_id' => $issue_id,
+            'usr_id' => is_numeric($usr_id) ? (int)$usr_id : $usr_id,
+        ];
+        $event = new ResultableEvent($attachment, $arguments);
+        EventManager::dispatch(SystemEvents::ATTACHMENT_ATTACH_FILE, $event);
+        if ($event->hasResult()) {
+            return $event->getResult();
+        }
+
         if (!self::hasWorkflowIntegration($prj_id)) {
             return true;
         }

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -181,6 +181,7 @@ abstract class Abstract_Workflow_Backend
      * @param   int $usr_id The id of the user who attached the file
      * @param   array $attachment attachment object
      * @return  bool
+     * @deprecated use ATTACHMENT_ATTACH_FILE event instead
      */
     public function shouldAttachFile($prj_id, $issue_id, $usr_id, $attachment)
     {

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -544,6 +544,7 @@ abstract class Abstract_Workflow_Backend
      *
      * @param   int $prj_id The ID of the project
      * @return  array An array of patterns and replacements
+     * @deprecated use ATTACHMENT_ATTACH_FILE event instead
      */
     public function getLinkFilters($prj_id)
     {

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -338,6 +338,7 @@ abstract class Abstract_Workflow_Backend
      * @param   string $email the email address to subscribe to subscribe (if this is not a real user)
      * @param   array $actions the action types
      * @return  array|bool an array of information or true to continue unchanged or false to prevent the user from being added
+     * @deprecated use NOTIFICATION_HANDLE_SUBSCRIPTION instead
      */
     public function handleSubscription($prj_id, $issue_id, &$subscriber_usr_id, &$email, &$actions)
     {
@@ -352,6 +353,7 @@ abstract class Abstract_Workflow_Backend
      * @param   int $issue_id the ID of the issue
      * @param   string $type the type of notification to send
      * @return  bool
+     * @deprecated use NOTIFICATION_NOTIFY_ADDRESS event instead
      */
     public function shouldEmailAddress($prj_id, $address, $issue_id = null, $type = null)
     {

--- a/src/Controller/ListController.php
+++ b/src/Controller/ListController.php
@@ -234,11 +234,7 @@ class ListController extends BaseController
 
         // items needed for bulk update tool
         if (Auth::getCurrentRole() > User::ROLE_DEVELOPER) {
-            if (Workflow::hasWorkflowIntegration($this->prj_id)) {
-                $open_statuses = Workflow::getAllowedStatuses($this->prj_id);
-            } else {
-                $open_statuses = Status::getAssocStatusList($this->prj_id, false);
-            }
+            $open_statuses = Workflow::getAllowedStatuses($this->prj_id);
             $this->tpl->assign(
                 [
                     'users' => $users,

--- a/src/Controller/UpdateController.php
+++ b/src/Controller/UpdateController.php
@@ -198,12 +198,8 @@ class UpdateController extends BaseController
             $releases = [$this->details['iss_pre_id'] => $this->details['pre_title']] + $releases;
         }
 
-        if (Workflow::hasWorkflowIntegration($this->prj_id)) {
-            // if currently selected release is not on list, go ahead and add it.
-            $statuses = Workflow::getAllowedStatuses($this->prj_id, $this->issue_id);
-        } else {
-            $statuses = Status::getAssocStatusList($this->prj_id, false);
-        }
+        // if currently selected release is not on list, go ahead and add it.
+        $statuses = Workflow::getAllowedStatuses($this->prj_id, $this->issue_id);
 
         if (!empty($this->details['iss_sta_id']) && empty($statuses[$this->details['iss_sta_id']])) {
             $statuses[$this->details['iss_sta_id']] = Status::getStatusTitle($this->details['iss_sta_id']);

--- a/src/Controller/ViewController.php
+++ b/src/Controller/ViewController.php
@@ -213,13 +213,7 @@ class ViewController extends BaseController
         $cookie = $this->getRequest()->cookies;
         $show_all_drafts = $cookie->get('show_all_drafts') == 1;
 
-        if (Workflow::hasWorkflowIntegration($this->prj_id)) {
-            // if currently selected release is not on list, go ahead and add it.
-            $statuses = Workflow::getAllowedStatuses($this->prj_id, $this->issue_id);
-        } else {
-            $statuses = Status::getAssocStatusList($this->prj_id, false);
-        }
-
+        $statuses = Workflow::getAllowedStatuses($this->prj_id, $this->issue_id);
         if (!empty($details['iss_sta_id']) && empty($statuses[$details['iss_sta_id']])) {
             $statuses[$details['iss_sta_id']] = Status::getStatusTitle($details['iss_sta_id']);
         }

--- a/src/Event/ResultableEvent.php
+++ b/src/Event/ResultableEvent.php
@@ -31,7 +31,7 @@ class ResultableEvent extends GenericEvent
     /**
      * Tells whether any consumer has set the result
      */
-    public function hasResult()
+    public function hasResult(): bool
     {
         return $this->result !== null;
     }

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -149,6 +149,12 @@ final class SystemEvents
     const ISSUE_UPDATED = 'issue.updated';
 
     /**
+     * @since 3.6.3
+     * @see Workflow::getAllowedStatuses()
+     */
+    public const ISSUE_ALLOWED_STATUSES = 'issue.allowed.statuses';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -168,7 +168,7 @@ final class SystemEvents
 
     /**
      * @since 3.6.3
-     * @see Workflow::getLinkFilters()
+     * @see Workflow::addLinkFilters()
      */
     public const ISSUE_LINK_FILTERS = 'issue.link.filters';
 

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -102,6 +102,12 @@ final class SystemEvents
     const NOTIFICATION_NOTIFY_ADDRESS = 'notification.notify.address';
 
     /**
+     * @since 3.6.3
+     * @see Workflow::handleSubscription()
+     */
+    public const NOTIFICATION_HANDLE_SUBSCRIPTION = 'notification.handle.subscription';
+
+    /**
      * @since 3.4.2
      */
     const IRC_NOTIFY = 'irc.notify';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -19,6 +19,12 @@ use Eventum\Model\Repository\CommitRepository;
 final class SystemEvents
 {
     /**
+     * @since 3.6.3
+     * @see Workflow::shouldAttachFile()
+     */
+    public const ATTACHMENT_ATTACH_FILE = 'attachment.attach.file';
+
+    /**
      * Event fired when history entry is added
      *
      * @since 3.3.0

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -167,6 +167,12 @@ final class SystemEvents
     public const ISSUE_ALLOWED_STATUSES = 'issue.allowed.statuses';
 
     /**
+     * @since 3.6.3
+     * @see Workflow::getLinkFilters()
+     */
+    public const ISSUE_LINK_FILTERS = 'issue.link.filters';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/LinkFilter/IssueLinkFilter.php
+++ b/src/LinkFilter/IssueLinkFilter.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\LinkFilter;
+
+use Issue;
+
+class IssueLinkFilter implements LinkFilterInterface
+{
+    /**
+     * Method used as a callback with the regular expression code that parses
+     * text and creates links to other issues.
+     *
+     * @param   array $matches Regular expression matches
+     * @return  string The link to the appropriate issue
+     */
+    public function __invoke(array $matches): string
+    {
+        $issue_id = $matches['issue_id'];
+        // check if the issue is still open
+        if (Issue::isClosed($issue_id)) {
+            $class = 'closed';
+        } else {
+            $class = '';
+        }
+        $issue_title = Issue::getTitle($issue_id);
+        $link_title = htmlspecialchars("issue {$issue_id} - {$issue_title}");
+
+        // use named capture 'match' if present
+        $match = $matches['match'] ?? "issue {$issue_id}";
+
+        return "<a title=\"{$link_title}\" class=\"{$class}\" href=\"view.php?id={$matches['issue_id']}\">{$match}</a>";
+    }
+}

--- a/src/LinkFilter/LinkFilter.php
+++ b/src/LinkFilter/LinkFilter.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\LinkFilter;
+
+use Ds\Set;
+
+class LinkFilter
+{
+    /** @var Set */
+    private $rules;
+
+    public function __construct()
+    {
+        $this->rules = new Set();
+    }
+
+    public function addFilter(LinkFilterInterface $handler): self
+    {
+        foreach ($handler->getPatterns() as $pattern) {
+            $this->addRule($pattern, $handler);
+        }
+
+        return $this;
+    }
+
+    public function addRule(string $pattern, $handler): self
+    {
+        $this->rules->add([$pattern, $handler]);
+
+        return $this;
+    }
+
+    public function addRules(array $rules): self
+    {
+        foreach ($rules as $rule) {
+            [$pattern, $handler] = $rule;
+            $this->addRule($pattern, $handler);
+        }
+
+        return $this;
+    }
+
+    public function replace(string $text): string
+    {
+        foreach ($this->rules as $rule) {
+            [$pattern, $handler] = $rule;
+            if (is_callable($handler)) {
+                $text = preg_replace_callback($pattern, $handler, $text);
+            } else {
+                $text = preg_replace($pattern, $handler, $text);
+            }
+        }
+
+        return $text;
+    }
+}

--- a/src/LinkFilter/LinkFilterInterface.php
+++ b/src/LinkFilter/LinkFilterInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\LinkFilter;
+
+interface LinkFilterInterface
+{
+    /**
+     * Method used as a callback with the regular expression code that parses
+     * text and creates links to other issues.
+     *
+     * @param   array $matches Regular expression matches
+     * @return  string The link to the appropriate issue
+     */
+    public function __invoke(array $matches): string;
+}

--- a/src/LinkFilter/LinkFilterInterface.php
+++ b/src/LinkFilter/LinkFilterInterface.php
@@ -15,6 +15,8 @@ namespace Eventum\LinkFilter;
 
 interface LinkFilterInterface
 {
+    public function getPatterns(): array;
+
     /**
      * Method used as a callback with the regular expression code that parses
      * text and creates links to other issues.

--- a/src/LinkFilter/ProjectLinkFilter.php
+++ b/src/LinkFilter/ProjectLinkFilter.php
@@ -16,9 +16,9 @@ namespace Eventum\LinkFilter;
 use Issue;
 
 /**
- * Linkfilter to Link Eventum issue id's
+ * Load LinkFilters from database for a project
  */
-class IssueLinkFilter implements LinkFilterInterface
+class ProjectLinkFilter implements LinkFilterInterface
 {
     /** @var string */
     private $baseUrl;

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Test;
 
-use Ds\Set;
+use Eventum\LinkFilter\LinkFilter;
 use Link_Filter;
 
 /**
@@ -21,12 +21,12 @@ use Link_Filter;
  */
 class LinkFilterTest extends TestCase
 {
-    /** @var Set */
-    private static $filters;
+    /** @var LinkFilter */
+    private static $linkFilter;
 
     public static function setUpBeforeClass(): void
     {
-        self::$filters = Link_Filter::getFilters();
+        self::$linkFilter = Link_Filter::getLinkFilter();
     }
 
     /**
@@ -35,16 +35,7 @@ class LinkFilterTest extends TestCase
      */
     public function testIssueLinking($text, $exp): void
     {
-        foreach (self::$filters as $filter) {
-            list($pattern, $replacement) = $filter;
-            // replacement may be a callback, provided by workflow
-            if (is_callable($replacement)) {
-                $text = preg_replace_callback($pattern, $replacement, $text);
-            } else {
-                $text = preg_replace($pattern, $replacement, $text);
-            }
-        }
-
+        $text = self::$linkFilter->replace($text);
         $this->assertRegExp($exp, $text);
     }
 

--- a/tests/LinkFilterTest.php
+++ b/tests/LinkFilterTest.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Test;
 
+use Ds\Set;
 use Link_Filter;
 
 /**
@@ -20,15 +21,21 @@ use Link_Filter;
  */
 class LinkFilterTest extends TestCase
 {
+    /** @var Set */
+    private static $filters;
+
+    public static function setUpBeforeClass(): void
+    {
+        self::$filters = Link_Filter::getFilters();
+    }
+
     /**
      * @dataProvider dataTestIssueLinking
      * @see          Link_Filter::proccessText
      */
     public function testIssueLinking($text, $exp): void
     {
-        $filters = Link_Filter::getFilters();
-
-        foreach ((array)$filters as $filter) {
+        foreach (self::$filters as $filter) {
             list($pattern, $replacement) = $filter;
             // replacement may be a callback, provided by workflow
             if (is_callable($replacement)) {


### PR DESCRIPTION
More workflow methods can be replaced by using events.

In fact, I can drop my workflow class.