### PR TITLE
Add heading permalink markdown extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - Update jquery-chosen from 1.2.0 to 1.8.7, #812
 - Add example Subscriber/PhinxConfig how to add custom migrations, #818
 - Update perftools/php-profiler to 0.3.0, #817
+- Add heading permalink markdown extension, #819
 
 [3.8.10]: https://github.com/eventum/eventum/compare/v3.8.9...master
 

--- a/composer.lock
+++ b/composer.lock
@@ -1838,16 +1838,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "1.4.1",
+            "version": "1.4.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "c995966d35424bae20f76f8b31248099487a3f57"
+                "reference": "9e780d972185e4f737a03bade0fd34a9e67bbf31"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/c995966d35424bae20f76f8b31248099487a3f57",
-                "reference": "c995966d35424bae20f76f8b31248099487a3f57",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/9e780d972185e4f737a03bade0fd34a9e67bbf31",
+                "reference": "9e780d972185e4f737a03bade0fd34a9e67bbf31",
                 "shasum": ""
             },
             "require": {
@@ -1908,7 +1908,33 @@
                 "md",
                 "parser"
             ],
-            "time": "2020-04-20T13:36:51+00:00"
+            "funding": [
+                {
+                    "url": "https://enjoy.gitstore.app/repositories/thephpleague/commonmark",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.colinodell.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://www.paypal.me/colinpodell/10.00",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/colinodell",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/colinodell",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/league/commonmark",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-24T13:39:56+00:00"
         },
         {
             "name": "league/flysystem",

--- a/res/assets/sass/all.scss
+++ b/res/assets/sass/all.scss
@@ -13,4 +13,5 @@
 // See CONTRIBUTING.md how to compile assets.
 
 @import 'main';
+@import 'markdown';
 @import 'page';

--- a/res/assets/sass/markdown.scss
+++ b/res/assets/sass/markdown.scss
@@ -1,0 +1,34 @@
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+/*
+ * https://commonmark.thephpleague.com/1.4/extensions/heading-permalinks/
+ */
+
+.heading-permalink {
+    font-size: .8em;
+    vertical-align: super;
+    text-decoration: none;
+    color: transparent;
+    visibility: hidden;
+}
+
+h1:hover .heading-permalink,
+h2:hover .heading-permalink,
+h3:hover .heading-permalink,
+h4:hover .heading-permalink,
+h5:hover .heading-permalink,
+h6:hover .heading-permalink,
+{
+    text-decoration: none;
+    color: #777;
+    visibility: visible;
+}

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -95,6 +95,10 @@ final class Markdown
             'html_input' => Environment::HTML_INPUT_ALLOW,
             'allow_unsafe_links' => false,
             'max_nesting_level' => self::MAX_NESTING_LEVEL,
+            'heading_permalink' => [
+                'inner_contents' => '¶',
+                'insert' => 'after',
+            ],
         ];
 
         $environment = new Environment($config);

--- a/src/Markdown.php
+++ b/src/Markdown.php
@@ -22,6 +22,7 @@ use League\CommonMark\CommonMarkConverter;
 use League\CommonMark\Environment;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
 use League\CommonMark\Extension\CommonMarkCoreExtension;
+use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
 use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\Extension\TaskList\TaskListExtension;
@@ -143,6 +144,7 @@ final class Markdown
         $environment->addExtension(new TaskListExtension());
         $environment->addExtension(new MentionExtension());
         $environment->addExtension(new TableExtension());
+        $environment->addExtension(new HeadingPermalinkExtension());
 
         // allow extensions to apply behaviour
         $event = new GenericEvent($environment);

--- a/tests/data/markdown/headers.html
+++ b/tests/data/markdown/headers.html
@@ -1,15 +1,15 @@
-<h1>H1</h1>
-<h2>H2</h2>
-<h3>H3</h3>
-<h4>H4</h4>
-<h5>H5</h5>
-<h6>H6</h6>
+<h1>H1<a href="#h1" class="heading-permalink" title="Permalink">¶</a></h1>
+<h2>H2<a href="#h2" class="heading-permalink" title="Permalink">¶</a></h2>
+<h3>H3<a href="#h3" class="heading-permalink" title="Permalink">¶</a></h3>
+<h4>H4<a href="#h4" class="heading-permalink" title="Permalink">¶</a></h4>
+<h5>H5<a href="#h5" class="heading-permalink" title="Permalink">¶</a></h5>
+<h6>H6<a href="#h6" class="heading-permalink" title="Permalink">¶</a></h6>
 <p>Alternatively, for H1 and H2, an underline-ish style:</p>
-<h1>Alt-H1</h1>
-<h2>Alt-H2</h2>
+<h1>Alt-H1<a href="#alt-h1" class="heading-permalink" title="Permalink">¶</a></h1>
+<h2>Alt-H2<a href="#alt-h2" class="heading-permalink" title="Permalink">¶</a></h2>
 <hr>
-<h2>This header has a :thumbsup: in it</h2>
-<h1>This header has Unicode in it: 한글</h1>
-<h2>This header has spaces in it</h2>
-<h3>This header has spaces in it</h3>
-<h2>This header has 3.5 in it (and parentheses)</h2>
+<h2>This header has a :thumbsup: in it<a href="#this-header-has-a-thumbsup-in-it" class="heading-permalink" title="Permalink">¶</a></h2>
+<h1>This header has Unicode in it: 한글<a href="#this-header-has-unicode-in-it-" class="heading-permalink" title="Permalink">¶</a></h1>
+<h2>This header has spaces in it<a href="#this-header-has-spaces-in-it" class="heading-permalink" title="Permalink">¶</a></h2>
+<h3>This header has spaces in it<a href="#this-header-has-spaces-in-it" class="heading-permalink" title="Permalink">¶</a></h3>
+<h2>This header has 3.5 in it (and parentheses)<a href="#this-header-has-35-in-it-and-parentheses" class="heading-permalink" title="Permalink">¶</a></h2>

--- a/tests/data/markdown/inline.html
+++ b/tests/data/markdown/inline.html
@@ -1,1 +1,1 @@
-<h1>closed h1</h1>
+<h1>closed h1<a href="#closed-h1" class="heading-permalink" title="Permalink">¶</a></h1>

--- a/tests/data/markdown/table.html
+++ b/tests/data/markdown/table.html
@@ -1,4 +1,4 @@
-<h2>heading</h2>
+<h2>heading<a href="#heading" class="heading-permalink" title="Permalink">¶</a></h2>
 <table>
 <thead>
 <tr>


### PR DESCRIPTION
Continuation from #816, adds [Heading Permalink extension].

[Heading Permalink extension]: https://commonmark.thephpleague.com/1.4/extensions/heading-permalinks/

Probably needs to be context-aware:
- different prefix for issue body and notes

uses `'inner_contents' => '¶'` as default `<svg>` is stripped out by htmlpurifier:
- https://github.com/thephpleague/commonmark/pull/458