### PR TITLE
GitLab: skip issue matching on empty text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.7.x versions requires that you upgrade to latest 3.5.x version first.
 
+- GitLab: skip issue matching on empty text (@glensc, #562)
+
 [3.7.1]: https://github.com/eventum/eventum/compare/v3.7.0...master
 
 ## [3.7.0] - 2019-05-16

--- a/src/Scm/Adapter/Gitlab.php
+++ b/src/Scm/Adapter/Gitlab.php
@@ -95,6 +95,10 @@ class Gitlab extends AbstractAdapter
     {
         $matcher = GroupMatcher::create();
         $description = $payload->getDescription();
+        if (!$description) {
+            return;
+        }
+
         $matches = iterator_to_array($matcher->match($description));
         if (!$matches) {
             return;


### PR DESCRIPTION
in case of issue deletion the description in payload is NULL

`{"code":-1,"message":"Argument 1 passed to Eventum\\IssueMatcher::match() must be of the type string, null given, called in /src/Scm/Adapter/Gitlab.php on line 98"}`

```json
{
  "object_kind": "issue",
  "event_type": "issue",
...
  "object_attributes": {
    "author_id": 68,
    "closed_at": null,
    "confidential": false,
    "created_at": "2019-05-09 15:23:45 +0300",
    "description": null,
```