### PR TITLE
Feature: show all projects checkbox in issues list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
 - Fix Custom Field Options order not being respected, #702, #703
+- Add option to show all projects checkbox in issues list, #681
 
 [3.8.4]: https://github.com/eventum/eventum/compare/v3.8.3...master
 

--- a/htdocs/js/page.js
+++ b/htdocs/js/page.js
@@ -54,6 +54,7 @@ list_issues.ready = function(page_id)
     $('#bulk_update_button').click(list_issues.bulk_update);
     $('#clear_filters').click(list_issues.clearFilters);
     $('#hide_closed').click(list_issues.hideClosed);
+    $('#show_all_projects').click(list_issues.showAllProjects);
     $('#page_size').change(list_issues.resizePager);
     $('#resize_page').click(list_issues.resizePager);
     $('#custom_filter').change(list_issues.runCustomFilter);
@@ -178,6 +179,15 @@ list_issues.hideClosed = function()
         window.location.href = list_issues.page_url + "?" + Eventum.replaceParam(window.location.href, 'hide_closed', '0');
     }
 };
+
+list_issues.showAllProjects = function()
+{
+    if ($('#show_all_projects').is(':checked')) {
+        window.location.href = list_issues.page_url + "?" + Eventum.replaceParam(window.location.href, 'show_all_projects', '1');
+    } else {
+        window.location.href = list_issues.page_url + "?" + Eventum.replaceParam(window.location.href, 'show_all_projects', '0');
+    }
+}
 
 list_issues.resizePager = function()
 {

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -356,7 +356,11 @@ class Search
 
         if ($options['show_all_projects'] == 0) {
             $stmt .= ' AND iss_prj_id= ' . Misc::escapeInteger($prj_id);
+        } else {
+            // get allowed project ids
+            $stmt .= ' AND iss_prj_id in(' . implode(',', array_keys(Project::getAssocList($usr_id))) . ')';
         }
+
         $stmt .= self::buildWhereClause($options);
 
         if (strpos($options['sort_by'], 'custom_field') !== false) {

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -93,6 +93,10 @@ class Search
         if ($hide_closed === '') {
             $hide_closed = 1;
         }
+        $show_all_projects = self::getParam('show_all_projects', $request_only);
+        if ($show_all_projects === '') {
+            $show_all_projects = 0;
+        }
         $search_type = self::getParam('search_type', $request_only);
         if (empty($search_type)) {
             $search_type = 'all_text';
@@ -105,6 +109,7 @@ class Search
             'rows' => Misc::escapeString($rows ? $rows : Setup::get()['default_pager_size']),
             'pagerRow' => Misc::escapeInteger(self::getParam('pagerRow', $request_only)),
             'hide_closed' => $hide_closed,
+            'show_all_projects' => $show_all_projects,
             'sort_by' => Misc::stripHTML($sort_by ? $sort_by : 'pri_rank'),
             'sort_order' => Misc::stripHTML($sort_order ? $sort_order : 'ASC'),
             'customer_id' => Misc::escapeString(self::getParam('customer_id')),
@@ -347,7 +352,11 @@ class Search
                  ON
                     ugr_usr_id = ' . $usr_id . '
                  WHERE
-                    iss_prj_id= ' . Misc::escapeInteger($prj_id);
+                    1=1';
+
+        if ($options['show_all_projects'] == 0) {
+            $stmt .= ' AND iss_prj_id= ' . Misc::escapeInteger($prj_id);
+        }
         $stmt .= self::buildWhereClause($options);
 
         if (strpos($options['sort_by'], 'custom_field') !== false) {

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -208,6 +208,10 @@
                 </td>
                 <td width="30%" align="right">
                   <input type="checkbox" id="hide_closed" name="hide_closed" {if $options.hide_closed}checked{/if}> <label for="hide_closed">{t}Hide Closed Issues{/t}</label>&nbsp;
+                  {if $core.current_role >= $core.roles.developer}
+                    <input type="checkbox" id="show_all_projects" name="show_all_projects"
+                        {if $options.show_all_projects}checked{/if}><label for="show_all_projects">{t}Show all projects{/t}</label>&nbsp;
+                  {/if}
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
I every was disgruntled cause it was too complicated to looking for all issues states in lot of projects . So I modified my issues list. I added checkbox to view all projects issue next to "hide closed" one, when user_role >= developer. 

Would be interest to merge this feature?

Thanx for discuss and proposals for modification