### PR TITLE
Fix PHP 7.2 count() warnings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - Move Symfony project provided configs to res, #658
 - Load optional `config/routes.yml` if present, #659
 - Expose project/issue id to window globals, #656
+- Fix PHP 7.2 `count()` warnings, #651
 
 [3.8.1]: https://github.com/eventum/eventum/compare/v3.8.0...master
 

--- a/lib/eventum/class.group.php
+++ b/lib/eventum/class.group.php
@@ -212,7 +212,7 @@ class Group
             return -1;
         }
 
-        if (count($res) > 0) {
+        if ($res) {
             $res['users'] = self::getUsers($grp_id);
             $res['projects'] = self::getProjects($grp_id);
             $res['project_ids'] = array_keys($res['projects']);

--- a/src/Controller/UpdateController.php
+++ b/src/Controller/UpdateController.php
@@ -174,7 +174,7 @@ class UpdateController extends BaseController
          * @see Issue::updateAssociatedIssuesRelations()
          */
         global $errors;
-        if ($has_duplicates || count($errors) > 0 || count($notify_list) > 0) {
+        if ($has_duplicates || $errors || $notify_list) {
             $update_tpl = new Template_Helper();
             $update_tpl->setTemplate('include/update_msg.tpl.html');
             $update_tpl->assign('update_result', $res);


### PR DESCRIPTION
```
E_WARNING: count(): Parameter must be an array or an object that implements Countable
```

- https://www.php.net/manual/en/migration72.incompatible.php#migration72.incompatible.warn-on-non-countable-types