### PR TITLE
Use npm packages instead of component installer

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -2,12 +2,14 @@ layout php
 layout node
 
 # Use Node version compatible with Travis.
-# Pre-installed Node.js versions on Travis
-# - v4.8.6
-# - v6.12.0
-# - v6.12.1
+# Pre-installed Node.js versions on Travis (xenial)
+# - v4.9.1
+# - v6.17.0
 # - v8.9
-# - v8.9.1
-export PATH="/usr/local/opt/node@8/bin:$PATH"
+# - v8.12.0
+# - v8.15.1
+# - v10.15.3
+# - v11.0.0
+export PATH="/usr/local/opt/node@10/bin:$PATH"
 
 [[ -f .envrc.local ]] && source_env .envrc.local

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,8 +29,14 @@ jobs:
     - stage: release
       name: GitHub Release
       dist: xenial
+      language:
+        - node_js
+        - php
       php: "7.1"
+      node_js: "10"
       script:
+        - node --version
+        - php --version
         - bin/releng/dist.sh
 
       # https://docs.travis-ci.com/user/deployment/releases

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
 - Add error message to email error reports, #831
+- Use npm packages instead of component installer, #823
 
 [3.8.12]: https://github.com/eventum/eventum/compare/v3.8.11...master
 

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -122,7 +122,7 @@ install_dependencies() {
 install_assets() {
 	echo >&2 "Install assets"
 	yarn
-	yarn production
+	yarn assets:production
 }
 
 dependencies_report() {

--- a/composer.json
+++ b/composer.json
@@ -94,7 +94,6 @@
         "balbuf/composer-git-merge-driver": "^1.1",
         "bgrins/filereader.js": "*",
         "components/jquery": "~1.8.3",
-        "components/jquery-blockui": "*@dev",
         "components/jquery-cookie": "~1.4.1",
         "components/jquery-datatables": "~1.10.4",
         "components/jqueryui": "1.11.*",

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
         "components/jquery-datatables": "~1.10.4",
         "components/jqueryui": "1.11.*",
         "eventum/rpc": "^4.3.0",
-        "fortawesome/font-awesome": "^4.7",
         "jasig/phpcas": "~1.3.3",
         "maximebf/debugbar": "1.*",
         "perftools/php-profiler": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
         "jasig/phpcas": "~1.3.3",
         "maximebf/debugbar": "1.*",
         "perftools/php-profiler": "^0.3.0",
-        "rmm5t/jquery-timeago": "*",
         "robloach/component-installer": "*",
         "sentry/sentry": "^1.7",
         "symfony/browser-kit": "^4.2",

--- a/composer.json
+++ b/composer.json
@@ -98,7 +98,6 @@
         "components/jquery-cookie": "~1.4.1",
         "components/jquery-datatables": "~1.10.4",
         "components/jqueryui": "1.11.*",
-        "drmonty/garlicjs": "~1.2.4",
         "enyo/dropzone": "~4.3.0",
         "eventum/rpc": "^4.3.0",
         "fortawesome/font-awesome": "^4.7",

--- a/composer.json
+++ b/composer.json
@@ -97,7 +97,6 @@
         "components/jquery-cookie": "~1.4.1",
         "components/jquery-datatables": "~1.10.4",
         "components/jqueryui": "1.11.*",
-        "enyo/dropzone": "~4.3.0",
         "eventum/rpc": "^4.3.0",
         "fortawesome/font-awesome": "^4.7",
         "jackmoore/autosize": "*",

--- a/composer.json
+++ b/composer.json
@@ -99,7 +99,6 @@
         "components/jqueryui": "1.11.*",
         "eventum/rpc": "^4.3.0",
         "fortawesome/font-awesome": "^4.7",
-        "jackmoore/autosize": "*",
         "jasig/phpcas": "~1.3.3",
         "maximebf/debugbar": "1.*",
         "perftools/php-profiler": "^0.3.0",

--- a/composer.json
+++ b/composer.json
@@ -102,7 +102,6 @@
         "fortawesome/font-awesome": "^4.7",
         "jackmoore/autosize": "*",
         "jasig/phpcas": "~1.3.3",
-        "jquery-form/form": "^4.2",
         "maximebf/debugbar": "1.*",
         "perftools/php-profiler": "^0.3.0",
         "rmm5t/jquery-timeago": "*",

--- a/composer.json
+++ b/composer.json
@@ -92,7 +92,6 @@
     "require-dev": {
         "alcaeus/mongo-php-adapter": "^1.1",
         "balbuf/composer-git-merge-driver": "^1.1",
-        "bgrins/filereader.js": "*",
         "components/jquery": "~1.8.3",
         "components/jquery-cookie": "~1.4.1",
         "components/jquery-datatables": "~1.10.4",

--- a/composer.json
+++ b/composer.json
@@ -156,7 +156,7 @@
         ],
         "assets": [
             "yarn",
-            "yarn run development"
+            "yarn run assets:development"
         ],
         "test": "simple-phpunit"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d531b10a6885a82bc3efd3d73f5f235b",
+    "content-hash": "763348c5bf6413b8cb4ec1d92ba0fbf7",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7329,29 +7329,6 @@
             ],
             "description": "jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.",
             "time": "2015-03-13T14:48:12+00:00"
-        },
-        {
-            "name": "enyo/dropzone",
-            "version": "4.3.0",
-            "dist": {
-                "type": "zip",
-                "url": "https://github.com/enyo/dropzone/archive/v4.3.0.zip",
-                "shasum": "42357a4753636163f73b8ce3bde140366b8f8039"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "dist/dropzone.js"
-                    ],
-                    "styles": [
-                        "dist/basic.css"
-                    ]
-                }
-            },
-            "license": [
-                "MIT"
-            ]
         },
         {
             "name": "eventum/rpc",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f9e9023e3176a4bd09499c0de5d8b733",
+    "content-hash": "35f5d13f6e8c776583551f655b395b83",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7384,48 +7384,6 @@
             ],
             "description": "jQuery UI is a curated set of user interface interactions, effects, widgets, and themes built on top of the jQuery JavaScript Library. Whether you're building highly interactive web applications or you just need to add a date picker to a form control, jQuery UI is the perfect choice.",
             "time": "2015-03-13T14:48:12+00:00"
-        },
-        {
-            "name": "drmonty/garlicjs",
-            "version": "1.2.4",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/mrohnstock/garlicjs.git",
-                "reference": "8d90b27dd4a12351d1a9b8774276481bfbc8f8a7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/mrohnstock/garlicjs/zipball/8d90b27dd4a12351d1a9b8774276481bfbc8f8a7",
-                "reference": "8d90b27dd4a12351d1a9b8774276481bfbc8f8a7",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": ">=1.8"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "js/garlic.min.js"
-                    ],
-                    "files": [
-                        "js/garlic.min.js",
-                        "js/garlic-standalone.min.js"
-                    ],
-                    "shim": {
-                        "deps": [
-                            "jquery"
-                        ]
-                    }
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "description": "Automatically persist your forms' text and select field values locally, until the form is submitted.",
-            "homepage": "http://garlicjs.org/",
-            "time": "2015-06-19T05:58:22+00:00"
         },
         {
             "name": "enyo/dropzone",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "83b458e6d14f36abad14e2c344ca646f",
+    "content-hash": "d531b10a6885a82bc3efd3d73f5f235b",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7514,62 +7514,6 @@
                 "jasig"
             ],
             "time": "2019-08-18T20:01:55+00:00"
-        },
-        {
-            "name": "jquery-form/form",
-            "version": "v4.2.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/jquery-form/form.git",
-                "reference": "4beae57bc92402e2d03ca66b5ae2942d0c94c695"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/jquery-form/form/zipball/4beae57bc92402e2d03ca66b5ae2942d0c94c695",
-                "reference": "4beae57bc92402e2d03ca66b5ae2942d0c94c695",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": ">=1.7.2"
-            },
-            "type": "library",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "src/jquery.form.js"
-                    ],
-                    "shim": {
-                        "deps": [
-                            "jquery"
-                        ]
-                    }
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "(LGPL-2.1+ OR MIT)"
-            ],
-            "authors": [
-                {
-                    "name": "Kevin Morris"
-                },
-                {
-                    "name": "Mike Alsup"
-                }
-            ],
-            "description": "The jQuery Form Plugin allows you to easily and unobtrusively upgrade HTML forms to use AJAX.",
-            "homepage": "https://github.com/jquery-form/form",
-            "keywords": [
-                "ajax",
-                "form",
-                "html-form",
-                "jquery",
-                "jquery-form",
-                "jquery-plugin",
-                "json",
-                "json-form"
-            ],
-            "time": "2017-08-09T20:56:53+00:00"
         },
         {
             "name": "kriswallsmith/assetic",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "763348c5bf6413b8cb4ec1d92ba0fbf7",
+    "content-hash": "b708609f7efa42a2d7e08075b3ec32e8",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7415,26 +7415,6 @@
                 "font",
                 "fontawesome",
                 "icon"
-            ]
-        },
-        {
-            "name": "jackmoore/autosize",
-            "version": "3.0.13",
-            "dist": {
-                "type": "zip",
-                "url": "https://github.com/jackmoore/autosize/archive/3.0.13.zip",
-                "shasum": "f2c48fb4cd76d89bb4e6e8c34e9cd130a1633aec"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "dist/autosize.js"
-                    ]
-                }
-            },
-            "license": [
-                "MIT"
             ]
         },
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a0bc68ad7163beae2aa1aed1e3a1a864",
+    "content-hash": "5e0bbccb3c6f7fcd3037b86878518ed9",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7330,53 +7330,6 @@
             ],
             "description": "Eventum RPC Client Library",
             "time": "2018-05-02T19:29:45+00:00"
-        },
-        {
-            "name": "fortawesome/font-awesome",
-            "version": "4.7.0",
-            "dist": {
-                "type": "tar",
-                "url": "https://github.com/FortAwesome/Font-Awesome/archive/v4.7.0.tar.gz",
-                "shasum": "7a94b1800202e20c382d9847cdf51e8d1c106b7e"
-            },
-            "type": "library",
-            "extra": {
-                "component": {
-                    "styles": [
-                        "css/font-awesome.css"
-                    ],
-                    "files": [
-                        "fonts/fontawesome-webfont.eot",
-                        "fonts/fontawesome-webfont.svg",
-                        "fonts/fontawesome-webfont.ttf",
-                        "fonts/fontawesome-webfont.woff",
-                        "fonts/fontawesome-webfont.woff2",
-                        "fonts/FontAwesome.otf"
-                    ]
-                }
-            },
-            "license": [
-                "OFL-1.1",
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Dave Gandy",
-                    "email": "dave@fontawesome.io",
-                    "role": "Developer",
-                    "homepage": "http://twitter.com/davegandy"
-                }
-            ],
-            "description": "The iconic font and CSS framework",
-            "homepage": "http://fontawesome.io/",
-            "keywords": [
-                "awesome",
-                "bootstrap",
-                "font",
-                "font",
-                "fontawesome",
-                "icon"
-            ]
         },
         {
             "name": "jasig/phpcas",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a25ee1e145e24403d2021f7c82f83235",
+    "content-hash": "a0bc68ad7163beae2aa1aed1e3a1a864",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7091,45 +7091,6 @@
                 "merge"
             ],
             "time": "2019-01-23T01:57:04+00:00"
-        },
-        {
-            "name": "bgrins/filereader.js",
-            "version": "dev-composer",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/glensc/filereader.js.git",
-                "reference": "dd7886cc6f6b4f852d76a300795e3caca06fb1db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/glensc/filereader.js/zipball/dd7886cc6f6b4f852d76a300795e3caca06fb1db",
-                "reference": "dd7886cc6f6b4f852d76a300795e3caca06fb1db",
-                "shasum": ""
-            },
-            "type": "library",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "filereader.js"
-                    ]
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Brian Grinstead",
-                    "email": "briangrinstead@gmail.com"
-                }
-            ],
-            "description": "A lightweight wrapper for the JavaScript FileReader interface",
-            "homepage": "http://bgrins.github.io/filereader.js/",
-            "support": {
-                "issues": "https://github.com/bgrins/filereader.js/issues",
-                "source": "https://github.com/glensc/filereader.js/tree/composer"
-            },
-            "time": "2016-01-12T21:48:16+00:00"
         },
         {
             "name": "components/jquery",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "35f5d13f6e8c776583551f655b395b83",
+    "content-hash": "83b458e6d14f36abad14e2c344ca646f",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7172,61 +7172,6 @@
             "time": "2013-04-05T19:32:49+00:00"
         },
         {
-            "name": "components/jquery-blockui",
-            "version": "2.70",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/malsup/blockui.git",
-                "reference": "316f6e5d76a33266970778e80507149d9ef6a02d"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/malsup/blockui/zipball/316f6e5d76a33266970778e80507149d9ef6a02d",
-                "reference": "316f6e5d76a33266970778e80507149d9ef6a02d",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": ">=1.7",
-                "robloach/component-installer": "*"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "jquery.blockUI.js"
-                    ],
-                    "shim": {
-                        "deps": [
-                            "jquery"
-                        ]
-                    }
-                }
-            },
-            "license": [
-                "MIT",
-                "GPL"
-            ],
-            "authors": [
-                {
-                    "name": "M. Alsup",
-                    "homepage": "http://jquery.malsup.com"
-                }
-            ],
-            "description": "Simulate synchronous ajax by blocking - not locking - the UI. This plugin lets you block user interaction with the page or with a specific element on the page. Also great at displaying modal dialogs.",
-            "homepage": "http://jquery.malsup.com/block/",
-            "keywords": [
-                "block",
-                "dialog",
-                "modal",
-                "overlay"
-            ],
-            "support": {
-                "source": "https://github.com/malsup/blockui/tree/2.70",
-                "issues": "https://github.com/malsup/blockui/issues"
-            },
-            "time": "2014-11-24T03:14:41+00:00"
-        },
-        {
             "name": "components/jquery-cookie",
             "version": "1.4.1.2",
             "source": {
@@ -8453,8 +8398,7 @@
     "stability-flags": {
         "horde/text-flowed": 20,
         "horde/util": 20,
-        "zendframework/zend-mail": 20,
-        "components/jquery-blockui": 20
+        "zendframework/zend-mail": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b708609f7efa42a2d7e08075b3ec32e8",
+    "content-hash": "a25ee1e145e24403d2021f7c82f83235",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7764,55 +7764,6 @@
             ],
             "description": "Library for collecting and storing XHProf results for later use by XHGUI.",
             "time": "2019-12-04T18:39:08+00:00"
-        },
-        {
-            "name": "rmm5t/jquery-timeago",
-            "version": "v1.6.7",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/rmm5t/jquery-timeago.git",
-                "reference": "48fdda3ca724dcd655e8e990f6d7fbd203718905"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/rmm5t/jquery-timeago/zipball/48fdda3ca724dcd655e8e990f6d7fbd203718905",
-                "reference": "48fdda3ca724dcd655e8e990f6d7fbd203718905",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": ">=1.5.0 <4.0"
-            },
-            "type": "library",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "jquery.timeago.js"
-                    ],
-                    "files": [
-                        "locales/jquery.timeago.*.js"
-                    ]
-                }
-            },
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Ryan McGeary",
-                    "email": "ryan@mcgeary.org"
-                }
-            ],
-            "description": "jQuery plugin that makes it easy to support automatically updating fuzzy timestamps (e.g. \"4 minutes ago\" or \"about 1 day ago\").",
-            "homepage": "http://timeago.yarp.com/",
-            "keywords": [
-                "microformat",
-                "time"
-            ],
-            "support": {
-                "issues": "https://github.com/rmm5t/jquery-timeago/issues",
-                "source": "https://github.com/rmm5t/jquery-timeago/tree/v1.6.7"
-            },
-            "time": "2019-04-23T15:55:20+00:00"
         },
         {
             "name": "robloach/component-installer",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "production": "cross-env NODE_ENV=production webpack --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "engines": {
-    "node": "^8.10.0"
+    "node": "^8.10.0||^10"
   },
   "devDependencies": {
     "chosen-js": "^1.8.7",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": "^8.10.0||^10"
   },
   "devDependencies": {
+    "block-ui": "^2.70.1",
     "chosen-js": "^1.8.7",
     "cross-env": "^5.1",
     "drmonty-garlicjs": "^1.2.3",
@@ -22,6 +23,7 @@
     "sass-loader": "^8.0.2"
   },
   "resolutions": {
+    "block-ui/jquery": "1.9.x",
     "drmonty-garlicjs/jquery": "1.9.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -18,12 +18,14 @@
     "cross-env": "^5.1",
     "drmonty-garlicjs": "^1.2.3",
     "jquery": "1.9.x",
+    "jquery-form": "^4.2.2",
     "laravel-mix": "^5.0.4",
     "sass": "^1.26.3",
     "sass-loader": "^8.0.2"
   },
   "resolutions": {
     "block-ui/jquery": "1.9.x",
-    "drmonty-garlicjs/jquery": "1.9.x"
+    "drmonty-garlicjs/jquery": "1.9.x",
+    "jquery-form/jquery": "1.9.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "node": "^8.10.0||^10"
   },
   "devDependencies": {
+    "autosize": "3.0.13",
     "block-ui": "^2.70.1",
     "chosen-js": "^1.8.7",
     "cross-env": "^5.1",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "drmonty-garlicjs": "^1.2.3",
     "dropzone": "^4.3",
     "file-reader-wrapper": "^0.9.10",
+    "font-awesome": "^4.7.0",
     "jquery": "1.9.x",
     "jquery-form": "^4.2.2",
     "laravel-mix": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,16 @@
 {
   "private": true,
   "scripts": {
-    "dev": "yarn run development",
-    "development": "cross-env NODE_ENV=development webpack --progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "watch": "yarn run development -- --watch",
-    "watch-poll": "yarn run watch -- --watch-poll",
-    "hot": "cross-env NODE_ENV=development webpack-dev-server --inline --hot --config=node_modules/laravel-mix/setup/webpack.config.js",
-    "prod": "yarn run production",
-    "production": "cross-env NODE_ENV=production webpack --no-progress --hide-modules --config=node_modules/laravel-mix/setup/webpack.config.js"
+    "assets:development": "yarn run webpack:development --hide-modules --progress",
+    "assets:production": "yarn run webpack:production --hide-modules --no-progress",
+    "dev": "yarn run assets:development",
+    "hot": "yarn run webpack-dev-server:development --inline --hot",
+    "prod": "yarn run assets:production",
+    "watch": "yarn run assets:development -- --watch",
+    "watch-poll": "yarn run assets:watch -- --watch-poll",
+    "webpack-dev-server:development": "cross-env NODE_ENV=development webpack-dev-server --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "webpack:development": "cross-env NODE_ENV=development webpack --config=node_modules/laravel-mix/setup/webpack.config.js",
+    "webpack:production": "cross-env NODE_ENV=production webpack --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "engines": {
     "node": "^8.10.0||^10"

--- a/package.json
+++ b/package.json
@@ -15,9 +15,13 @@
   "devDependencies": {
     "chosen-js": "^1.8.7",
     "cross-env": "^5.1",
-    "jquery": "1.9",
+    "drmonty-garlicjs": "^1.2.3",
+    "jquery": "1.9.x",
     "laravel-mix": "^5.0.4",
     "sass": "^1.26.3",
     "sass-loader": "^8.0.2"
+  },
+  "resolutions": {
+    "drmonty-garlicjs/jquery": "1.9.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
   "devDependencies": {
     "chosen-js": "^1.8.7",
     "cross-env": "^5.1",
+    "jquery": "1.9",
     "laravel-mix": "^5.0.4",
     "sass": "^1.26.3",
     "sass-loader": "^8.0.2"

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "chosen-js": "^1.8.7",
     "cross-env": "^5.1",
     "drmonty-garlicjs": "^1.2.3",
+    "dropzone": "^4.3",
     "jquery": "1.9.x",
     "jquery-form": "^4.2.2",
     "laravel-mix": "^5.0.4",

--- a/package.json
+++ b/package.json
@@ -23,11 +23,13 @@
     "jquery-form": "^4.2.2",
     "laravel-mix": "^5.0.4",
     "sass": "^1.26.3",
-    "sass-loader": "^8.0.2"
+    "sass-loader": "^8.0.2",
+    "timeago": "^1.6.7"
   },
   "resolutions": {
     "block-ui/jquery": "1.9.x",
     "drmonty-garlicjs/jquery": "1.9.x",
-    "jquery-form/jquery": "1.9.x"
+    "jquery-form/jquery": "1.9.x",
+    "timeago/jquery": "1.9.x"
   }
 }

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "cross-env": "^5.1",
     "drmonty-garlicjs": "^1.2.3",
     "dropzone": "^4.3",
+    "file-reader-wrapper": "^0.9.10",
     "jquery": "1.9.x",
     "jquery-form": "^4.2.2",
     "laravel-mix": "^5.0.4",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -37,7 +37,7 @@ mix.scripts([
     'node_modules/jquery/jquery.js',
     'node_modules/jquery/jquery-migrate.js',
     'node_modules/block-ui/jquery.blockUI.js',
-    'htdocs/components/form/src/jquery.form.js',
+    'node_modules/jquery-form/src/jquery.form.js',
     'htdocs/components/jquery-cookie/jquery.cookie.js',
     'htdocs/components/jquery-ui/ui/core.js',
     'htdocs/components/jquery-ui/ui/datepicker.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -20,14 +20,14 @@ mix.sass('res/assets/sass/all.scss', 'htdocs/css/all.css').options({
 });
 
 mix.styles([
-    'htdocs/components/font-awesome/css/font-awesome.css',
+    'node_modules/font-awesome/css/font-awesome.css',
     'htdocs/components/jquery-ui/themes/base/all.css',
     'node_modules/chosen-js/chosen.css',
     'node_modules/dropzone/dist/basic.css',
 ], 'htdocs/css/components.css');
 
 mix.copy('node_modules/chosen-js/*.png', 'htdocs/css');
-mix.copy('vendor/fortawesome/font-awesome/fonts', 'htdocs/fonts');
+mix.copy('node_modules/font-awesome/fonts', 'htdocs/fonts');
 
 mix.scripts([
     'htdocs/js/main.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -23,7 +23,7 @@ mix.styles([
     'htdocs/components/font-awesome/css/font-awesome.css',
     'htdocs/components/jquery-ui/themes/base/all.css',
     'node_modules/chosen-js/chosen.css',
-    'htdocs/components/dropzone/dist/basic.css',
+    'node_modules/dropzone/dist/basic.css',
 ], 'htdocs/css/components.css');
 
 mix.copy('node_modules/chosen-js/*.png', 'htdocs/css');
@@ -49,7 +49,7 @@ mix.scripts([
     'htdocs/components/jquery-ui/ui/selectmenu.js',
     'htdocs/components/jquery-ui/ui/sortable.js',
     'node_modules/chosen-js/chosen.jquery.js',
-    'htdocs/components/dropzone/dist/dropzone.js',
+    'node_modules/dropzone/dist/dropzone.js',
     'htdocs/components/autosize/dist/autosize.js',
     'htdocs/components/jquery-timeago/jquery.timeago.js',
     'htdocs/components/filereader.js/filereader.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -52,7 +52,7 @@ mix.scripts([
     'node_modules/dropzone/dist/dropzone.js',
     'node_modules/autosize/dist/autosize.js',
     'node_modules/timeago/jquery.timeago.js',
-    'htdocs/components/filereader.js/filereader.js',
+    'node_modules/file-reader-wrapper/filereader.js',
     'node_modules/drmonty-garlicjs/js/garlic.min.js',
     'htdocs/components/cmd-ctrl-enter/src/cmd-ctrl-enter.js',
 ], 'htdocs/js/components.js');

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -50,7 +50,7 @@ mix.scripts([
     'htdocs/components/jquery-ui/ui/sortable.js',
     'node_modules/chosen-js/chosen.jquery.js',
     'node_modules/dropzone/dist/dropzone.js',
-    'htdocs/components/autosize/dist/autosize.js',
+    'node_modules/autosize/dist/autosize.js',
     'htdocs/components/jquery-timeago/jquery.timeago.js',
     'htdocs/components/filereader.js/filereader.js',
     'node_modules/drmonty-garlicjs/js/garlic.min.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -34,7 +34,8 @@ mix.scripts([
     'htdocs/js/page.js',
 ], 'htdocs/js/all.js');
 mix.scripts([
-    'htdocs/components/jquery/jquery.js',
+    'node_modules/jquery/jquery.js',
+    'node_modules/jquery/jquery-migrate.js',
     'htdocs/components/jquery-blockui/jquery.blockUI.js',
     'htdocs/components/form/src/jquery.form.js',
     'htdocs/components/jquery-cookie/jquery.cookie.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -53,7 +53,7 @@ mix.scripts([
     'htdocs/components/autosize/dist/autosize.js',
     'htdocs/components/jquery-timeago/jquery.timeago.js',
     'htdocs/components/filereader.js/filereader.js',
-    'htdocs/components/garlicjs/js/garlic.min.js',
+    'node_modules/drmonty-garlicjs/js/garlic.min.js',
     'htdocs/components/cmd-ctrl-enter/src/cmd-ctrl-enter.js',
 ], 'htdocs/js/components.js');
 

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -36,7 +36,7 @@ mix.scripts([
 mix.scripts([
     'node_modules/jquery/jquery.js',
     'node_modules/jquery/jquery-migrate.js',
-    'htdocs/components/jquery-blockui/jquery.blockUI.js',
+    'node_modules/block-ui/jquery.blockUI.js',
     'htdocs/components/form/src/jquery.form.js',
     'htdocs/components/jquery-cookie/jquery.cookie.js',
     'htdocs/components/jquery-ui/ui/core.js',

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -51,7 +51,7 @@ mix.scripts([
     'node_modules/chosen-js/chosen.jquery.js',
     'node_modules/dropzone/dist/dropzone.js',
     'node_modules/autosize/dist/autosize.js',
-    'htdocs/components/jquery-timeago/jquery.timeago.js',
+    'node_modules/timeago/jquery.timeago.js',
     'htdocs/components/filereader.js/filereader.js',
     'node_modules/drmonty-garlicjs/js/garlic.min.js',
     'htdocs/components/cmd-ctrl-enter/src/cmd-ctrl-enter.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,11 @@ autoprefixer@^9.4.2:
     postcss "^7.0.27"
     postcss-value-parser "^4.0.3"
 
+autosize@3.0.13:
+  version "3.0.13"
+  resolved "https://registry.yarnpkg.com/autosize/-/autosize-3.0.13.tgz#34bc43675cbc9ef0fe89cb294797c75f2df24ffc"
+  integrity sha1-NLxDZ1y8nvD+icspR5fHXy3yT/w=
+
 babel-code-frame@^6.26.0:
   version "6.26.0"
   resolved "https://registry.yarnpkg.com/babel-code-frame/-/babel-code-frame-6.26.0.tgz#63fd43f7dc1e3bb7ce35947db8fe369a3f58c74b"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2377,6 +2377,11 @@ drmonty-garlicjs@^1.2.3:
   dependencies:
     jquery ">=1.8"
 
+dropzone@^4.3:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/dropzone/-/dropzone-4.3.0.tgz#48b0b8f2ad092872e4b535b672a7c3f1a1d67c91"
+  integrity sha1-SLC48q0JKHLktTW2cqfD8aHWfJE=
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2363,6 +2363,13 @@ dotenv@^6.2.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
 
+drmonty-garlicjs@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/drmonty-garlicjs/-/drmonty-garlicjs-1.2.3.tgz#469322717e0288b00a5ed930590818d80f6a1cef"
+  integrity sha1-RpMicX4CiLAKXtkwWQgY2A9qHO8=
+  dependencies:
+    jquery ">=1.8"
+
 duplexify@^3.4.2, duplexify@^3.6.0:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/duplexify/-/duplexify-3.7.1.tgz#2a4df5317f6ccfd91f86d6fd25d8d8a103b88309"
@@ -3742,7 +3749,7 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@1.9:
+jquery@1.9.x, jquery@>=1.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3773,7 +3773,7 @@ jquery-form@^4.2.2:
   dependencies:
     jquery ">=1.7.2"
 
-jquery@1.9.x, jquery@>=1.7.2, jquery@>=1.7.x, jquery@>=1.8:
+jquery@1.9.x, "jquery@>=1.5.0 <4.0", jquery@>=1.7.2, jquery@>=1.7.x, jquery@>=1.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=
@@ -6214,6 +6214,13 @@ thunky@^1.0.2:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/thunky/-/thunky-1.1.0.tgz#5abaf714a9405db0504732bbccd2cedd9ef9537d"
   integrity sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==
+
+timeago@^1.6.7:
+  version "1.6.7"
+  resolved "https://registry.yarnpkg.com/timeago/-/timeago-1.6.7.tgz#afd467c29a911e697fc22a81888c7c3022783cb5"
+  integrity sha512-FikcjN98+ij0siKH4VO4dZ358PR3oDDq4Vdl1+sN9gWz1/+JXGr3uZbUShYH/hL7bMhcTpPbplJU5Tej4b4jbQ==
+  dependencies:
+    jquery ">=1.5.0 <4.0"
 
 timers-browserify@^2.0.4:
   version "2.0.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2762,6 +2762,11 @@ file-loader@^2.0.0:
     loader-utils "^1.0.2"
     schema-utils "^1.0.0"
 
+file-reader-wrapper@^0.9.10:
+  version "0.9.10"
+  resolved "https://registry.yarnpkg.com/file-reader-wrapper/-/file-reader-wrapper-0.9.10.tgz#92b2f48a86196dcef6ddfef5791e53463778414a"
+  integrity sha1-krL0ioYZbc723f71eR5TRjd4QUo=
+
 file-type@^10.7.0:
   version "10.11.0"
   resolved "https://registry.yarnpkg.com/file-type/-/file-type-10.11.0.tgz#2961d09e4675b9fb9a3ee6b69e9cd23f43fd1890"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2865,6 +2865,11 @@ follow-redirects@^1.0.0:
   dependencies:
     debug "^3.0.0"
 
+font-awesome@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/font-awesome/-/font-awesome-4.7.0.tgz#8fa8cf0411a1a31afd07b06d2902bb9fc815a133"
+  integrity sha1-j6jPBBGhoxr9B7BtKQK7n8gVoTM=
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3756,7 +3756,14 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@1.9.x, jquery@>=1.7.x, jquery@>=1.8:
+jquery-form@^4.2.2:
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/jquery-form/-/jquery-form-4.2.2.tgz#9f96fb141ec9cbe0cdaf58b4d3f1dcbb009cdd52"
+  integrity sha512-HJTef7DRBSg8ge/RNUw8rUTTtB3l8ozO0OhD16AzDl+eIXp4skgCqRTd9fYPsOzL+pN6+1B9wvbTLGjgikz8Tg==
+  dependencies:
+    jquery ">=1.7.2"
+
+jquery@1.9.x, jquery@>=1.7.2, jquery@>=1.7.x, jquery@>=1.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=

--- a/yarn.lock
+++ b/yarn.lock
@@ -1270,6 +1270,13 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
+block-ui@^2.70.1:
+  version "2.70.1"
+  resolved "https://registry.yarnpkg.com/block-ui/-/block-ui-2.70.1.tgz#c862d64ee6288fb78123377c6680bc7ab262103f"
+  integrity sha1-yGLWTuYoj7eBIzd8ZoC8erJiED8=
+  dependencies:
+    jquery ">=1.7.x"
+
 bluebird@^3.1.1, bluebird@^3.5.5:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
@@ -3749,7 +3756,7 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
-jquery@1.9.x, jquery@>=1.8:
+jquery@1.9.x, jquery@>=1.7.x, jquery@>=1.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=

--- a/yarn.lock
+++ b/yarn.lock
@@ -3742,6 +3742,11 @@ jest-worker@^25.1.0:
     merge-stream "^2.0.0"
     supports-color "^7.0.0"
 
+jquery@1.9:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
+  integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
replace long deprecated component-installer.

it's getting on a way of various things.

example, locked to old symfony/process:

```
$ composer why symfony/process
kriswallsmith/assetic  v1.4.0  requires  symfony/process (~2.1|~3.0)

$ composer why kriswallsmith/assetic
robloach/component-installer  0.2.3  requires  kriswallsmith/assetic (1.*)
```

This replaces most of the packages, keeping same version. missing (ctrl-alt-del) or complicated (jquery-ui) packages left for the future replacement.

refs:
- https://github.com/RobLoach/component-installer/pull/101
- https://github.com/kriswallsmith/assetic/issues/882