### PR TITLE
Add support for converting html to markdown

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,6 +19,7 @@
 	"require": {
 		"php": "^7.1.3 || ^8.0",
 		"ext-ctype": "*",
+		"ext-dom": "*",
 		"ext-fileinfo": "*",
 		"ext-filter": "*",
 		"ext-gettext": "*",
@@ -31,6 +32,7 @@
 		"ext-pdo_mysql": "*",
 		"ext-session": "*",
 		"ext-spl": "*",
+		"ext-xml": "*",
 		"defuse/php-encryption": "^2.1",
 		"doctrine/dbal": "^2.5",
 		"doctrine/doctrine-bundle": "^1.11",
@@ -48,6 +50,7 @@
 		"league/commonmark-ext-table": "^2.0",
 		"league/commonmark-ext-task-list": "^1.0",
 		"league/flysystem": "^1.0",
+		"league/html-to-markdown": "^4.8",
 		"malkusch/lock": "^2.1",
 		"mnapoli/silly": "^1.5",
 		"monolog/monolog": "^1.22.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "8204bbae0a0d7dfe0be130564d2be3bc",
+    "content-hash": "e760c9b214781e6bd715d568a5a261a9",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -2293,6 +2293,70 @@
                 "storage"
             ],
             "time": "2019-10-16T21:01:05+00:00"
+        },
+        {
+            "name": "league/html-to-markdown",
+            "version": "4.8.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/thephpleague/html-to-markdown.git",
+                "reference": "e747489191f8e9144a7270eb61f8b9516e99e413"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/thephpleague/html-to-markdown/zipball/e747489191f8e9144a7270eb61f8b9516e99e413",
+                "reference": "e747489191f8e9144a7270eb61f8b9516e99e413",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-xml": "*",
+                "php": ">=5.3.3"
+            },
+            "require-dev": {
+                "mikehaertl/php-shellcommand": "~1.1.0",
+                "phpunit/phpunit": "4.*",
+                "scrutinizer/ocular": "~1.1"
+            },
+            "bin": [
+                "bin/html-to-markdown"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "League\\HTMLToMarkdown\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Colin O'Dell",
+                    "email": "colinodell@gmail.com",
+                    "homepage": "https://www.colinodell.com",
+                    "role": "Lead Developer"
+                },
+                {
+                    "name": "Nick Cernis",
+                    "email": "nick@cern.is",
+                    "homepage": "http://modernnerd.net",
+                    "role": "Original Author"
+                }
+            ],
+            "description": "An HTML-to-markdown conversion helper for PHP",
+            "homepage": "https://github.com/thephpleague/html-to-markdown",
+            "keywords": [
+                "html",
+                "markdown"
+            ],
+            "time": "2019-08-02T11:57:39+00:00"
         },
         {
             "name": "malkusch/lock",
@@ -7984,6 +8048,7 @@
     "platform": {
         "php": "^7.1.3 || ^8.0",
         "ext-ctype": "*",
+        "ext-dom": "*",
         "ext-fileinfo": "*",
         "ext-filter": "*",
         "ext-gettext": "*",
@@ -7995,7 +8060,8 @@
         "ext-pdo": "*",
         "ext-pdo_mysql": "*",
         "ext-session": "*",
-        "ext-spl": "*"
+        "ext-spl": "*",
+        "ext-xml": "*"
     },
     "platform-dev": [],
     "platform-overrides": {

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -23,7 +23,12 @@ final class HtmlConverter
 
     public function __construct()
     {
-        $this->converter = new LeagueHtmlConverter();
+        $options = [
+            'remove_nodes' => 'head style meta',
+            'strip_tags' => true,
+        ];
+
+        $this->converter = new LeagueHtmlConverter($options);
     }
 
     public function convert(string $html): string

--- a/src/HtmlConverter.php
+++ b/src/HtmlConverter.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum;
+
+use League\HTMLToMarkdown\HtmlConverter as LeagueHtmlConverter;
+use League\HTMLToMarkdown\HtmlConverterInterface;
+
+final class HtmlConverter
+{
+    /** @var HtmlConverterInterface */
+    private $converter;
+
+    public function __construct()
+    {
+        $this->converter = new LeagueHtmlConverter();
+    }
+
+    public function convert(string $html): string
+    {
+        return $this->converter->convert($html);
+    }
+}

--- a/src/Setup/RequirementNotSatisfiedException.php
+++ b/src/Setup/RequirementNotSatisfiedException.php
@@ -27,7 +27,7 @@ class RequirementNotSatisfiedException extends RuntimeException
         $this->errors = $errors;
     }
 
-    public function getErrors()
+    public function getErrors(): array
     {
         return $this->errors;
     }

--- a/src/Setup/Requirements.php
+++ b/src/Setup/Requirements.php
@@ -37,6 +37,7 @@ class Requirements
         // sync with composer.json
         $requiredExtensions = [
             'ctype',
+            'dom',
             'fileinfo',
             'filter',
             'gd',
@@ -50,6 +51,7 @@ class Requirements
             'pdo_mysql',
             'session',
             'spl',
+            'xml',
         ];
 
         foreach ($requiredExtensions as $extension) {


### PR DESCRIPTION
Adds support via [league/html-to-markdown](https://packagist.org/packages/league/html-to-markdown) to convert html to markdown.

requires new extensions:
- ext-xml
- ext-dom

NOTE: the class is not used yet, but merged to have new dependencies in place
