### PR TITLE
Fx fatal errors when opening rss feeds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Fix fatal errors when opening rss feeds (@glensc)
+
 [3.6.6]: https://github.com/eventum/eventum/compare/v3.6.5...master
 
 ## [3.6.5] - 2019-04-08

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -572,14 +572,14 @@ class Filter
                     cst_id=?';
         $params[] = $cst_id;
 
-        try {
-            $res = DB_Helper::getInstance()->getRow($stmt, $params);
-        } catch (DatabaseException $e) {
-            return '';
-        }
+        $res = DB_Helper::getInstance()->getRow($stmt, $params);
 
+        // FIXME: in get rss feed context,
+        // getFiltersInfo() requires current project context,
+        // but that is not known as this method returns current project id
+        // this probably needs to be refactored to split logic to individual methods
         foreach (self::getFiltersInfo() as $field => $filter) {
-            if (@$filter['is_array'] == true) {
+            if (($filter['is_array'] ?? null) == true) {
                 $res['cst_' . $field] = explode(',', $res['cst_' . $field]);
             }
         }

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -937,6 +937,11 @@ class Filter
 
         // add custom fields
         $prj_id = Auth::getCurrentProject();
+        if (!$prj_id) {
+            // no project cookie, no fields to give
+            return [];
+        }
+
         $repo = Doctrine::getCustomFieldRepository();
         // XXX should the minRole be Auth::getCurrentRole()?
         // XXX should fromType be passed?

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -485,7 +485,10 @@ class Search
                 continue;
             }
 
-            $formattedValue = Custom_Field::formatValue($cf['value'], $cf['fld_id'], $iss_id);
+            $formattedValue = $cf['value'];
+            if ($formattedValue) {
+                $formattedValue = Custom_Field::formatValue($formattedValue, $cf['fld_id'], $iss_id);
+            }
             $cf['formatted_value'] = $formattedValue;
 
             $row['custom_field'][$cf['fld_id']] = $cf;


### PR DESCRIPTION
```
[2019-04-10 14:12:42] app.ERROR: Uncaught Exception TypeError:
"Argument 1 passed to Eventum\Model\Repository\CustomFieldRepository::getListByProject() must be of the type integer, string given

[stacktrace]
lib/eventum/class.filter.php(943): Eventum\Model\Repository\CustomFieldRepository->getListByProject('', 1, NULL)
#1 lib/eventum/class.filter.php(581): Filter::getFiltersInfo()
#2 src/Controller/RssController.php(177): Filter::getDetails(158, false)
#3 src/Controller/BaseController.php(82): Eventum\Controller\RssController->prepareTemplate()
#4 htdocs/rss.php(17): Eventum\Controller\BaseController->run()
#5 {main}
```

Fixes several mistakes down the path.