### PR TITLE
Add support for enabling xhgui-profiler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version fi
 - Fix fatal errors when opening rss feeds (@glensc, #518)
 - SCM commit: do not log wrong branch push as error (@glensc, #517)
 - Split extension features to each interface (@glensc, #510)
+- Add support for enabling xhgui-profiler (@glensc, #519)
 
 [3.6.6]: https://github.com/eventum/eventum/compare/v3.6.5...master
 

--- a/bin/ci/configure.sh
+++ b/bin/ci/configure.sh
@@ -12,6 +12,13 @@ composer config platform.ext-ldap '0'
 # https://travis-ci.org/glensc/eventum/jobs/490544010
 composer config platform.ext-gd '0'
 
+# add mongodb extension
+# https://github.com/eventum/eventum/pull/519
+MONGODB_VERSION=1.4.3
+# don't really need it being present, so fake
+#pecl install -f mongodb-$MONGODB_VERSION
+composer config platform.ext-mongodb $MONGODB_VERSION
+
 # disable xdebug
 phpenv config-rm xdebug.ini || :
 

--- a/bin/ci/configure.sh
+++ b/bin/ci/configure.sh
@@ -14,10 +14,10 @@ composer config platform.ext-gd '0'
 
 # add mongodb extension
 # https://github.com/eventum/eventum/pull/519
-MONGODB_VERSION=1.4.3
+MONGODB_VERSION=1.5.0
 # don't really need it being present, so fake
 #pecl install -f mongodb-$MONGODB_VERSION
-composer config platform.ext-mongodb $MONGODB_VERSION
+#composer config platform.ext-mongodb $MONGODB_VERSION
 
 # disable xdebug
 phpenv config-rm xdebug.ini || :

--- a/composer.json
+++ b/composer.json
@@ -116,6 +116,7 @@
 		"zendframework/zend-crypt": "2.4.9"
 	},
 	"require-dev": {
+		"alcaeus/mongo-php-adapter": "^1.1",
 		"bgrins/filereader.js": "*",
 		"components/jquery": "~1.8.3",
 		"components/jquery-blockui": "*@dev",
@@ -131,6 +132,7 @@
 		"jasig/phpcas": "~1.3.3",
 		"jquery-form/form": "^4.2",
 		"maximebf/debugbar": "1.*",
+		"perftools/php-profiler": "^0.1.1",
 		"rmm5t/jquery-timeago": "*",
 		"robloach/component-installer": "*",
 		"sentry/sentry": "^1.7",

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,8 @@
 		"component-baseurl": "/components",
 		"component-dir": "htdocs/components",
 		"platform": {
-			"php": "7.1.3"
+			"php": "7.1.3",
+			"ext-mongodb": "1.5.0"
 		},
 		"sort-packages": true
 	},

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "05a64dbe1c02dfa04272ac9c159d6ee5",
+    "content-hash": "26d55efd6e81925a91ec99832840114f",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -5444,6 +5444,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.3"
+        "php": "7.1.3",
+        "ext-mongodb": "1.5.0"
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fb22111f374a3deeb71eaf282c8c4509",
+    "content-hash": "05a64dbe1c02dfa04272ac9c159d6ee5",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -4095,6 +4095,72 @@
     ],
     "packages-dev": [
         {
+            "name": "alcaeus/mongo-php-adapter",
+            "version": "1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/alcaeus/mongo-php-adapter.git",
+                "reference": "b4c2f0d30dbddd624d3bc2a27175e6eb602241d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/alcaeus/mongo-php-adapter/zipball/b4c2f0d30dbddd624d3bc2a27175e6eb602241d4",
+                "reference": "b4c2f0d30dbddd624d3bc2a27175e6eb602241d4",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-hash": "*",
+                "ext-mongodb": "^1.2.0",
+                "mongodb/mongodb": "^1.0.1",
+                "php": "^5.6 || ^7.0"
+            },
+            "provide": {
+                "ext-mongo": "1.6.14"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^5.7.27 || ^6.0 || ^7.0",
+                "squizlabs/php_codesniffer": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Mongo": "lib/Mongo"
+                },
+                "psr-4": {
+                    "Alcaeus\\MongoDbAdapter\\": "lib/Alcaeus/MongoDbAdapter"
+                },
+                "files": [
+                    "lib/Mongo/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "alcaeus",
+                    "email": "alcaeus@alcaeus.org"
+                },
+                {
+                    "name": "Olivier Lechevalier",
+                    "email": "olivier.lechevalier@gmail.com"
+                }
+            ],
+            "description": "Adapter to provide ext-mongo interface on top of mongo-php-libary",
+            "keywords": [
+                "database",
+                "mongodb"
+            ],
+            "time": "2019-04-06T08:08:09+00:00"
+        },
+        {
             "name": "bgrins/filereader.js",
             "version": "dev-composer",
             "source": {
@@ -4836,6 +4902,161 @@
                 "debugbar"
             ],
             "time": "2017-12-15T11:13:46+00:00"
+        },
+        {
+            "name": "mongodb/mongodb",
+            "version": "1.4.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/mongodb/mongo-php-library.git",
+                "reference": "bd148eab0493e38354e45e2cd7db59b90fdcad79"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/bd148eab0493e38354e45e2cd7db59b90fdcad79",
+                "reference": "bd148eab0493e38354e45e2cd7db59b90fdcad79",
+                "shasum": ""
+            },
+            "require": {
+                "ext-hash": "*",
+                "ext-json": "*",
+                "ext-mongodb": "^1.5.0",
+                "php": ">=5.5"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^4.8.36 || ^6.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "MongoDB\\": "src/"
+                },
+                "files": [
+                    "src/functions.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "Apache-2.0"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Mikola",
+                    "email": "jmikola@gmail.com"
+                },
+                {
+                    "name": "Derick Rethans",
+                    "email": "github@derickrethans.nl"
+                },
+                {
+                    "name": "Katherine Walker",
+                    "email": "katherine.walker@mongodb.com"
+                }
+            ],
+            "description": "MongoDB driver library",
+            "homepage": "https://jira.mongodb.org/browse/PHPLIB",
+            "keywords": [
+                "database",
+                "driver",
+                "mongodb",
+                "persistence"
+            ],
+            "time": "2018-07-18T14:33:41+00:00"
+        },
+        {
+            "name": "perftools/php-profiler",
+            "version": "v0.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/perftools/php-profiler.git",
+                "reference": "137890309934332da672069483c1a3a86c15616d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/perftools/php-profiler/zipball/137890309934332da672069483c1a3a86c15616d",
+                "reference": "137890309934332da672069483c1a3a86c15616d",
+                "shasum": ""
+            },
+            "require": {
+                "perftools/xhgui-collector": "^1.1.0",
+                "php": "^5.3.0 || ^7.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Adapter to provide ext-mongo interface on top of mongo-php-libary",
+                "ext-mongo": "mongo extension (PHP>=5.3,<7.0)",
+                "ext-mongodb": "mongodb extension (PHP>=5.4,<7.3)"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Xhgui\\Profiler\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lauri Piisang",
+                    "email": "lauri.piisang@eesti.ee"
+                },
+                {
+                    "name": "Elan Ruusamäe",
+                    "email": "glen@pld-linux.org"
+                }
+            ],
+            "description": "PHP Profiling based on XHGUI",
+            "time": "2019-04-02T15:42:10+00:00"
+        },
+        {
+            "name": "perftools/xhgui-collector",
+            "version": "1.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/perftools/xhgui-collector.git",
+                "reference": "0d0e01049121b3d64f02c135d738bee70d7a52ec"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/perftools/xhgui-collector/zipball/0d0e01049121b3d64f02c135d738bee70d7a52ec",
+                "reference": "0d0e01049121b3d64f02c135d738bee70d7a52ec",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "suggest": {
+                "alcaeus/mongo-php-adapter": "Mongo PHP Adapter is required for PHP >7 (when using ext-mongodb)",
+                "ext-curl": "You need to install the curl extension to upload saved files",
+                "ext-mongo": "Mongo is needed to store profiler results for PHP < 7.",
+                "ext-mongodb": "Mongo is needed to store profiler results for PHP > 7.",
+                "ext-uprofiler": "You need to install either xhprof or uprofiler to use XHGui.",
+                "ext-xhprof": "You need to install either xhprof or uprofiler to use XHGui."
+            },
+            "type": "library",
+            "autoload": {
+                "psr-0": {
+                    "Xhgui_": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lauri Piisang",
+                    "email": "lauri.piisang@eesti.ee"
+                }
+            ],
+            "description": "Library for collecting and storing XHProf results for later use by XHGUI.",
+            "time": "2019-03-27T11:24:40+00:00"
         },
         {
             "name": "rmm5t/jquery-timeago",

--- a/composer.lock
+++ b/composer.lock
@@ -4905,33 +4905,28 @@
         },
         {
             "name": "mongodb/mongodb",
-            "version": "1.4.2",
+            "version": "1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/mongodb/mongo-php-library.git",
-                "reference": "bd148eab0493e38354e45e2cd7db59b90fdcad79"
+                "reference": "5cffeb33b893b6bb04195b99ddc3955a29252339"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/bd148eab0493e38354e45e2cd7db59b90fdcad79",
-                "reference": "bd148eab0493e38354e45e2cd7db59b90fdcad79",
+                "url": "https://api.github.com/repos/mongodb/mongo-php-library/zipball/5cffeb33b893b6bb04195b99ddc3955a29252339",
+                "reference": "5cffeb33b893b6bb04195b99ddc3955a29252339",
                 "shasum": ""
             },
             "require": {
                 "ext-hash": "*",
                 "ext-json": "*",
-                "ext-mongodb": "^1.5.0",
+                "ext-mongodb": "^1.3.0",
                 "php": ">=5.5"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.36 || ^6.4"
+                "phpunit/phpunit": "^4.8"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.4.x-dev"
-                }
-            },
             "autoload": {
                 "psr-4": {
                     "MongoDB\\": "src/"
@@ -4950,12 +4945,12 @@
                     "email": "jmikola@gmail.com"
                 },
                 {
-                    "name": "Derick Rethans",
-                    "email": "github@derickrethans.nl"
+                    "name": "Hannes Magnusson",
+                    "email": "bjori@mongodb.com"
                 },
                 {
-                    "name": "Katherine Walker",
-                    "email": "katherine.walker@mongodb.com"
+                    "name": "Derick Rethans",
+                    "email": "github@derickrethans.nl"
                 }
             ],
             "description": "MongoDB driver library",
@@ -4966,7 +4961,7 @@
                 "mongodb",
                 "persistence"
             ],
-            "time": "2018-07-18T14:33:41+00:00"
+            "time": "2017-10-27T19:42:57+00:00"
         },
         {
             "name": "perftools/php-profiler",

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -207,6 +207,11 @@ class Setup
 
             'extensions' => [],
 
+            'xhgui_profiler' => [
+                // https://github.com/eventum/eventum/pull/519
+                'status' => 'enabled',
+            ],
+
             'handle_clock_in' => 'enabled',
 
             // default expiry: 5 minutes

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Console\Command;
 
-use Eventum\Extension\Provider;
+use Eventum\Extension\Provider\ExtensionProvider;
 use InvalidArgumentException;
 use ReflectionClass;
 use ReflectionException;
@@ -39,7 +39,7 @@ class ExtensionEnableCommand
      * Setup Extension being loaded by default
      *
      * @param string $extensionFile path to filename that loads extension
-     * @param string $extensionName class name of extension, must implement ExtensionInterface
+     * @param string $extensionName class name of extension, must implement ExtensionProvider
      * @throws ReflectionException
      */
     public function setupExtension($extensionFile, $extensionName): void
@@ -83,7 +83,7 @@ class ExtensionEnableCommand
      * @throws InvalidArgumentException
      * @return ReflectionClass
      */
-    private function getExtensionClass($extensionName)
+    private function getExtensionClass($extensionName): ReflectionClass
     {
         if (!$extensionName) {
             throw new InvalidArgumentException('Extension class name not specified');
@@ -91,9 +91,9 @@ class ExtensionEnableCommand
 
         $reflectionClass = new ReflectionClass($extensionName);
 
-        $implements = $reflectionClass->implementsInterface(Provider::class);
+        $implements = $reflectionClass->implementsInterface(ExtensionProvider::class);
         if (!$implements) {
-            throw new InvalidArgumentException("Class $extensionName does not implement ExtensionInterface");
+            throw new InvalidArgumentException("Class $extensionName does not implement ExtensionProvider");
         }
 
         return $reflectionClass;

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -179,7 +179,13 @@ class ExtensionManager
         $loader = $this->getAutoloader();
 
         foreach ($this->getExtensionFiles() as $classname => $filename) {
-            $extension = $this->loadExtension($classname, $filename);
+            try {
+                $extension = $this->loadExtension($classname, $filename);
+            } catch (Throwable $e) {
+                Logger::app()->error("Unable to load $classname: {$e->getMessage()}", ['exception' => $e]);
+                continue;
+            }
+
             if ($extension instanceof AutoloadProvider) {
                 $extension->registerAutoloader($loader);
             }

--- a/src/Extension/XhguiProfilerExtension.php
+++ b/src/Extension/XhguiProfilerExtension.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use Eventum\Event\SystemEvents;
+use Eventum\Extension\Provider\SubscriberProvider;
+use RuntimeException;
+use Setup;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Xhgui\Profiler\Profiler;
+
+class XhguiProfilerExtension implements SubscriberProvider, EventSubscriberInterface
+{
+    public function getSubscribers(): array
+    {
+        return [
+            self::class,
+        ];
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            SystemEvents::BOOT => 'boot',
+        ];
+    }
+
+    public function boot(): void
+    {
+        $config = $this->getConfig();
+
+        if ($config['status'] !== 'enabled') {
+            return;
+        }
+
+        try {
+            $profiler = new Profiler($config);
+        } catch (RuntimeException $e) {
+            return;
+        }
+
+        $profiler->enable();
+        $profiler->registerShutdownHandler();
+    }
+
+    private function getConfig(): array
+    {
+        $defaultConfig = [
+            'profiler.enable' => function () {
+                return true;
+            },
+        ];
+        $config = Setup::get()['xhgui_profiler']->toArray();
+
+        return array_merge($defaultConfig, $config);
+    }
+}


### PR DESCRIPTION
To enable this extension, you need to register it first:

```
$ ./bin/extension.php src/Extension/XhguiProfilerExtension.php 'Eventum\Extension\XhguiProfilerExtension'
Enabling extension: \Eventum\Extension\XhguiProfilerExtension
```

NOTE: This adds `ext-mongodb` requirement for development.
If don't want mongodb, can just tell composer to ignore it:
```
composer config platform.ext-mongodb 1.4.3
```

cc @balsdorf @lauripiisang