### PR TITLE
Expose project/issue id to window globals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,12 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
-- Add support for Extensions to add Symfony routes (@glensc, #655)
-- Drop AbstractExtension, use Providers (@glensc, #654)
-- Extensions: Add Proxy to Composer Autoloader (@glensc, #657)
-- Move Symfony project provided configs to res (@glensc, #658)
-- Load optional `config/routes.yml` if present (@glensc, #659)
+- Add support for Extensions to add Symfony routes, #655
+- Drop AbstractExtension, use Providers, #654
+- Extensions: Add Proxy to Composer Autoloader, #657
+- Move Symfony project provided configs to res, #658
+- Load optional `config/routes.yml` if present, #659
+- Expose project/issue id to window globals, #656
 
 [3.8.1]: https://github.com/eventum/eventum/compare/v3.8.0...master
 

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -17,6 +17,13 @@
   <title>{if $title != '' or isset($extra_title)}{$extra_title|default:$title} - {/if}{$core.app_setup.tool_caption|default:$core.app_title}</title>
   <script type="text/javascript">
   <!--
+  var project = {
+{if isset($core.project_id)}
+    id: {$core.project_id},
+    name: {$core.project_name|json_encode},
+{/if}
+    _: 0
+  };
   var user_prefs = {
 {if isset($core.user)}
     relative_date: {$core.current_user_prefs.relative_date},

--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -17,6 +17,12 @@
   <title>{if $title != '' or isset($extra_title)}{$extra_title|default:$title} - {/if}{$core.app_setup.tool_caption|default:$core.app_title}</title>
   <script type="text/javascript">
   <!--
+  var issue = {
+{if isset($issue.iss_id)}
+    id: {$issue.iss_id},
+{/if}
+    _: 0
+  };
   var project = {
 {if isset($core.project_id)}
     id: {$core.project_id},


### PR DESCRIPTION
this allows adding project specific user javascript (`config/userscript.js`) to the page:

```javascript

$(document).ready(function($) {
	if (window.project && window.project.id === 1) {
		// do some stuff
	}
});
```

refs:
- https://github.com/eventum/eventum/issues/652