### PR TITLE
Use array json decode for cst_custom_field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Upgrading to 3.6.x versions requires that you upgrade to latest 3.5.x version first.
 
 - Avoid fatal error if declared workflow class can not be loaded (@glensc, #529)
+- Use array json decode for `cst_custom_field` (@glensc, #530)
 
 [3.6.7]: https://github.com/eventum/eventum/compare/v3.6.6...master
 

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -585,7 +585,7 @@ class Filter
         }
 
         if (is_string($res['cst_custom_field'])) {
-            $res['cst_custom_field'] = json_decode($res['cst_custom_field']);
+            $res['cst_custom_field'] = json_decode($res['cst_custom_field'], true);
         }
 
         return $res;

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -99,7 +99,7 @@ class Search
         }
         $custom_field = self::getParam('custom_field', $request_only);
         if (is_string($custom_field)) {
-            $custom_field = json_decode(urldecode($custom_field));
+            $custom_field = json_decode(urldecode($custom_field), true);
         }
         $cookie = [
             'rows' => Misc::escapeString($rows ? $rows : APP_DEFAULT_PAGER_SIZE),


### PR DESCRIPTION
https://github.com/eventum/eventum/pull/393 changed `cst_custom_field ` serialization from `serialize` to `json_encode`, but this caused wrong data type, when it was previously array, it's now `stdClass`, and templates can't handle that:


on `adv_search.php?custom_id=1`:

```
[2019-04-22 23:07:37] app.ERROR: Uncaught Exception Error: "Cannot use object of type stdClass as array" at /Users/glen/scm/eventum/eventum/var/cache/5f42ad00d36c4e9912c1dbb8862f873575e473ae_0.file.adv_search.tpl.html.php line 95 {"exception":"[object] (Error(code: 0): Cannot use object of type stdClass as array at /Users/glen/scm/eventum/eventum/var/cache/5f42ad00d36c4e9912c1dbb8862f873575e473ae_0.file.adv_search.tpl.html.php:95)
```

this PR changes seralization to use arrays.

unclear how migration was handled in to different type in #393 so nothing changed here as well.

cc @balsdorf 