### PR TITLE
Fix loading emails with semicolon in name field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.7.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Add export issues to CSV command (@glensc, #460)
 - Fix forgot password page (@glensc, #605, #606)
+- Fix loading emails with semicolon in name field (@glensc, #607)
 
 [3.7.2]: https://github.com/eventum/eventum/compare/v3.7.1...master
 

--- a/composer.lock
+++ b/composer.lock
@@ -5427,12 +5427,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/eventum/zend-mail.git",
-                "reference": "e92282e8ab30a161bf9b69e010e1002a893a6428"
+                "reference": "f8aa846157951793c226e0fe5ae32a0a82f5f1db"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/eventum/zend-mail/zipball/e92282e8ab30a161bf9b69e010e1002a893a6428",
-                "reference": "e92282e8ab30a161bf9b69e010e1002a893a6428",
+                "url": "https://api.github.com/repos/eventum/zend-mail/zipball/f8aa846157951793c226e0fe5ae32a0a82f5f1db",
+                "reference": "f8aa846157951793c226e0fe5ae32a0a82f5f1db",
                 "shasum": ""
             },
             "require": {
@@ -5512,7 +5512,7 @@
                 "chat": "https://zendframework-slack.herokuapp.com",
                 "forum": "https://discourse.zendframework.com/c/questions/components"
             },
-            "time": "2019-05-02T21:03:22+00:00"
+            "time": "2019-07-06T10:34:36+00:00"
         },
         {
             "name": "zendframework/zend-mime",

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -17,24 +17,25 @@ use Eventum\Mail\Helper\MailLoader;
 use Exception;
 use RuntimeException;
 use Zend\Mail;
+use Zend\Mail\Header\HeaderInterface;
 
 class InvalidMessageException extends RuntimeException
 {
     public static function create(Exception $e, array $params): self
     {
-        // convert only array or string type of headers (exclude Headers object)
-        if (isset($params['headers']) && !is_object($params['headers'])) {
+        if (isset($params['headers'])) {
             if (is_string($params['headers'])) {
                 MailLoader::convertHeaders($params['headers']);
             }
 
             // test loading each header to identify which one fails with better error message
             $headers = new Mail\Headers();
-            foreach ($params['headers'] as $i => $header) {
+            foreach ($params['headers'] as $header) {
+                $headerLine = $header instanceof HeaderInterface ? $header->toString() : (string)$header;
                 try {
-                    $headers->addHeaderLine($header);
+                    $headers->addHeaderLine($headerLine);
                 } catch (Mail\Exception\InvalidArgumentException $e) {
-                    $message = $e->getMessage() . '; Header: ' . $header;
+                    $message = $e->getMessage() . '; Header: ' . $headerLine;
 
                     return new self($message, $e->getCode());
                 }

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -20,10 +20,11 @@ use Zend\Mail;
 
 class InvalidMessageException extends RuntimeException
 {
-    public static function create(Exception $e, array $params)
+    public static function create(Exception $e, array $params): self
     {
-        if (isset($params['headers'])) {
-            if (!is_array($params['headers'])) {
+        // convert only array or string type of headers (exclude Headers object)
+        if (isset($params['headers']) && !is_object($params['headers'])) {
+            if (is_string($params['headers'])) {
                 MailLoader::convertHeaders($params['headers']);
             }
 

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -55,7 +55,7 @@ use Zend\Mail\Storage\Message;
  */
 class MailMessage extends Message
 {
-    const ENCODING = APP_CHARSET;
+    private const ENCODING = APP_CHARSET;
 
     /** @var MailAttachment */
     private $attachment;
@@ -85,7 +85,7 @@ class MailMessage extends Message
      *
      * @return MailMessage
      */
-    public static function createNew()
+    public static function createNew(): self
     {
         $message = new self(['root' => true]);
 
@@ -101,7 +101,7 @@ class MailMessage extends Message
      * @param string $raw The full email message
      * @return MailMessage
      */
-    public static function createFromString($raw)
+    public static function createFromString(string $raw): self
     {
         MailLoader::splitMessage($raw, $headers, $content);
 
@@ -115,7 +115,7 @@ class MailMessage extends Message
      * @param string $content
      * @return MailMessage
      */
-    public static function createFromHeaderBody($headers, $content)
+    public static function createFromHeaderBody($headers, $content): self
     {
         if (is_string($headers)) {
             // create from string which is more relax for broken mails
@@ -135,7 +135,7 @@ class MailMessage extends Message
      * @param string $filename Path to the file to read in
      * @return MailMessage
      */
-    public static function createFromFile($filename)
+    public static function createFromFile($filename): self
     {
         return new self(['root' => true, 'file' => $filename]);
     }
@@ -146,7 +146,7 @@ class MailMessage extends Message
      * @param Mail\Message $message
      * @return MailMessage
      */
-    public static function createFromMessage(Mail\Message $message)
+    public static function createFromMessage(Mail\Message $message): self
     {
         return self::createFromString($message->toString());
     }

--- a/tests/Mail/LoadEmailTest.php
+++ b/tests/Mail/LoadEmailTest.php
@@ -59,4 +59,16 @@ class LoadEmailTest extends TestCase
         $mail = MailMessage::createFromString($raw);
         $this->assertTrue($mail->getHeaders()->has('X-Broken-Header-Mbox'));
     }
+
+    /**
+     * From: "Famous bearings |;" <skf@example.com>
+     */
+    public function testLoadInvalidName(): void
+    {
+        $raw = $this->readDataFile('110616.txt');
+        $mail = MailMessage::createFromString($raw);
+        $headers = $mail->getHeaders();
+        $this->assertEquals('"Famous bearings |;" <skf@example.com>', $headers->get('From')->getFieldValue());
+        $this->assertEquals('Famous bearings | <skf@example.com>', $headers->get('Reply-To')->getFieldValue());
+    }
 }

--- a/tests/data/110616.txt
+++ b/tests/data/110616.txt
@@ -1,0 +1,32 @@
+Return-Path: <support-bounces@lists.example.org>
+Delivered-To: eventum-imap@example.org
+Received: from win2003 ([127.0.0.1]) by localhost via TCP with ESMTPA;
+	Tue, 02 Jul 2019 03:31:13 +0800
+MIME-Version: 1.0
+From: "Famous bearings |;" <skf@example.com>
+To: support@lists.example.org
+Date: 2 Jul 2019 03:31:13 +0800
+Subject: =?utf-8?B?cyBiZWFyaW5ncyAgICBFbmI=?=
+Content-Type: multipart/alternative;
+	boundary=--boundary_118276_94ad25ae-43fa-4eb6-968c-fc87bcdcbd75
+Message-Id: <20190701193130.27DB1103194A@minni.example.org>
+Reply-To: "Famous bearings |" <skf@example.com>
+Sender: support-bounces@lists.example.org
+Errors-To: support-bounces@lists.example.org
+
+
+----boundary_118276_94ad25ae-43fa-4eb6-968c-fc87bcdcbd75
+Content-Type: text/plain; charset=utf-8
+Content-Transfer-Encoding: base64
+
+UmljayBhbmQgbW9ydHkgcnVsZXMK
+
+----boundary_118276_94ad25ae-43fa-4eb6-968c-fc87bcdcbd75
+Content-Type: text/html; charset=utf-8
+Content-Transfer-Encoding: base64
+
+UmljayBhbmQgbW9ydHkgcnVsZXMK
+
+----boundary_118276_94ad25ae-43fa-4eb6-968c-fc87bcdcbd75--
+
+


### PR DESCRIPTION
Internal error of zend-mail causes mail download to abort: https://github.com/zendframework/zend-mail/pull/230

And eventum internally creates another type error by unable to convert the type.

```
app.ERROR: E_RECOVERABLE_ERROR: Object of class Zend\Mail\Headers could not be converted to string {"code":4096,"message":"Object of class Zend\\Mail\\Headers could not be converted to string","file":"/Users/glen/scm/eventum/eventum/src/Mail/Helper/MailLoader.php","line":73} {"file":null,"line":null,"class":null,"function":"preg_replace","memory_usage":"6 MB","memory_peak_usage":"6 MB","version":"dev-master-g5992f433c","usr_id":""}
PHP Catchable fatal error:  Object of class Zend\Mail\Headers could not be converted to string in /Users/glen/scm/eventum/eventum/src/Mail/Helper/MailLoader.php on line 73
PHP Stack trace:
...
PHP  11. Eventum\Mail\MailMessage::createFromString() /Users/glen/scm/eventum/eventum/tests/Mail/LoadEmailTest.php:69
PHP  12. Eventum\Mail\MailMessage->__construct() /Users/glen/scm/eventum/eventum/src/Mail/MailMessage.php:108
PHP  13. Eventum\Mail\Exception\InvalidMessageException::create() /Users/glen/scm/eventum/eventum/src/Mail/MailMessage.php:73
PHP  14. Eventum\Mail\Helper\MailLoader::convertHeaders() /Users/glen/scm/eventum/eventum/src/Mail/Exception/InvalidMessageException.php:27
PHP  15. preg_replace() /Users/glen/scm/eventum/eventum/src/Mail/Helper/MailLoader.php:73

Catchable fatal error: Object of class Zend\Mail\Headers could not be converted to string in /Users/glen/scm/eventum/eventum/src/Mail/Helper/MailLoader.php on line 73
```