### PR TITLE
Add missing database indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Add index: `support_email`.`sup_message_id` (@glensc, #632)
+
 [3.8.0]: https://github.com/eventum/eventum/compare/v3.7.4...master
 
 ## [3.7.4] - 2019-08-04

--- a/db/migrations/20190803221836_eventum_add_indexes.php
+++ b/db/migrations/20190803221836_eventum_add_indexes.php
@@ -1,0 +1,24 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumAddIndexes extends AbstractMigration
+{
+    public function change(): void
+    {
+        $this->table('support_email')
+            ->addIndex(['sup_message_id'], ['unique' => false])
+            ->update();
+    }
+}


### PR DESCRIPTION
Enabled slow log without indexes. This is indexes added from my database instance.

- add index: `support_email.sup_message_id`