### PR TITLE
Split extension features to each interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Fix fatal errors when opening rss feeds (@glensc, #518)
 - SCM commit: do not log wrong branch push as error (@glensc, #517)
+- Split extension features to each interface (@glensc, #510)
 
 [3.6.6]: https://github.com/eventum/eventum/compare/v3.6.5...master
 

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -14,7 +14,7 @@
 namespace Example\Extension;
 
 use Composer\Autoload\ClassLoader;
-use Eventum\Extension\AbstractExtension;
+use Eventum\Extension\Provider;
 use Example\Event\Subscriber;
 
 /**
@@ -25,10 +25,14 @@ use Example\Event\Subscriber;
  * 'extensions' => [
  *   'Eventum\\Extension\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
  * ],
- *
- * Class doc comment will be used to describe purpose or add documentation.
  */
-class ExampleExtension extends AbstractExtension
+class ExampleExtension implements
+    Provider\AutoloadProvider,
+    Provider\CrmProvider,
+    Provider\CustomFieldProvider,
+    Provider\PartnerProvider,
+    Provider\SubscriberProvider,
+    Provider\WorkflowProvider
 {
     /**
      * Method invoked so the extension can setup class loader.

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -13,6 +13,7 @@
 
 namespace Example\Extension;
 
+use Composer\Autoload\ClassLoader;
 use Eventum\Extension\AbstractExtension;
 use Example\Event\Subscriber;
 
@@ -32,7 +33,7 @@ class ExampleExtension extends AbstractExtension
     /**
      * Method invoked so the extension can setup class loader.
      *
-     * @param \Composer\Autoload\ClassLoader $loader
+     * @param ClassLoader $loader
      */
     public function registerAutoloader($loader): void
     {

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Console\Command;
 
-use Eventum\Extension\ExtensionInterface;
+use Eventum\Extension\Provider;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
@@ -91,7 +91,7 @@ class ExtensionEnableCommand
 
         $reflectionClass = new ReflectionClass($extensionName);
 
-        $implements = $reflectionClass->implementsInterface(ExtensionInterface::class);
+        $implements = $reflectionClass->implementsInterface(Provider::class);
         if (!$implements) {
             throw new InvalidArgumentException("Class $extensionName does not implement ExtensionInterface");
         }

--- a/src/Extension/AbstractExtension.php
+++ b/src/Extension/AbstractExtension.php
@@ -14,64 +14,59 @@
 namespace Eventum\Extension;
 
 /**
- * Class AbstractExtension
- *
- * Class doc comment will be used to describe purpose or add documentation.
- *
- * $d = new \ReflectionClass('foo');
- * $d->getDocComment();
+ * @deprecated [since 3.6.5]: implement each interface by your own
  */
 abstract class AbstractExtension implements ExtensionInterface
 {
     /**
      * {@inheritdoc}
-     * @see ExtensionInterface::registerAutoloader()
+     * @see Provider\AutoloadProvider::registerAutoloader()
      */
-    public function registerAutoloader($loader)
+    public function registerAutoloader($loader): void
     {
     }
 
     /**
      * {@inheritdoc}
-     * @see ExtensionInterface::getSubscribers()
+     * @see Provider\SubscriberProvider::getSubscribers()
      */
-    public function getSubscribers()
-    {
-        return [];
-    }
-
-    /**
-     * {@inheritdoc}
-     * @see ExtensionInterface::getAvailableWorkflows()
-     */
-    public function getAvailableWorkflows()
+    public function getSubscribers(): array
     {
         return [];
     }
 
     /**
      * {@inheritdoc}
-     * @see ExtensionInterface::getAvailableCustomFields()
+     * @see Provider\WorkflowProvider::getAvailableWorkflows()
      */
-    public function getAvailableCustomFields()
+    public function getAvailableWorkflows(): array
     {
         return [];
     }
 
     /**
      * {@inheritdoc}
-     * @see ExtensionInterface::getAvailablePartners()
+     * @see Provider\CustomFieldProvider::getAvailableCustomFields()
      */
-    public function getAvailablePartners()
+    public function getAvailableCustomFields(): array
     {
         return [];
     }
 
     /**
      * {@inheritdoc}
-     * @see ExtensionInterface::getAvailableCRMs()
+     * @see Provider\PartnerProvider::getAvailablePartners()
      */
-    public function getAvailableCRMs()
+    public function getAvailablePartners(): array
+    {
+        return [];
+    }
+
+    /**
+     * {@inheritdoc}
+     * @see Provider\CrmProvider::getAvailableCRMs()
+     */
+    public function getAvailableCRMs(): array
     {
         return [];
     }

--- a/src/Extension/BuiltinLegacyLoaderExtension.php
+++ b/src/Extension/BuiltinLegacyLoaderExtension.php
@@ -19,7 +19,7 @@ use Partner;
 use Workflow;
 
 /**
- * Extension providing autoloader for legacy backends locations:
+ * Extension providing autoloader for legacy backend locations:
  * - workflow
  * - partner
  * - custom_field
@@ -80,7 +80,7 @@ class BuiltinLegacyLoaderExtension extends AbstractExtension
      * @param array $classnames array where to append found class names
      * @return array
      */
-    private function createAutoloadMap($loader, &$classnames): array
+    private function createAutoloadMap(ExtensionLoader $loader, array &$classnames): array
     {
         $map = [];
 

--- a/src/Extension/ExtensionFactoryInterface.php
+++ b/src/Extension/ExtensionFactoryInterface.php
@@ -13,14 +13,11 @@
 
 namespace Eventum\Extension;
 
-interface ExtensionFactoryInterface
+use Eventum\Extension\Provider\FactoryProvider;
+
+/**
+ * @deprecated [since 3.6.5]: implement FactoryProvider instead
+ */
+interface ExtensionFactoryInterface extends FactoryProvider
 {
-    /**
-     * Create instance of $className
-     *
-     * @param string $className
-     * @return object|null
-     * @since 3.5.0
-     */
-    public function factory($className);
 }

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -157,7 +157,9 @@ class ExtensionManager
     private function getSortedExtensions(array $extensions, Provider\ExtensionProvider $preferredExtension): Generator
     {
         // prefer provided extension
-        yield $preferredExtension;
+        if ($preferredExtension instanceof FactoryProvider) {
+            yield $preferredExtension;
+        }
         unset($extensions[get_class($preferredExtension)]);
 
         foreach ($extensions as $extension) {

--- a/src/Extension/IrcNotifyExtension.php
+++ b/src/Extension/IrcNotifyExtension.php
@@ -21,7 +21,7 @@ class IrcNotifyExtension extends AbstractExtension
     /**
      * {@inheritdoc}
      */
-    public function getSubscribers()
+    public function getSubscribers(): array
     {
         $subscribers = [];
 

--- a/src/Extension/Provider/AutoloadProvider.php
+++ b/src/Extension/Provider/AutoloadProvider.php
@@ -11,17 +11,17 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+use Composer\Autoload\ClassLoader;
+
+interface AutoloadProvider extends ExtensionProvider
 {
+    /**
+     * Method invoked so the extension can setup class loader.
+     *
+     * @param ClassLoader $loader
+     * @since 3.6.5
+     */
+    public function registerAutoloader($loader): void;
 }

--- a/src/Extension/Provider/CrmProvider.php
+++ b/src/Extension/Provider/CrmProvider.php
@@ -11,17 +11,15 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface CrmProvider extends ExtensionProvider
 {
+    /**
+     * Return CRM Class names the extension provides.
+     *
+     * @return string[]
+     * @since 3.6.5
+     */
+    public function getAvailableCRMs(): array;
 }

--- a/src/Extension/Provider/CustomFieldProvider.php
+++ b/src/Extension/Provider/CustomFieldProvider.php
@@ -11,17 +11,15 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface CustomFieldProvider extends ExtensionProvider
 {
+    /**
+     * Return Custom Field Class names the extension provides.
+     *
+     * @return string[]
+     * @since 3.6.5
+     */
+    public function getAvailableCustomFields(): array;
 }

--- a/src/Extension/Provider/ExtensionProvider.php
+++ b/src/Extension/Provider/ExtensionProvider.php
@@ -11,17 +11,8 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface ExtensionProvider
 {
 }

--- a/src/Extension/Provider/FactoryProvider.php
+++ b/src/Extension/Provider/FactoryProvider.php
@@ -11,17 +11,16 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface FactoryProvider extends ExtensionProvider
 {
+    /**
+     * Create instance of $className
+     *
+     * @param string $className
+     * @return object|null
+     * @since 3.6.5
+     */
+    public function factory($className);
 }

--- a/src/Extension/Provider/PartnerProvider.php
+++ b/src/Extension/Provider/PartnerProvider.php
@@ -11,17 +11,15 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface PartnerProvider extends ExtensionProvider
 {
+    /**
+     * Return Partner Class names the extension provides.
+     *
+     * @return string[]
+     * @since 3.6.5
+     */
+    public function getAvailablePartners(): array;
 }

--- a/src/Extension/Provider/SubscriberProvider.php
+++ b/src/Extension/Provider/SubscriberProvider.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension\Provider;
+
+interface SubscriberProvider extends ExtensionProvider
+{
+    /**
+     * Get classes implementing EventSubscriberInterface.
+     *
+     * @see http://symfony.com/doc/current/components/event_dispatcher.html#using-event-subscribers
+     * @see \Symfony\Component\EventDispatcher\EventSubscriberInterface
+     * @return string[]
+     * @since 3.6.5
+     */
+    public function getSubscribers(): array;
+}

--- a/src/Extension/Provider/WorkflowProvider.php
+++ b/src/Extension/Provider/WorkflowProvider.php
@@ -11,17 +11,15 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Extension;
+namespace Eventum\Extension\Provider;
 
-/**
- * @deprecated [since 3.6.5]: implement each interface by your own
- */
-interface ExtensionInterface extends
-    Provider\AutoloadProvider,
-    Provider\CustomFieldProvider,
-    Provider\PartnerProvider,
-    Provider\SubscriberProvider,
-    Provider\WorkflowProvider,
-    Provider\CrmProvider
+interface WorkflowProvider extends ExtensionProvider
 {
+    /**
+     * Return Workflow Class names your extension provides.
+     *
+     * @return string[]
+     * @since 3.6.5
+     */
+    public function getAvailableWorkflows(): array;
 }


### PR DESCRIPTION
- Deprecates `AbstractExtension` and `ExtensionInterface`
- Breaks compatibility: parameter and return type hints are required now

This allows writing single-purpose extensions:
- an extension providing only `SubscriberProvider` interface

cc @balsdorf 