### PR TITLE
Use allowed statuses from workflow when writing notes or emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Query workflow backend for allowed next statuses when writing notes or emails, #802
+
 [3.8.9]: https://github.com/eventum/eventum/compare/v3.8.8...master
 
 ## [3.8.8] - 2020-03-19

--- a/src/Controller/PostNoteController.php
+++ b/src/Controller/PostNoteController.php
@@ -259,7 +259,7 @@ class PostNoteController extends BaseController
                 'from' => User::getFromHeader($this->usr_id),
                 'users' => Project::getUserAssocList($this->prj_id, 'active', User::ROLE_CUSTOMER),
                 'subscribers' => Notification::getSubscribers($this->issue_id, false, User::ROLE_USER),
-                'statuses' => Status::getAssocStatusList($this->prj_id, false),
+                'statuses' => Workflow::getAllowedStatuses($this->prj_id, $this->issue_id),
                 'current_issue_status' => Issue::getStatusID($this->issue_id),
                 'time_categories' => Time_Tracking::getAssocCategories($this->prj_id),
                 'note_category_id' => Time_Tracking::getCategoryId($this->prj_id, 'Note Discussion'),

--- a/src/Controller/SendController.php
+++ b/src/Controller/SendController.php
@@ -139,7 +139,7 @@ class SendController extends BaseController
                 [
                     'issue_id' => $this->issue_id,
 
-                    'statuses' => Status::getAssocStatusList($this->prj_id, false),
+                    'statuses' => Workflow::getAllowedStatuses($this->prj_id, $this->issue_id),
                     'current_issue_status' => Issue::getStatusID($this->issue_id),
                     // set if the current user is allowed to send emails on this issue or not
                     'can_send_email' => Support::isAllowedToEmail($this->issue_id, $sender_details['usr_email']),


### PR DESCRIPTION
This makes the list of allowed next statuses when posting an internal
note consistent with the other views (view issue, update issue and
bulk update).