### PR TITLE
Increase font size on the pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Increase font size on the pages, #809
+
 [3.8.10]: https://github.com/eventum/eventum/compare/v3.8.9...master
 
 ## [3.8.9] - 2020-03-27

--- a/htdocs/css/main.css
+++ b/htdocs/css/main.css
@@ -11,8 +11,8 @@
 
 body {
     background: white;
-    font-family: Verdana, Arial, Helvetica;
-    font-size: .8em;
+    font-family: "Open Sans", Verdana, Arial, Helvetica, serif;
+    font-size: 0.9em;
     padding: 0;
     margin: 0;
 }


### PR DESCRIPTION
Eventum always had weird tiny fonts, makes pretty annoying especioally retina displays.

This CSS I've got long time ago from @slay123.