### PR TITLE
Add event to be able to configure Phinx config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Escape plain description HTML (@glensc, #515, #428)
 - Simplify Crypto enable/disable flow (@glensc, #514)
+- Add event to be able to configure Phinx config (@glensc, #516)
 
 [3.6.5]: https://github.com/eventum/eventum/compare/v3.6.4...master
 

--- a/phinx.php
+++ b/phinx.php
@@ -12,6 +12,9 @@
  */
 
 use Eventum\Db\AbstractMigration;
+use Eventum\Event\SystemEvents;
+use Eventum\EventDispatcher\EventManager;
+use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Configuration proxy for sphix
@@ -42,8 +45,12 @@ $config = DB_Helper::getConfig();
 
 $phinx = [
     'paths' => [
-        'migrations' => 'db/migrations',
-        'seeds' => 'db/seeds',
+        'migrations' => [
+            'db/migrations',
+        ],
+        'seeds' => [
+            'db/seeds',
+        ],
     ],
 
     // http://docs.phinx.org/en/latest/configuration.html#custom-migration-base
@@ -88,4 +95,7 @@ $phinx = [
 $phinx['environments']['test'] = $phinx['environments']['production'];
 $phinx['environments']['test']['name'] = 'e_test';
 
-return $phinx;
+$event = new GenericEvent(null, $phinx);
+EventManager::getEventDispatcher()->dispatch(SystemEvents::PHINX_CONFIG, $event);
+
+return $event->getArguments();

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -218,6 +218,13 @@ final class SystemEvents
     public const BOOT = 'eventum.boot';
 
     /**
+     * Allow to hook into phinx configuration, to be able to specify extra migrations dirs.
+     *
+     * @since 3.6.5
+     */
+    public const PHINX_CONFIG = 'phinx.config';
+
+    /**
      * Event emitted when eventum shuts down.
      * You can listen to this event to do cleanup on request end.
      *


### PR DESCRIPTION
Example:

```php
class PhinxConfig implements EventSubscriberInterface
{
    public static function getSubscribedEvents(): array
    {
        return [
            SystemEvents::PHINX_CONFIG => 'phinxConfig',
        ];
    }

    public function phinxConfig(GenericEvent $event): void
    {
        $phinx = $event->getArguments();
        $phinx['paths']['migrations'][] = $this->getMigrationPath();
        $event->setArguments($phinx);
    }
```