### PR TITLE
Update league/commonmark to 1.4.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
 		"horde/text-flowed": "dev-patch-1 as 2.0.3",
 		"horde/util": "dev-patch-1 as 2.5.8",
 		"ircmaxell/random-lib": "^1.2",
-		"league/commonmark": "^1.3",
+		"league/commonmark": "^1.4",
 		"league/flysystem": "^1.0",
 		"league/html-to-markdown": "^4.8",
 		"malkusch/lock": "^2.1",

--- a/composer.lock
+++ b/composer.lock
@@ -1838,16 +1838,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.4.0",
+            "version": "1.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "517cbe1c6faf90afeb38a0e917c73acc6d3051ce"
+                "reference": "c995966d35424bae20f76f8b31248099487a3f57"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/517cbe1c6faf90afeb38a0e917c73acc6d3051ce",
-                "reference": "517cbe1c6faf90afeb38a0e917c73acc6d3051ce",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c995966d35424bae20f76f8b31248099487a3f57",
+                "reference": "c995966d35424bae20f76f8b31248099487a3f57",
                 "shasum": ""
             },
             "require": {
@@ -1908,7 +1908,7 @@
                 "md",
                 "parser"
             ],
-            "time": "2020-04-18T20:46:13+00:00"
+            "time": "2020-04-20T13:36:51+00:00"
         },
         {
             "name": "league/flysystem",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "24e224dcdca25eadb39ec2f87ef8d113",
+    "content-hash": "3e238060af0f764cdd8d62a459088b1e",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -1838,16 +1838,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.3.1",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "8015f806173c6ee54de25a87c2d69736696e88db"
+                "reference": "517cbe1c6faf90afeb38a0e917c73acc6d3051ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/8015f806173c6ee54de25a87c2d69736696e88db",
-                "reference": "8015f806173c6ee54de25a87c2d69736696e88db",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/517cbe1c6faf90afeb38a0e917c73acc6d3051ce",
+                "reference": "517cbe1c6faf90afeb38a0e917c73acc6d3051ce",
                 "shasum": ""
             },
             "require": {
@@ -1865,7 +1865,7 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "~1.4",
                 "mikehaertl/php-shellcommand": "^1.4",
-                "phpstan/phpstan-shim": "^0.11.5",
+                "phpstan/phpstan": "^0.12",
                 "phpunit/phpunit": "^7.5",
                 "scrutinizer/ocular": "^1.5",
                 "symfony/finder": "^4.2"
@@ -1908,21 +1908,7 @@
                 "md",
                 "parser"
             ],
-            "funding": [
-                {
-                    "url": "https://github.com/colinodell",
-                    "type": "github"
-                },
-                {
-                    "url": "https://www.patreon.com/colinodell",
-                    "type": "patreon"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/league%2fcommonmark",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2020-02-28T18:53:50+00:00"
+            "time": "2020-04-18T20:46:13+00:00"
         },
         {
             "name": "league/flysystem",

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -19,13 +19,13 @@ use Eventum\EventDispatcher\EventManager;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
 use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\ConverterInterface;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
 use League\CommonMark\Extension\CommonMarkCoreExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\Extension\TaskList\TaskListExtension;
+use League\CommonMark\MarkdownConverterInterface;
 use Misc;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -41,7 +41,7 @@ final class Markdown
 
     /** @var HTMLPurifier */
     private $purifier;
-    /** @var ConverterInterface[] */
+    /** @var MarkdownConverterInterface[] */
     private $converter = [];
 
     public function __construct()
@@ -73,7 +73,7 @@ final class Markdown
         return $html;
     }
 
-    private function getConverter(bool $inline): ConverterInterface
+    private function getConverter(bool $inline): MarkdownConverterInterface
     {
         return $this->converter[(int)$inline] ?? $this->converter[(int)$inline] = $this->createConverter($inline);
     }
@@ -83,7 +83,7 @@ final class Markdown
         return $this->purifier ?? $this->purifier = $this->createPurifier();
     }
 
-    private function createConverter(bool $inline): ConverterInterface
+    private function createConverter(bool $inline): MarkdownConverterInterface
     {
         $config = [
             'renderer' => [


### PR DESCRIPTION
This allows using new extensions:
- Added new Heading Permalink extension (https://github.com/thephpleague/commonmark/pull/420)
- Added new Table of Contents extension (https://github.com/thephpleague/commonmark/issues/441)