### PR TITLE
Replace Misc::getFileList with Symfony Finder

### DIFF
--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -362,27 +362,6 @@ class Misc
     }
 
     /**
-     * Method used to get the list of files contained in a specific
-     * directory with their absolute paths.
-     *
-     * @param   string $directory The path to list the files from
-     * @return  array The list of files
-     */
-    public static function getFileList($directory)
-    {
-        $files = [];
-        $dir = @opendir($directory);
-        while ($item = @readdir($dir)) {
-            if (($item == '.') || ($item == '..') || ($item == 'CVS') || ($item == 'SCCS')) {
-                continue;
-            }
-            $files[] = "$directory/$item";
-        }
-
-        return $files;
-    }
-
-    /**
      * Method used to format the given number of minutes in a string showing
      * the number of hours and minutes (02:30)
      *

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -14,8 +14,10 @@
 namespace Eventum\Extension;
 
 use InvalidArgumentException;
-use Misc;
 use ReflectionClass;
+use Symfony\Component\Finder\Exception\DirectoryNotFoundException;
+use Symfony\Component\Finder\Finder;
+use Symfony\Component\Finder\SplFileInfo;
 
 class ExtensionLoader
 {
@@ -80,14 +82,17 @@ class ExtensionLoader
      */
     public function getClassList(): array
     {
-        $list = $files = [];
-        foreach ($this->paths as $path) {
-            $files = array_merge($files, Misc::getFileList($path));
+        $list = [];
+        try {
+            $finder = Finder::create()->files()->in($this->paths);
+        } catch (DirectoryNotFoundException $e) {
+            return [];
         }
 
-        foreach ($files as $filename) {
-            $basename = basename($filename);
-            $classname = $this->getClassName($basename);
+        /** @var SplFileInfo $fi */
+        foreach ($finder as $fi) {
+            $filename = $fi->getPathname();
+            $classname = $this->getClassName($fi->getBaseName());
 
             if (!$classname || !$this->isExtension($filename, $classname)) {
                 continue;

--- a/src/Extension/ExtensionLoader.php
+++ b/src/Extension/ExtensionLoader.php
@@ -83,10 +83,12 @@ class ExtensionLoader
     public function getClassList(): array
     {
         $list = [];
-        try {
-            $finder = Finder::create()->files()->in($this->paths);
-        } catch (DirectoryNotFoundException $e) {
-            return [];
+        $finder = Finder::create()->files();
+        foreach ($this->paths as $dir) {
+            try {
+                $finder->in($dir);
+            } catch (DirectoryNotFoundException $e) {
+            }
         }
 
         /** @var SplFileInfo $fi */


### PR DESCRIPTION
The existing code is faulty, not checking errors properly:

```
app.ERROR: Uncaught Exception TypeError: "readdir() expects parameter 1 to be resource, bool given" at /home/travis/build/eventum/eventum/lib/eventum/class.misc.php line 375 {"exception":"[object] (TypeError(code: 0): readdir() expects parameter 1 to be resource, bool given at /home/travis/build/eventum/eventum/lib/eventum/class.misc.php:375)
[stacktrace]
#0 /home/travis/build/eventum/eventum/lib/eventum/class.misc.php(375): readdir(false)
#1 /home/travis/build/eventum/eventum/src/Extension/ExtensionLoader.php(85): Misc::getFileList('/home/travis/bu...')
#2 /home/travis/build/eventum/eventum/src/Extension/BuiltinLegacyLoaderExtension.php(88): Eventum\\Extension\\ExtensionLoader->getClassList()
```