### PR TITLE
Drop support for storing ldap config in separate config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - Set max-width to inline markdown images, #679
 - Fix saving custom field attached to multiple projects, #683, #682
 - Use `EventManager::dispatch()` to get consistent API from Eventum itself, #678
+- Drop support for storing ldap config in separate config, #686
 
 [3.8.3]: https://github.com/eventum/eventum/compare/v3.8.2...master
 

--- a/db/migrations/20190925202208_eventum_merge_ldap_config.php
+++ b/db/migrations/20190925202208_eventum_merge_ldap_config.php
@@ -1,0 +1,26 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+class EventumMergeLdapConfig extends AbstractMigration
+{
+    public function up(): void
+    {
+        Setup::save();
+    }
+
+    public function down(): void
+    {
+    }
+}

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -218,15 +218,7 @@ class Setup
     {
         $config = self::set($options);
         try {
-            $clone = clone $config;
-            // save ldap config to separate file
-            $ldap = $clone->ldap;
-            unset($clone->ldap);
-
-            self::saveConfig(self::getSetupFile(), $clone);
-            if ($ldap) {
-                self::saveConfig(self::getConfigPath() . '/ldap.php', $ldap);
-            }
+            self::saveConfig(self::getSetupFile(), $config);
         } catch (Exception $e) {
             $code = $e->getCode();
             Logger::app()->error($e);
@@ -276,10 +268,16 @@ class Setup
 
         // some subtrees are saved to different files
         $extra_configs = [
+            // @deprecated
             'ldap' => self::getConfigPath() . '/ldap.php',
         ];
 
         foreach ($extra_configs as $section => $filename) {
+            // skip if already present in main config
+            if (isset($config[$section]) && $config[$section]->toArray()) {
+                continue;
+            }
+
             if (!file_exists($filename)) {
                 continue;
             }


### PR DESCRIPTION
Now kept in main `config/setup.php` file.