### PR TITLE
Extensions: Add Proxy to Composer Autoloader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Add support for Extensions to add Symfony routes (@glensc, #655)
 - Drop AbstractExtension, use Providers (@glensc, #654)
+- Extensions: Add Proxy to Composer Autoloader (@glensc, #657)
 
 [3.8.1]: https://github.com/eventum/eventum/compare/v3.8.0...master
 

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -13,7 +13,7 @@
 
 namespace Example\Extension;
 
-use Composer\Autoload\ClassLoader;
+use Eventum\Extension\ClassLoader;
 use Eventum\Extension\Provider;
 use Example\Event\Subscriber;
 
@@ -55,14 +55,26 @@ class ExampleExtension implements
             'Example\\Extension\\' => [$baseDir . '/docs/examples/extension'],
         ];
 
+        $files = [
+            '37a3dc5111fe8f707ab4c132ef1dbc62' => $baseDir . '/docs/examples/workflow/class.example.php',
+        ];
+
+        // add classmap
         $loader->addClassMap($classmap);
 
+        // add namespaces (psr-0)
         foreach ($psr0 as $namespace => $path) {
             $loader->add($namespace, $path);
         }
 
+        // add namespaces (psr-4)
         foreach ($psr4 as $namespace => $path) {
-            $loader->setPsr4($namespace, $path);
+            $loader->addPsr4($namespace, $path);
+        }
+
+        // add files
+        foreach ($files as $fileIdentifier => $file) {
+            $loader->autoloadFile($fileIdentifier, $file);
         }
     }
 

--- a/src/Extension/ClassLoader.php
+++ b/src/Extension/ClassLoader.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use Composer\Autoload\ClassLoader as ComposerClassLoader;
+use function composerRequireEventumCore;
+
+/**
+ * A proxy class to have stable interface and method to include files.
+ *
+ * @method addClassMap(array $classmap)
+ * @method add(string $prefix, array | string $paths, bool $prepend = false)
+ * @method addPsr4(string $prefix, array | string $paths, bool $prepend = false)
+ */
+class ClassLoader
+{
+    /** @var ComposerClassLoader */
+    private $loader;
+
+    public function __construct(ComposerClassLoader $loader)
+    {
+        $this->loader = $loader;
+    }
+
+    public function autoloadFile(string $fileIdentifier, string $file): void
+    {
+        /**
+         * The name became fixed due "config.autoloader-suffix" in composer.json
+         */
+        composerRequireEventumCore($fileIdentifier, $file);
+    }
+
+    public function __call(string $name, array $arguments = [])
+    {
+        return $this->loader->$name(...$arguments);
+    }
+}

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Extension;
 
-use Composer\Autoload\ClassLoader;
 use Eventum\Extension\Provider\AutoloadProvider;
 use Eventum\Extension\Provider\CrmProvider;
 use Eventum\Extension\Provider\CustomFieldProvider;
@@ -252,14 +251,18 @@ class ExtensionManager implements RouteProvider
     }
 
     /**
-     * Return composer autoloader
+     * Return Composer autoloader decorated with Eventum ClassLoader
      *
      * @return ClassLoader
      */
     protected function getAutoloader(): ClassLoader
     {
         $baseDir = dirname(__DIR__, 2);
-        foreach ([$baseDir . '/vendor/autoload.php', $baseDir . '/../../../vendor/autoload.php'] as $autoload) {
+        $searchPaths = [
+            $baseDir . '/vendor/autoload.php',
+            $baseDir . '/../../../vendor/autoload.php',
+        ];
+        foreach ($searchPaths as $autoload) {
             if (file_exists($autoload)) {
                 break;
             }
@@ -269,6 +272,9 @@ class ExtensionManager implements RouteProvider
             throw new RuntimeException('Could not locate autoloader');
         }
 
-        return require $autoload;
+        /** @noinspection PhpIncludeInspection */
+        $loader = require $autoload;
+
+        return new ClassLoader($loader);
     }
 }

--- a/src/Extension/Provider/AutoloadProvider.php
+++ b/src/Extension/Provider/AutoloadProvider.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Extension\Provider;
 
-use Composer\Autoload\ClassLoader;
+use Eventum\Extension\ClassLoader;
 
 interface AutoloadProvider extends ExtensionProvider
 {
@@ -22,6 +22,7 @@ interface AutoloadProvider extends ExtensionProvider
      *
      * @param ClassLoader $loader
      * @since 3.6.6
+     * @since 3.8.1 $loader is decorator over composer ClassLoader
      */
     public function registerAutoloader($loader): void;
 }


### PR DESCRIPTION
This adds stable interface to Extensions and method to load "autoload.files"

```php

use Eventum\Extension\ClassLoader;
use Eventum\Extension\Provider;

class ExampleExtension implements
    Provider\AutoloadProvider
{
    /**
     * Method invoked so the extension can setup class loader.
     *
     * @param ClassLoader $loader
     */
    public function registerAutoloader($loader): void
    {
        [$classmap, $psr0, $psr4, $files] = $this->getComposerAutoload();

        // add classmap
        $loader->addClassMap($classmap);

        // add namespaces (psr-0)
        foreach ($psr0 as $namespace => $path) {
            $loader->add($namespace, $path);
        }

        // add namespaces (psr-4)
        foreach ($psr4 as $namespace => $path) {
            $loader->addPsr4($namespace, $path);
        }

        // add files
        foreach ($files as $fileIdentifier => $file) {
            $loader->autoloadFile($fileIdentifier, $file);
        }
    }
```