### PR TITLE
Add Pimple based service container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - Add `MAIL_PROCESS_BEFORE` event to skip processing certain emails, #820
 - Catch and log fatal errors if XhguiProfile fails to initialize, #822
 - Migrate `SPHINX_SEARCHD_HOST` constant to `setup.php`, #824
+- Add Pimple based service container, #826
 
 [3.8.11]: https://github.com/eventum/eventum/compare/v3.8.10...master
 

--- a/composer.json
+++ b/composer.json
@@ -55,6 +55,7 @@
 		"php-ds/php-ds": "^1.2",
 		"phplot/phplot": "~6.1.0",
 		"phpxmlrpc/phpxmlrpc": "^4.1",
+		"pimple/pimple": "^3.2",
 		"portphp/csv": "^1.1",
 		"portphp/doctrine": "^1.1",
 		"portphp/steps": "^1.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0b5095f193a7b47c85d153030d903a9e",
+    "content-hash": "f9e9023e3176a4bd09499c0de5d8b733",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -2601,6 +2601,56 @@
                 "xmlrpc"
             ],
             "time": "2020-03-04T10:26:33+00:00"
+        },
+        {
+            "name": "pimple/pimple",
+            "version": "v3.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/silexphp/Pimple.git",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/silexphp/Pimple/zipball/9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "reference": "9e403941ef9d65d20cba7d54e29fe906db42cf32",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0",
+                "psr/container": "^1.0"
+            },
+            "require-dev": {
+                "symfony/phpunit-bridge": "^3.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-0": {
+                    "Pimple": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                }
+            ],
+            "description": "Pimple, a simple Dependency Injection Container",
+            "homepage": "http://pimple.sensiolabs.org",
+            "keywords": [
+                "container",
+                "dependency injection"
+            ],
+            "time": "2018-01-21T07:42:36+00:00"
         },
         {
             "name": "portphp/csv",

--- a/init.php
+++ b/init.php
@@ -12,6 +12,8 @@
  */
 
 use Eventum\Event\SystemEvents;
+use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 
 require_once __DIR__ . '/autoload.php';
 require_once __DIR__ . '/globals.php';
@@ -54,5 +56,5 @@ if (Setup::get()['maintenance']) {
 }
 
 Eventum\DebugBarManager::getDebugBarManager();
-Eventum\Extension\ExtensionManager::getManager();
+ServiceContainer::get(ExtensionManager::class);
 Eventum\EventDispatcher\EventManager::dispatch(SystemEvents::BOOT);

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -20,6 +20,7 @@ use Eventum\Db\Doctrine;
 use Eventum\Extension\ExtensionManager;
 use Eventum\Model\Entity\CustomField;
 use Eventum\Model\Repository\CustomFieldRepository;
+use Eventum\ServiceContainer;
 use Project;
 use Setup;
 use Symfony\Component\HttpFoundation\ParameterBag;
@@ -207,7 +208,8 @@ class CustomFieldsController extends ManageBaseController
     private function getBackends(): array
     {
         // load classes from extension manager
-        $manager = ExtensionManager::getManager();
+        /** @var ExtensionManager $manager */
+        $manager = ServiceContainer::get(ExtensionManager::class);
         $backends = $manager->getCustomFieldClasses();
 
         return $this->filterValues($backends);

--- a/src/Controller/Manage/PartnersController.php
+++ b/src/Controller/Manage/PartnersController.php
@@ -15,6 +15,7 @@ namespace Eventum\Controller\Manage;
 
 use Eventum\Controller\Helper\MessagesHelper;
 use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 use Partner;
 use Project;
 
@@ -94,7 +95,9 @@ class PartnersController extends ManageBaseController
     private function getPartnersList(): array
     {
         $partners = [];
-        $backends = ExtensionManager::getManager()->getPartnerClasses();
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
+        $backends = $em->getPartnerClasses();
         foreach ($backends as $par_code => $backend) {
             $partners[] = [
                 'code' => $par_code,

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -16,6 +16,7 @@ namespace Eventum\Controller\Manage;
 use Auth;
 use Eventum\Controller\Helper\MessagesHelper;
 use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 use Project;
 use Status;
 use User;
@@ -111,8 +112,9 @@ class ProjectsController extends ManageBaseController
     private function getWorkflowBackends()
     {
         // load classes from extension manager
-        $manager = ExtensionManager::getManager();
-        $backends = $manager->getWorkflowClasses();
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
+        $backends = $em->getWorkflowClasses();
 
         return $this->filterValues($backends);
     }
@@ -120,8 +122,9 @@ class ProjectsController extends ManageBaseController
     private function getCustomerBackends()
     {
         // load classes from extension manager
-        $manager = ExtensionManager::getManager();
-        $backends = $manager->getCustomerClasses();
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
+        $backends = $em->getCustomerClasses();
 
         return $this->filterValues($backends);
     }

--- a/src/Controller/Manage/UsersController.php
+++ b/src/Controller/Manage/UsersController.php
@@ -14,6 +14,7 @@
 namespace Eventum\Controller\Manage;
 
 use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 use Exception;
 use Group;
 use Project;
@@ -270,7 +271,9 @@ class UsersController extends ManageBaseController
     private function getPartnersList(): array
     {
         $partners = [];
-        $backends = ExtensionManager::getManager()->getPartnerClasses();
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
+        $backends = $em->getPartnerClasses();
         foreach ($backends as $par_code => $backend) {
             $partners[$par_code] = $backend->getName();
         }

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -15,6 +15,7 @@ namespace Eventum\EventDispatcher;
 
 use Eventum\Event\Subscriber;
 use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -31,7 +32,8 @@ class EventManager
             $dispatcher = new EventDispatcher();
 
             // register subscribers from extensions
-            $em = ExtensionManager::getManager();
+            /** @var ExtensionManager $em */
+            $em = ServiceContainer::get(ExtensionManager::class);
             $subscribers = $em->getSubscribers();
             foreach ($subscribers as $subscriber) {
                 $dispatcher->addSubscriber($subscriber);

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -23,6 +23,7 @@ use Eventum\Extension\Provider\RouteProvider;
 use Eventum\Extension\Provider\SubscriberProvider;
 use Eventum\Extension\Provider\WorkflowProvider;
 use Eventum\Logger\LoggerTrait;
+use Eventum\ServiceContainer;
 use Generator;
 use InvalidArgumentException;
 use RuntimeException;
@@ -42,6 +43,7 @@ class ExtensionManager implements RouteProvider
      * Singleton Extension Manager
      *
      * @return ExtensionManager
+     * @deprecated since 3.8.11, use ServiceContainer::get(ExtensionManager::class) instead
      */
     public static function getManager(): self
     {

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -20,6 +20,7 @@ use Eventum\Extension\Provider\ExtensionProvider;
 use Eventum\Extension\Provider\FactoryProvider;
 use Eventum\Extension\Provider\PartnerProvider;
 use Eventum\Extension\Provider\RouteProvider;
+use Eventum\Extension\Provider\ServiceProvider;
 use Eventum\Extension\Provider\SubscriberProvider;
 use Eventum\Extension\Provider\WorkflowProvider;
 use Eventum\Logger\LoggerTrait;
@@ -203,6 +204,7 @@ class ExtensionManager implements RouteProvider
     {
         $extensions = [];
         $loader = $this->getAutoloader();
+        $container = ServiceContainer::getInstance();
 
         foreach ($this->getExtensionFiles() as $classname => $filename) {
             try {
@@ -214,6 +216,9 @@ class ExtensionManager implements RouteProvider
 
             if ($extension instanceof AutoloadProvider) {
                 $extension->registerAutoloader($loader);
+            }
+            if ($extension instanceof ServiceProvider) {
+                $extension->register($container);
             }
             $extensions[$classname] = $extension;
         }

--- a/src/Extension/Provider/ServiceProvider.php
+++ b/src/Extension/Provider/ServiceProvider.php
@@ -1,0 +1,23 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension\Provider;
+
+use Pimple\ServiceProviderInterface;
+
+/**
+ * @since 3.8.11
+ */
+interface ServiceProvider extends ExtensionProvider, ServiceProviderInterface
+{
+}

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -120,7 +120,8 @@ class Kernel extends BaseKernel
             $routes->import("{$this->configDir}/routes.yml");
         }
 
-        $em = ExtensionManager::getManager();
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
         $em->configureRoutes($routes);
     }
 

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -23,6 +23,7 @@ class ServiceContainer
 
         if (!$container) {
             $container = new Container();
+            $container->register(new ServiceProvider\ServiceProvider());
         }
 
         return $container;

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum;
+
+use Pimple\Container;
+
+class ServiceContainer
+{
+    public static function getInstance(): Container
+    {
+        static $container;
+
+        if (!$container) {
+            $container = new Container();
+        }
+
+        return $container;
+    }
+}

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -13,6 +13,7 @@
 
 namespace Eventum;
 
+use Eventum\Config\Config;
 use Pimple\Container;
 
 class ServiceContainer
@@ -32,5 +33,10 @@ class ServiceContainer
     public static function get(string $className)
     {
         return static::getInstance()[$className];
+    }
+
+    public static function getConfig(): Config
+    {
+        return static::get('config');
     }
 }

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -28,4 +28,9 @@ class ServiceContainer
 
         return $container;
     }
+
+    public static function get(string $className)
+    {
+        return static::getInstance()[$className];
+    }
 }

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\ServiceProvider;
+
+use Eventum\Monolog\Logger;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+use Setup;
+
+class ServiceProvider implements ServiceProviderInterface
+{
+    public function register(Container $app): void
+    {
+        $app['logger'] = static function () {
+            return Logger::app();
+        };
+
+        $app['config'] = static function () {
+            return Setup::get();
+        };
+    }
+}

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -14,18 +14,21 @@
 namespace Eventum\ServiceProvider;
 
 use DB_Helper;
+use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionManager;
 use Eventum\Monolog\Logger;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
+use Psr\Log\LoggerInterface;
 use Setup;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 class ServiceProvider implements ServiceProviderInterface
 {
     public function register(Container $app): void
     {
-        $app['logger'] = static function () {
-            return Logger::app();
+        $app['logger'] = static function ($app) {
+            return $app[LoggerInterface::class];
         };
 
         $app['config'] = static function () {
@@ -34,6 +37,14 @@ class ServiceProvider implements ServiceProviderInterface
 
         $app['db'] = static function () {
             return DB_Helper::getInstance();
+        };
+
+        $app[LoggerInterface::class] = static function () {
+            return Logger::app();
+        };
+
+        $app[EventDispatcherInterface::class] = static function () {
+            return EventManager::getEventDispatcher();
         };
 
         $app[ExtensionManager::class] = static function () {

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\ServiceProvider;
 
+use DB_Helper;
 use Eventum\Extension\ExtensionManager;
 use Eventum\Monolog\Logger;
 use Pimple\Container;
@@ -29,6 +30,10 @@ class ServiceProvider implements ServiceProviderInterface
 
         $app['config'] = static function () {
             return Setup::get();
+        };
+
+        $app['db'] = static function () {
+            return DB_Helper::getInstance();
         };
 
         $app[ExtensionManager::class] = static function () {

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\ServiceProvider;
 
+use Eventum\Extension\ExtensionManager;
 use Eventum\Monolog\Logger;
 use Pimple\Container;
 use Pimple\ServiceProviderInterface;
@@ -28,6 +29,10 @@ class ServiceProvider implements ServiceProviderInterface
 
         $app['config'] = static function () {
             return Setup::get();
+        };
+
+        $app[ExtensionManager::class] = static function () {
+            return ExtensionManager::getManager();
         };
     }
 }

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -19,6 +19,7 @@ use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionManager;
 use Eventum\Model\Entity;
 use Eventum\Model\Repository\StatusRepository;
+use Eventum\ServiceContainer;
 use Eventum\Test\Traits\DoctrineTrait;
 
 use ProjectSeeder;
@@ -37,7 +38,7 @@ abstract class TestCase extends WebTestCase
 
         // Boot ExtensionManager
         // current test touches parts that would require workflow to be called
-        ExtensionManager::getManager();
+        ServiceContainer::get(ExtensionManager::class);
     }
 
     /**


### PR DESCRIPTION
Add [Pimple] - A simple PHP Dependency Injection Container, as it's what I'm familiar with.

[Pimple]: https://pimple.symfony.com/

Changing later to PSR11 container, for example [Symfony Service Container], is smaller task than refactoring code to use containers and DI in general.

[Symfony Service Container]: https://symfony.com/doc/4.4/service_container.html
