### PR TITLE
Invalidate opcache when changing crypto state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Invalidate opcache when changing crypto state, #674
+
 [3.8.3]: https://github.com/eventum/eventum/compare/v3.8.2...master
 
 ## [3.8.2] - 2019-09-04

--- a/src/Config/ConfigPersistence.php
+++ b/src/Config/ConfigPersistence.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Config;
 
+use Eventum\Opcache;
 use InvalidArgumentException;
 use Symfony\Component\Filesystem\Filesystem;
 use Symfony\Component\VarExporter\VarExporter;
@@ -57,6 +58,7 @@ class ConfigPersistence
     {
         $fs = new Filesystem();
         $fs->dumpFile($path, $this->serialize($config));
+        Opcache::invalidate($path);
     }
 
     /**

--- a/src/Controller/Manage/EncryptionController.php
+++ b/src/Controller/Manage/EncryptionController.php
@@ -66,7 +66,6 @@ class EncryptionController extends ManageBaseController
             $cm->disable();
             $km = new CryptoKeyManager();
             $km->generateKey();
-            $cm->cacheClear();
             $this->messages->addInfoMessage(ev_gettext('Thank you, new key for encryption was generated.'));
             $this->redirect('encryption.php', ['cat' => 'activate', 'encryption' => '1']);
         } catch (CryptoException $e) {
@@ -103,7 +102,6 @@ class EncryptionController extends ManageBaseController
             }
         }
 
-        $cm->cacheClear();
         $this->redirect('encryption.php');
     }
 

--- a/src/Crypto/CryptoKeyManager.php
+++ b/src/Crypto/CryptoKeyManager.php
@@ -14,6 +14,7 @@
 namespace Eventum\Crypto;
 
 use Defuse\Crypto\Key;
+use Eventum\Opcache;
 use Setup;
 use Symfony\Component\Filesystem\Exception\IOException;
 use Symfony\Component\Filesystem\Filesystem;
@@ -138,8 +139,7 @@ final class CryptoKeyManager
             $content = sprintf('<' . '?php return %s;', var_export($this->key->saveToAsciiSafeString(), 1));
             $fs->dumpFile($this->keyfile, $content);
 
-            // clear cache avoid opcode(?) cache giving previous version. yet it still fails in some cases
-            clearstatcache(true, $this->keyfile);
+            Opcache::invalidate($this->keyfile);
         } catch (IOException $e) {
             throw new CryptoException("Unable to store secret file '{$this->keyfile}': {$e->getMessage()}");
         }

--- a/src/Crypto/CryptoUpgradeManager.php
+++ b/src/Crypto/CryptoUpgradeManager.php
@@ -108,16 +108,4 @@ class CryptoUpgradeManager
         $km->generateKey();
         $this->enable();
     }
-
-    public function cacheClear(): void
-    {
-        // hack needed for macOS cli-server
-        // somehow "require" calls are cached,
-        // clearstatcache and opcache disable do not help. only time
-        if (PHP_SAPI !== 'cli-server') {
-            return;
-        }
-
-        sleep(3);
-    }
 }

--- a/src/Opcache.php
+++ b/src/Opcache.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum;
+
+final class Opcache
+{
+    /**
+     * @see https://www.php.net/opcache_invalidate
+     */
+    public static function invalidate(string $script, bool $force = true): void
+    {
+        if (!function_exists('opcache_invalidate') || !filter_var(ini_get('opcache.enable'), FILTER_VALIDATE_BOOLEAN)) {
+            return;
+        }
+
+        opcache_invalidate($script, $force);
+    }
+}


### PR DESCRIPTION
Finally resolved this bug:

Having `secret_key.php` or `setup.php` cached in any way,
when enabling/disabling encryption,
creates inconsistency and breaks the enable/disable