### PR TITLE
Add error message to email error reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Add error message to email error reports, #831
+
 [3.8.12]: https://github.com/eventum/eventum/compare/v3.8.11...master
 
 ## [3.8.11] - 2020-05-06

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -337,7 +337,9 @@ class Setup
             'smtp' => [],
             'ldap' => [],
 
-            'email_error' => [],
+            'email_error' => [
+                'subject' => '%extra.short_name%: %message%',
+            ],
 
             'email_routing' => [
                 'warning' => [],

--- a/src/Monolog/AppInfoProcessor.php
+++ b/src/Monolog/AppInfoProcessor.php
@@ -15,6 +15,7 @@ namespace Eventum\Monolog;
 
 use Auth;
 use Eventum\AppInfo;
+use Setup;
 
 /**
  * Inject Eventum Version into logger
@@ -27,6 +28,8 @@ class AppInfoProcessor
      */
     public function __invoke(array $record)
     {
+        $record['extra']['short_name'] = Setup::getShortName();
+        $record['extra']['tool_caption'] = Setup::getToolCaption();
         $record['extra']['version'] = AppInfo::getInstance()->getVersion();
 
         $record['extra']['usr_id'] = Auth::getUserID();

--- a/src/Monolog/MailHandler.php
+++ b/src/Monolog/MailHandler.php
@@ -13,10 +13,10 @@
 
 namespace Eventum\Monolog;
 
+use Eventum\ServiceContainer;
 use Misc;
 use Monolog;
 use Monolog\Handler\NativeMailerHandler;
-use Setup;
 
 class MailHandler extends NativeMailerHandler
 {
@@ -27,18 +27,17 @@ class MailHandler extends NativeMailerHandler
      */
     public function __construct($level = Monolog\Logger::ERROR)
     {
-        $setup = Setup::get();
+        $setup = ServiceContainer::getConfig();
+        $config = $setup['email_error'];
 
-        if ($setup['email_error']['status'] === 'enabled') {
-            $notify_list = trim($setup['email_error']['addresses']);
+        if ($config['status'] === 'enabled') {
+            $notify_list = trim($config['addresses']);
             // recipient list can be comma separated
             $to = Misc::trim(explode(',', $notify_list));
-            $subject = Setup::getToolCaption() . ' - Error found!';
         } else {
             $to = [];
-            $subject = null;
         }
 
-        parent::__construct($to, $subject, $setup['smtp']['from'], $level);
+        parent::__construct($to, $config['subject'], $setup['smtp']['from'], $level);
     }
 }


### PR DESCRIPTION
If `email_error` handler is enabled, this adds error message to email subject making it easier to filter messages.

![image](https://user-images.githubusercontent.com/199095/81270486-7eaa5980-9053-11ea-99c8-50e6ce10d1d3.png)
