### PR TITLE
Add CSS overflow to notes view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Fix URL normalization not handling non-UTF-8 sequences properly in Markdown render, #789
 - Update thephpleague/commonmark to 1.3.0, #795
+- Add CSS overflow to notes view, #794
 
 [3.8.8]: https://github.com/eventum/eventum/compare/v3.8.7...master
 

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -361,6 +361,8 @@ table.grid.internal th, table.grid th.internal {
 
 table.grid td {
     padding: .3em;
+    max-width: 95vw;
+    overflow-y: auto;
 }
 
 table.grid tr.odd {


### PR DESCRIPTION
This makes long notes not to break UI of notes listing.

cc @slay123 