### PR TITLE
Move workflow handling to WorkflowLegacyExtension extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 
 [3.8.13]: https://github.com/eventum/eventum/compare/v3.8.12...master
 
-- Move JavaScript classes (CustomField, ExpandableCell, GrowingFileField, Validation) to modules #839
+- Move JavaScript classes (CustomField, ExpandableCell, GrowingFileField, Validation) to modules, #839
+- Move workflow handling to WorkflowLegacyExtension extension, #832
 
 ## [3.8.12] - 2020-05-14
 

--- a/docs/examples/extension/Subscriber/IssuePercentageUpdater.php
+++ b/docs/examples/extension/Subscriber/IssuePercentageUpdater.php
@@ -13,12 +13,12 @@
 
 namespace Example\Subscriber;
 
+use Eventum\Event\EventContext;
 use Eventum\Event\SystemEvents;
 use Eventum\TaskList\TaskListItem;
 use Eventum\TaskList\TaskListMatcher;
 use Issue;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 class IssuePercentageUpdater implements EventSubscriberInterface
 {
@@ -38,7 +38,7 @@ class IssuePercentageUpdater implements EventSubscriberInterface
         $this->matcher = new TaskListMatcher();
     }
 
-    public function updateIssueComplete(GenericEvent $event): void
+    public function updateIssueComplete(EventContext $event): void
     {
         $complete = $this->getTaskComplete($event['issue_details']['iss_description']);
         if ($complete === null) {
@@ -46,7 +46,7 @@ class IssuePercentageUpdater implements EventSubscriberInterface
             return;
         }
 
-        Issue::setIssueCompletePercentage($event['issue_id'], $complete);
+        Issue::setIssueCompletePercentage($event->getIssueId(), $complete);
     }
 
     /**
@@ -62,7 +62,7 @@ class IssuePercentageUpdater implements EventSubscriberInterface
             return null;
         }
 
-        $complete = array_filter(array_map(function (TaskListItem $c) {
+        $complete = array_filter(array_map(static function (TaskListItem $c) {
             return $c->isChecked();
         }, $tasks));
 

--- a/lib/eventum/class.access.php
+++ b/lib/eventum/class.access.php
@@ -323,7 +323,7 @@ class Access
         return self::canUpdateIssue($issue_id, $usr_id);
     }
 
-    public static function canCloneIssue($issue_id, $usr_id)
+    public static function canCloneIssue(int $issue_id, int $usr_id): bool
     {
         if (!self::canAccessIssue($issue_id, $usr_id)) {
             return false;
@@ -342,11 +342,7 @@ class Access
             }
         }
 
-        if (User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_USER) {
-            return true;
-        }
-
-        return false;
+        return User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_USER;
     }
 
     public static function canChangeAccessLevel($issue_id, $usr_id)

--- a/lib/eventum/class.access.php
+++ b/lib/eventum/class.access.php
@@ -345,7 +345,7 @@ class Access
         return User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_USER;
     }
 
-    public static function canChangeAccessLevel($issue_id, $usr_id)
+    public static function canChangeAccessLevel(int $issue_id, int $usr_id): bool
     {
         if (!self::canAccessIssue($issue_id, $usr_id)) {
             return false;

--- a/lib/eventum/class.access.php
+++ b/lib/eventum/class.access.php
@@ -622,6 +622,7 @@ class Access
     {
         $sql = '';
         if (Auth::getCurrentRole() < User::ROLE_MANAGER) {
+            $usr_id = Auth::getUserID();
             $sql .= " AND
                         (
                             iss_access_level = 'normal' OR
@@ -630,10 +631,10 @@ class Access
                                 SUBSTR(iss_access_level, 1, 6) = 'group_' AND ugr_grp_id = SUBSTR(iss_access_level, 7)
                             ) OR
                             (
-                                isu_usr_id = " . Auth::getUserID() . '
+                                isu_usr_id = " . $usr_id . '
                             )';
 
-            $workflow = Workflow::getAdditionalAccessSQL($prj_id, Auth::getUserID());
+            $workflow = Workflow::getAdditionalAccessSQL($prj_id, $usr_id);
             if ($workflow !== null) {
                 $sql .= $workflow;
             }

--- a/lib/eventum/class.access.php
+++ b/lib/eventum/class.access.php
@@ -391,7 +391,7 @@ class Access
         ];
     }
 
-    public static function canUpdateIssue($issue_id, $usr_id)
+    public static function canUpdateIssue(int $issue_id, int $usr_id): bool
     {
         if (!self::canAccessIssue($issue_id, $usr_id)) {
             return false;
@@ -410,11 +410,7 @@ class Access
             }
         }
 
-        if (User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_CUSTOMER) {
-            return true;
-        }
-
-        return false;
+        return User::getRoleByUser($usr_id, $prj_id) >= User::ROLE_CUSTOMER;
     }
 
     public static function canChangeAssignee($issue_id, $usr_id)

--- a/lib/eventum/class.authorized_replier.php
+++ b/lib/eventum/class.authorized_replier.php
@@ -118,7 +118,8 @@ class Authorized_Replier
             return -1;
         }
 
-        $workflow = Workflow::handleAuthorizedReplierAdded(Issue::getProjectID($issue_id), $issue_id, $email);
+        $prj_id = Issue::getProjectID($issue_id);
+        $workflow = Workflow::handleAuthorizedReplierAdded($prj_id, $issue_id, $email);
         if ($workflow === false) {
             // cancel subscribing the user
             return -1;

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -289,9 +289,10 @@ class Issue
      * @param   bool $notify if a notification should be sent about this change
      * @return  int 1 if the update worked, -2 if no change is made, -1 on error
      */
-    public static function setStatus($issue_id, $status_id, $notify = false)
+    public static function setStatus(int $issue_id, int $status_id, bool $notify = false)
     {
-        $workflow = Workflow::preStatusChange(self::getProjectID($issue_id), $issue_id, $status_id, $notify);
+        $prj_id = self::getProjectID($issue_id);
+        $workflow = Workflow::preStatusChange($prj_id, $issue_id, $status_id, $notify);
         if ($workflow !== true) {
             return $workflow;
         }

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1442,7 +1442,7 @@ class Issue
      */
     public static function moveIssue($issue_id, $new_prj_id)
     {
-        $current_prj_id = self::getProjectID($issue_id);
+        $old_prj_id = self::getProjectID($issue_id);
         $mapping = self::getMovedIssueMapping($issue_id, $new_prj_id);
 
         $values = [$new_prj_id];
@@ -1468,13 +1468,13 @@ class Issue
         self::getProjectID($issue_id, true);
 
         History::add($issue_id, Auth::getUserID(), 'issue_moved', 'Issue moved from {old_project} to {new_project} by {user}', [
-                'old_project' => Project::getName($current_prj_id),
+                'old_project' => Project::getName($old_prj_id),
                 'new_project' => Project::getName($new_prj_id),
                 'user' => User::getFullName(Auth::getUserID()),
         ]);
 
-        Workflow::handleIssueMovedFromProject($current_prj_id, $issue_id, $new_prj_id);
-        Workflow::handleIssueMovedToProject($new_prj_id, $issue_id, $current_prj_id);
+        Workflow::handleIssueMovedFromProject($old_prj_id, $issue_id, $new_prj_id);
+        Workflow::handleIssueMovedToProject($new_prj_id, $issue_id, $old_prj_id);
 
         Notification::notifyNewIssue($new_prj_id, $issue_id);
 

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1421,7 +1421,7 @@ class Issue
             if (($prj_id != $new_prj_id) && (array_key_exists($new_prj_id, Project::getAssocList($usr_id)))) {
                 if (User::getRoleByUser($usr_id, $new_prj_id) >= User::ROLE_REPORTER) {
                     $res = self::moveIssue($issue_id, $new_prj_id);
-                    if ($res == -1) {
+                    if ($res === -1) {
                         return $res;
                     }
                 } else {
@@ -1440,7 +1440,7 @@ class Issue
      * @param int $new_prj_id
      * @return int 1 on success, -1 otherwise
      */
-    public static function moveIssue($issue_id, $new_prj_id)
+    public static function moveIssue(int $issue_id, int $new_prj_id): int
     {
         $old_prj_id = self::getProjectID($issue_id);
         $mapping = self::getMovedIssueMapping($issue_id, $new_prj_id);
@@ -1481,11 +1481,7 @@ class Issue
         return 1;
     }
 
-    /**
-     * @param int $issue_id
-     * @param int $new_prj_id
-     */
-    private static function getMovedIssueMapping($issue_id, $new_prj_id)
+    private static function getMovedIssueMapping(int $issue_id, int $new_prj_id): array
     {
         $mapping = [];
         $current_details = self::getDetails($issue_id);

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -1936,7 +1936,7 @@ class Notification
      * @param   string $source The source of this call, "add_unknown_user", "self_assign", "remote_assign", "anon_issue", "issue_update", "issue_from_email", "new_issue", "note", "add_extra_recipients"
      * @return  array The list of default notification actions
      */
-    public static function getDefaultActions($issue_id = null, $email = null, $source = null)
+    public static function getDefaultActions($issue_id = null, $email = null, $source = null): array
     {
         $prj_id = Auth::getCurrentProject();
         $workflow = Workflow::getNotificationActions($prj_id, $issue_id, $email, $source);

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -709,7 +709,7 @@ class Support
         $severity = false;
         $references = $mail->getAllReferences();
 
-        $workflow = Workflow::getIssueIDforNewEmail($info['ema_prj_id'], $info, $mail);
+        $workflow = Workflow::getIssueIDForNewEmail($info['ema_prj_id'], $info, $mail);
         if (is_array($workflow)) {
             if (isset($workflow['customer_id'])) {
                 $customer_id = $workflow['customer_id'];

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1258,7 +1258,7 @@ class Support
 
         // now for the real thing
         if ($mail->getAttachment()->hasAttachments()) {
-            if (empty($associated_note_id)) {
+            if (!$associated_note_id) {
                 $history_log = ev_gettext('Attachment originated from an email');
             } else {
                 $history_log = ev_gettext('Attachment originated from a note');

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1696,13 +1696,13 @@ class Support
      * @param   string $sender_email The email address
      * @return  bool
      */
-    public static function isAllowedToEmail($issue_id, $sender_email)
+    public static function isAllowedToEmail(int $issue_id, $sender_email): bool
     {
         $prj_id = Issue::getProjectID($issue_id);
 
         // check the workflow
         $workflow_can_email = Workflow::canEmailIssue($prj_id, $issue_id, $sender_email);
-        if ($workflow_can_email != null) {
+        if ($workflow_can_email !== null) {
             return $workflow_can_email;
         }
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -903,7 +903,7 @@ class Support
      * - string cc (overwrites $mail->cc) !!!
      * @return  int The support ID inserted to database
      */
-    public static function insertEmail(MailMessage $mail, $email_options): int
+    public static function insertEmail(MailMessage $mail, array $email_options): int
     {
         $closing = $email_options['closing'] ?? false;
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1350,10 +1350,9 @@ class Support
      * @param   int $usr_id The user ID of the person performing this change
      * @param   int $issue_id The issue ID
      * @param   array $sup_ids The list of email IDs to associate
-     * @param   bool $authorize If the senders should be added the authorized repliers list
      * @return  int 1 if it worked, -1 otherwise
      */
-    public static function associate(int $usr_id, int $issue_id, array $sup_ids, bool $authorize = false)
+    public static function associate(int $usr_id, int $issue_id, array $sup_ids)
     {
         $res = self::associateEmail($usr_id, $issue_id, $sup_ids);
         if ($res != 1) {
@@ -1396,10 +1395,6 @@ class Support
             $t['sup_id'] = $row['sup_id'];
             $t['usr_id'] = $usr_id;
             Notification::notifyNewEmail($mail, $t);
-            if ($authorize) {
-                $sender_email = $mail->getSender();
-                Authorized_Replier::manualInsert($issue_id, $sender_email, false);
-            }
         }
 
         return 1;

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -1303,7 +1303,7 @@ class Support
      * @param   array $sup_ids The list of email IDs to associate
      * @return  int 1 if it worked, -1 otherwise
      */
-    public static function associateEmail($usr_id, $issue_id, $sup_ids)
+    public static function associateEmail(int $usr_id, int $issue_id, array $sup_ids)
     {
         $list = DB_Helper::buildList($sup_ids);
         $stmt = "UPDATE
@@ -1353,7 +1353,7 @@ class Support
      * @param   bool $authorize If the senders should be added the authorized repliers list
      * @return  int 1 if it worked, -1 otherwise
      */
-    public static function associate($usr_id, $issue_id, $sup_ids, $authorize = false)
+    public static function associate(int $usr_id, int $issue_id, array $sup_ids, bool $authorize = false)
     {
         $res = self::associateEmail($usr_id, $issue_id, $sup_ids);
         if ($res != 1) {

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -592,14 +592,19 @@ class Workflow
      * @param   string $email The email address that is trying to send an email
      * @return  bool true if the sender can email the issue, false if the sender
      *          should not email the issue and null if the default rules should be used
+     * @since 3.8.13 emits ACCESS_ISSUE_EMAIL event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function canEmailIssue($prj_id, $issue_id, $email)
+    public static function canEmailIssue(int $prj_id, int $issue_id, string $email): ?bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $address = AddressHeader::fromString($email)->getAddress();
+        $event = new ResultableEvent($prj_id, $issue_id, null, [], $address);
+        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_EMAIL, $event);
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->canEmailIssue($prj_id, $issue_id, $email);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -302,25 +302,20 @@ class Workflow
      * @param   bool $has_TAM if this issue has a technical account manager
      * @param   bool $has_RR if Round Robin was used to assign this issue
      * @since 3.5.0 emits ISSUE_CREATED event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits EventContext event
      */
-    public static function handleNewIssue($prj_id, $issue_id, $has_TAM, $has_RR): void
+    public static function handleNewIssue(int $prj_id, int $issue_id, bool $has_TAM, bool $has_RR): void
     {
-        $usr_id = Auth::getUserID() ?: Setup::get()['system_user_id'];
+        $usr_id = Auth::getUserID() ?: Setup::getSystemUserId();
         $arguments = [
-            'issue_id' => (int)$issue_id,
-            'prj_id' => (int)$prj_id,
-            'usr_id' => (int)$usr_id,
             'has_TAM' => $has_TAM,
             'has_RR' => $has_RR,
             'issue_details' => Issue::getDetails($issue_id),
         ];
-        EventManager::dispatch(SystemEvents::ISSUE_CREATED, new GenericEvent(null, $arguments));
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
 
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleNewIssue($prj_id, $issue_id, $has_TAM, $has_RR);
+        EventManager::dispatch(SystemEvents::ISSUE_CREATED, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -254,25 +254,19 @@ class Workflow
      * @param   string $type what type of blocked email this is
      * @param MailMessage $mail
      * @since 3.4.2 emits BLOCKED_EMAIL event
-     * @deprecated use SystemEvents::EMAIL_BLOCKED event listener
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 $mail is passed as $subject to an event
+     * @since 3.8.13 emits EventContext event
      */
-    public static function handleBlockedEmail($prj_id, $issue_id, $email_details, $type, $mail = null): void
+    public static function handleBlockedEmail(int $prj_id, int $issue_id, array $email_details, string $type, MailMessage $mail): void
     {
         $arguments = [
-            'prj_id' => (int)$prj_id,
-            'issue_id' => (int)$issue_id,
             'email_details' => $email_details,
             'type' => $type,
             'mail' => $mail,
         ];
-        $event = new GenericEvent(null, $arguments);
+        $event = new EventContext($prj_id, $issue_id, null, $arguments, $mail);
         EventManager::dispatch(SystemEvents::EMAIL_BLOCKED, $event);
-
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleBlockedEmail($prj_id, $issue_id, $email_details, $type);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -211,14 +211,17 @@ class Workflow
      * @param   int $usr_id the id of the user who changed the issue
      * @param   array $old_details the old details of the issue
      * @param   array $changes The changes that were applied to this issue (the $_POST)
+     * @since 3.8.13 emits ISSUE_UPDATED_PRIORITY event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handlePriorityChange($prj_id, $issue_id, $usr_id, $old_details, $changes): void
+    public static function handlePriorityChange(int $prj_id, int $issue_id, int $usr_id, array $old_details, array $changes): void
     {
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handlePriorityChange($prj_id, $issue_id, $usr_id, $old_details, $changes);
+        $arguments = [
+            'old_details' => $old_details,
+            'changes' => $changes,
+        ];
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
+        EventManager::dispatch(SystemEvents::ISSUE_UPDATED_PRIORITY, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -1030,17 +1030,20 @@ class Workflow
     /**
      * Returns custom SQL to limit what results a user can see on the list issues page
      *
-     * @param $prj_id
-     * @param $usr_id
      * @return mixed null to use default rules or an sql string otherwise
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ACCESS_SQL_STATEMENT event
      */
-    public static function getAdditionalAccessSQL($prj_id, $usr_id)
+    public static function getAdditionalAccessSQL(int $prj_id, int $usr_id): ?string
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, null, $usr_id);
+        EventManager::dispatch(SystemEvents::ACCESS_LISTING_SQL, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->getAdditionalAccessSQL($prj_id, $usr_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -192,22 +192,15 @@ class Workflow
      * @param   array $attachment attachment object
      * @return  bool
      * @since 3.6.3 emits ATTACHMENT_ATTACH_FILE event
-     * @deprecated
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
     public static function shouldAttachFile(int $prj_id, int $issue_id, $usr_id, array $attachment): bool
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id, [], $attachment);
+        $event->setResult(true);
         EventManager::dispatch(SystemEvents::ATTACHMENT_ATTACH_FILE, $event);
-        if ($event->hasResult()) {
-            return $event->getResult();
-        }
 
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return true;
-        }
-
-        return $backend->shouldAttachFile($prj_id, $issue_id, $usr_id, $attachment);
+        return $event->getResult();
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -127,8 +127,9 @@ class Workflow
      * @param array $updated_fields
      * @param array $updated_custom_fields
      * @since 3.5.0 emits ISSUE_UPDATED event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handleIssueUpdated($prj_id, $issue_id, $usr_id, $old_details, $raw_post, $updated_fields, $updated_custom_fields): void
+    public static function handleIssueUpdated(int $prj_id, int $issue_id, int $usr_id, $old_details, $raw_post, $updated_fields, $updated_custom_fields): void
     {
         Partner::handleIssueChange($issue_id, $usr_id, $old_details, $raw_post);
 
@@ -143,13 +144,6 @@ class Workflow
             'raw_post' => $raw_post,
         ];
         EventManager::dispatch(SystemEvents::ISSUE_UPDATED, new GenericEvent(null, $arguments));
-
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-
-        $backend->handleIssueUpdated($prj_id, $issue_id, $usr_id, $old_details, $raw_post);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -924,24 +924,16 @@ class Workflow
     }
 
     /**
-     * Updates filters in $filters.
+     * Updates filters in $linkFilter.
      *
      * @since 3.6.3 emits ISSUE_LINK_FILTERS event
-     * @deprecated
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits EventContext event
      */
     public static function addLinkFilters(LinkFilter $linkFilter, int $prj_id): void
     {
-        $arguments = [
-            'prj_id' => $prj_id,
-        ];
-        $event = new GenericEvent($linkFilter, $arguments);
+        $event = new EventContext($prj_id, null, null, [], $linkFilter);
         EventManager::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
-
-        if (!$backend = self::getBackend($prj_id)) {
-            return;
-        }
-
-        $linkFilter->addRules($backend->getLinkFilters($prj_id));
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -14,6 +14,7 @@
 use Eventum\Attachment\AttachmentGroup;
 use Eventum\Config\Paths;
 use Eventum\Db\Doctrine;
+use Eventum\Event\EventContext;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\EventDispatcher\EventManager;
@@ -173,15 +174,13 @@ class Workflow
      * @param   int $issue_id the ID of the issue
      * @param   int $usr_id the id of the user who attached this file
      * @param   AttachmentGroup $attachment_group The attachment object
+     * @since 3.8.13 Emits ATTACHMENT_ATTACHMENT_GROUP event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handleAttachment($prj_id, $issue_id, $usr_id, AttachmentGroup $attachment_group): void
+    public static function handleAttachment(int $prj_id, int $issue_id, int $usr_id, AttachmentGroup $attachment_group): void
     {
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-
-        $backend->handleAttachment($prj_id, $issue_id, $usr_id, $attachment_group);
+        $event = new EventContext($prj_id, $issue_id, $usr_id, [], $attachment_group);
+        EventManager::dispatch(SystemEvents::ATTACHMENT_ATTACHMENT_GROUP, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -1049,35 +1049,33 @@ class Workflow
     /**
      * Called when an issue is moved from this project to another.
      *
-     * @param $prj_id integer
-     * @param $issue_id integer
-     * @param $new_prj_id integer
      * @since 3.1.7
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ISSUE_MOVE_FROM_PROJECT event
      */
-    public static function handleIssueMovedFromProject($prj_id, $issue_id, $new_prj_id)
+    public static function handleIssueMovedFromProject(int $prj_id, int $issue_id, int $new_prj_id): void
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
-        }
-
-        $backend->handleIssueMovedFromProject($prj_id, $issue_id, $new_prj_id);
+        $arguments = [
+            'new_prj_id' => $new_prj_id,
+        ];
+        $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
+        EventManager::dispatch(SystemEvents::ISSUE_MOVE_FROM_PROJECT, $event);
     }
 
     /**
      * Called when an issue is moved to this project from another.
      *
-     * @param $prj_id integer
-     * @param $issue_id integer
-     * @param $old_prj_id integer
      * @since 3.1.7
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ISSUE_MOVE_TO_PROJECT event
      */
-    public static function handleIssueMovedToProject($prj_id, $issue_id, $old_prj_id)
+    public static function handleIssueMovedToProject(int $prj_id, int $issue_id, int $old_prj_id): void
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
-        }
-
-        $backend->handleIssueMovedToProject($prj_id, $issue_id, $old_prj_id);
+        $arguments = [
+            'old_prj_id' => $old_prj_id,
+        ];
+        $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
+        EventManager::dispatch(SystemEvents::ISSUE_MOVE_TO_PROJECT, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -908,14 +908,19 @@ class Workflow
      * @param   int $issue_id The ID of the issue
      * @param   string $location The location to display these fields at
      * @return  array   an array of fields to display and their associated options
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ISSUE_FIELDS_DISPLAY event
      */
-    public static function getIssueFieldsToDisplay($prj_id, $issue_id, $location)
+    public static function getIssueFieldsToDisplay(int $prj_id, int $issue_id, string $location): array
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return [];
+        $event = new ResultableEvent($prj_id, $issue_id, null, [], $location);
+        EventManager::dispatch(SystemEvents::ISSUE_FIELDS_DISPLAY, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->getIssueFieldsToDisplay($prj_id, $issue_id, $location);
+        return [];
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -807,18 +807,21 @@ class Workflow
      * Modifies the content of the message being added to the mail queue.
      *
      * @param   int $prj_id
-     * @param   string $recipient
+     * @param   string $email
      * @param MailMessage $mail The Mail object
      * @param array $options Optional options, see Mail_Queue::queue
      * @since 3.3.0 the method signature changed
+     * @since 3.8.13 emits MAIL_QUEUE_MODIFY event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function modifyMailQueue($prj_id, $recipient, MailMessage $mail, $options): void
+    public static function modifyMailQueue(int $prj_id, string $email, MailMessage $mail, array $options): void
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return;
-        }
-
-        $backend->modifyMailQueue($prj_id, $recipient, $mail, $options);
+        $arguments = [
+            'options' => $options,
+            'address' => AddressHeader::fromString($email)->getAddress(),
+        ];
+        $event = new EventContext($prj_id, null, null, $arguments, $mail);
+        EventManager::dispatch(SystemEvents::MAIL_QUEUE_MODIFY, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -862,14 +862,13 @@ class Workflow
      *
      * @param   int $prj_id The project ID
      * @param   string $page_name The name of the page
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits PAGE_BEFORE event
      */
-    public static function prePage($prj_id, $page_name)
+    public static function prePage(int $prj_id, string $page_name): void
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return true;
-        }
-
-        return $backend->prePage($prj_id, $page_name);
+        $event = new EventContext($prj_id, null, null, [], $page_name);
+        EventManager::dispatch(SystemEvents::PAGE_BEFORE, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -395,27 +395,21 @@ class Workflow
      * @param   int $note_id The ID of the new note
      * @since 3.5.0 emits NOTE_CREATED event
      * @since 3.7.0 adds 'issue' argument to event
+     * @since 3.8.13 emits EventContext event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
     public static function handleNewNote(int $prj_id, int $issue_id, $usr_id, $closing, $note_id): void
     {
         Partner::handleNewNote($issue_id, $note_id);
 
         $arguments = [
-            'issue_id' => (int)$issue_id,
             'issue' => Doctrine::getIssueRepository()->findById($issue_id),
-            'prj_id' => (int)$prj_id,
-            'usr_id' => (int)$usr_id,
             'note_id' => (int)$note_id,
             'note_details' => Note::getDetails($note_id),
             'closing' => (bool)$closing,
         ];
-        EventManager::dispatch(SystemEvents::NOTE_CREATED, new GenericEvent(null, $arguments));
-
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleNewNote($prj_id, $issue_id, $usr_id, $closing, $note_id);
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
+        EventManager::dispatch(SystemEvents::NOTE_CREATED, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -640,14 +640,18 @@ class Workflow
      * @param   int $issue_id The issue ID
      * @param   string $usr_id The ID of the user
      * @return  bool True if the issue can be cloned, false otherwise
+     * @since 3.8.13 emits ACCESS_ISSUE_CLONE event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function canCloneIssue($prj_id, $issue_id, $usr_id)
+    public static function canCloneIssue(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
+        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CLONE, $event);
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->canCloneIssue($prj_id, $issue_id, $usr_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -938,14 +938,20 @@ class Workflow
 
     /**
      * Returns if a user can update an issue. Return null to use default rules.
+     *
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ACCESS_ISSUE_UPDATE event
      */
-    public static function canUpdateIssue($prj_id, $issue_id, $usr_id)
+    public static function canUpdateIssue(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
+        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_UPDATE, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->canUpdateIssue($prj_id, $issue_id, $usr_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -445,30 +445,23 @@ class Workflow
      * @param   string $reason The reason for closing this issue
      * @param   int $usr_id The ID of the user closing this issue
      * @since 3.4.2 emits ISSUE_CLOSED event
-     * @deprecated since 3.4.2
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits EventContext event
      */
-    public static function handleIssueClosed($prj_id, $issue_id, $send_notification, $resolution_id, $status_id, $reason, $usr_id): void
+    public static function handleIssueClosed(int $prj_id, int $issue_id, $send_notification, int $resolution_id, int $status_id, $reason, int $usr_id): void
     {
         $issue_details = Issue::getDetails($issue_id, true);
 
         $arguments = [
-            'prj_id' => (int)$prj_id,
-            'issue_id' => (int)$issue_id,
             'send_notification' => $send_notification,
-            'resolution_id' => (int)$resolution_id,
-            'status_id' => (int)$status_id,
+            'resolution_id' => $resolution_id,
+            'status_id' => $status_id,
             'reason' => $reason,
-            'usr_id' => (int)$usr_id,
             'issue_details' => $issue_details,
         ];
 
-        $event = new GenericEvent(null, $arguments);
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
         EventManager::dispatch(SystemEvents::ISSUE_CLOSED, $event);
-
-        if (!$backend = self::getBackend($prj_id)) {
-            return;
-        }
-        $backend->handleIssueClosed($prj_id, $issue_id, $send_notification, $resolution_id, $status_id, $reason, $usr_id);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -778,18 +778,29 @@ class Workflow
      * a new issue.
      * Can also return an array containing 'customer_id', 'contact_id' and 'contract_id', 'sev_id'
      *
+     * TODO:
+     * - update caller so this method always returns array
+     *
      * @param   int $prj_id The ID of the project
-     * @param   array $info an array of info about the email account
+     * @param   array $account an array of info about the email account
      * @param   MailMessage $mail The Mail object
      * @return  string|array
+     * @since 3.8.13 emits ISSUE_EMAIL_CREATE_OPTIONS event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function getIssueIDForNewEmail($prj_id, $info, MailMessage $mail)
+    public static function getIssueIDForNewEmail(int $prj_id, array $account, MailMessage $mail)
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $arguments = [
+            'account' => $account,
+        ];
+        $event = new ResultableEvent($prj_id, null, null, $arguments, $mail);
+        EventManager::dispatch(SystemEvents::ISSUE_EMAIL_CREATE_OPTIONS, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->getIssueIDforNewEmail($prj_id, $info, $mail);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -661,14 +661,18 @@ class Workflow
      * @param   int $issue_id The issue ID
      * @param   string $usr_id The ID of the user
      * @return  bool True if the issue can be cloned, false otherwise
+     * @since 3.8.13 emits ACCESS_ISSUE_CHANGE_ACCESS event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function canChangeAccessLevel($prj_id, $issue_id, $usr_id)
+    public static function canChangeAccessLevel(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
+        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ACCESS, $event);
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->canChangeAccessLevel($prj_id, $issue_id, $usr_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -498,7 +498,7 @@ class Workflow
      * @return  array|bool|null an array of information or true to continue unchanged or false to prevent the user from being added
      * @since 3.6.3 emits NOTIFICATION_HANDLE_SUBSCRIPTION event
      * @since 3.6.4 add 'address' property of type Address
-     * @deprecated
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
     public static function handleSubscription(int $prj_id, int $issue_id, &$subscriber_usr_id, &$email, &$actions)
     {
@@ -521,11 +521,7 @@ class Workflow
             return $event->getResult();
         }
 
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
-        }
-
-        return $backend->handleSubscription($prj_id, $issue_id, $subscriber_usr_id, $email, $actions);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -993,16 +993,19 @@ class Workflow
     /**
      * Returns an array of additional access levels an issue can be set to
      *
-     * @param $prj_id
-     * @return array
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ACCESS_LEVELS event
      */
-    public static function getAccessLevels($prj_id)
+    public static function getAccessLevels(int $prj_id): ?array
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return [];
+        $event = new ResultableEvent($prj_id, null, null);
+        EventManager::dispatch(SystemEvents::ACCESS_LEVELS, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->getAccessLevels($prj_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -472,14 +472,18 @@ class Workflow
      * @param   array $old the custom fields before the update
      * @param   array $new the custom fields after the update
      * @param   array $changed an array containing what was changed
+     * @since 3.8.13 emits CUSTOM_FIELDS_UPDATED event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handleCustomFieldsUpdated($prj_id, $issue_id, $old, $new, $changed): void
+    public static function handleCustomFieldsUpdated(int $prj_id, int $issue_id, array $old, array $new, array $changed): void
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return;
-        }
-
-        $backend->handleCustomFieldsUpdated($prj_id, $issue_id, $old, $new, $changed);
+        $arguments = [
+            'old' => $old,
+            'new' => $new,
+            'changed' => $changed,
+        ];
+        $event = new EventContext($prj_id, $issue_id, null, $arguments);
+        EventManager::dispatch(SystemEvents::CUSTOM_FIELDS_UPDATED, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -756,16 +756,21 @@ class Workflow
     /**
      * Indicates if the email addresses should automatically be added to the NL from notes and emails.
      *
+     * TODO:
+     * This should be probably moved to project settings as it has no context than project id.
+     *
      * @param   int $prj_id the project ID
      * @return  bool
+     * @since 3.8.13 emits PROJECT_NOTIFICATION_AUTO_ADD event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function shouldAutoAddToNotificationList($prj_id)
+    public static function shouldAutoAddToNotificationList(int $prj_id): bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return true;
-        }
+        $event = new ResultableEvent($prj_id, null, null);
+        $event->setResult(true);
+        EventManager::dispatch(SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD, $event);
 
-        return $backend->shouldAutoAddToNotificationList($prj_id);
+        return $event->getResult();
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -710,24 +710,18 @@ class Workflow
      * @param   int $prj_id The project ID
      * @param   ImapMessage $mail The Imap Mail Message object
      * @return  mixed null by default, -1 if the rest of the email script should not be processed
-     * @deprecated since 3.8.11 use ISSUE_UPDATED_BEFORE event
+     * @since 3.8.11 emits ISSUE_UPDATED_BEFORE event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function preEmailDownload($prj_id, ImapMessage $mail): bool
+    public static function preEmailDownload(int $prj_id, ImapMessage $mail): bool
     {
-        $arguments = [
-            'prj_id' => (int)$prj_id,
-        ];
-
-        $event = EventManager::dispatch(SystemEvents::MAIL_PROCESS_BEFORE, new GenericEvent($mail, $arguments));
+        $event = new EventContext($prj_id, null, null, [], $mail);
+        EventManager::dispatch(SystemEvents::MAIL_PROCESS_BEFORE, $event);
         if ($event->isPropagationStopped()) {
             return false;
         }
 
-        if (!$backend = self::getBackend($prj_id)) {
-            return true;
-        }
-
-        return $backend->preEmailDownload($prj_id, $mail) !== -1;
+        return true;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -956,14 +956,20 @@ class Workflow
 
     /**
      * Returns if a user can change the assignee of an issue. Return null to use default rules.
+     *
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ACCESS_ISSUE_CHANGE_ASSIGNEE event
      */
-    public static function canChangeAssignee($prj_id, $issue_id, $usr_id)
+    public static function canChangeAssignee(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
+        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->canChangeAssignee($prj_id, $issue_id, $usr_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -420,19 +420,15 @@ class Workflow
      * @return  array an associative array of statuses valid for this issue
      * @since 3.6.3 emits ISSUE_ALLOWED_STATUSES event
      * @since 3.6.4 adds Status::getAssocStatusList as Subject
-     * @deprecated
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function getAllowedStatuses($prj_id, $issue_id = null): array
+    public static function getAllowedStatuses(int $prj_id, ?int $issue_id = null): array
     {
         $statusList = Status::getAssocStatusList($prj_id, false);
         $event = new ResultableEvent($prj_id, $issue_id, null, [], $statusList);
         EventManager::dispatch(SystemEvents::ISSUE_ALLOWED_STATUSES, $event);
         if ($event->hasResult()) {
             return $event->getResult();
-        }
-
-        if ($backend = self::getBackend($prj_id)) {
-            $statusList = $backend->getAllowedStatuses($prj_id, $issue_id);
         }
 
         return $statusList;

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -371,14 +371,13 @@ class Workflow
      *
      * @param   int $prj_id The project ID
      * @param   int $issue_id the ID of the issue
+     * @since 3.8.13 emits MAIL_ASSOCIATED_MANUAL event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handleManualEmailAssociation($prj_id, $issue_id): void
+    public static function handleManualEmailAssociation(int $prj_id, int $issue_id): void
     {
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleManualEmailAssociation($prj_id, $issue_id);
+        $event = new EventContext($prj_id, $issue_id, null, []);
+        EventManager::dispatch(SystemEvents::MAIL_ASSOCIATED_MANUAL, $event);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -1011,7 +1011,8 @@ class Workflow
     /**
      * Returns true if a user can access an issue.
      *
-     * @deprecated since 3.8.11 use ACCESS_ISSUE event
+     * @since 3.8.11 emits ACCESS_ISSUE event
+     * @since 3.8.11 workflow integration is done by WorkflowLegacyExtension
      */
     public static function canAccessIssue(int $prj_id, int $issue_id, int $usr_id, bool $return, bool $internal): bool
     {

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -137,7 +137,8 @@ class Workflow
      * @param   array $changes
      * @return  mixed. True to continue, anything else to cancel the change and return the value
      * @since 3.5.0 emits ISSUE_CREATED_BEFORE event
-     * @todo port to ResultableEvent
+     * @since 3.8.13 can use stopPropagation() to cancel event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
     public static function preIssueUpdated($prj_id, $issue_id, $usr_id, &$changes, $issue_details)
     {
@@ -148,6 +149,7 @@ class Workflow
             'issue_details' => $issue_details,
             'changes' => $changes,
             // 'true' to continue, anything else to cancel the change and return the value
+            // @deprecated since 3.8.13, use stopPropagation() to cancel
             'bubble' => true,
         ];
 
@@ -157,12 +159,11 @@ class Workflow
             return $event['bubble'];
         }
 
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return true;
+        if ($event->isPropagationStopped()) {
+            return false;
         }
 
-        return $backend->preIssueUpdated($prj_id, $issue_id, $usr_id, $changes);
+        return true;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -974,14 +974,20 @@ class Workflow
 
     /**
      * Returns the ID of the group that is "active" right now.
+     *
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits GROUP_ACTIVE event
      */
-    public static function getActiveGroup($prj_id)
+    public static function getActiveGroup(int $prj_id): ?int
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return null;
+        $event = new ResultableEvent($prj_id, null, null);
+        EventManager::dispatch(SystemEvents::GROUP_ACTIVE, $event);
+
+        if ($event->hasResult()) {
+            return $event->getResult();
         }
 
-        return $backend->getActiveGroup($prj_id);
+        return null;
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -1087,14 +1087,19 @@ class Workflow
      * @param $old_prj_id integer The ID of the project the issue is being moved from
      * @return array A key/value array with the keys being field names in the issue table
      * @since 3.1.7
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits ISSUE_MOVE_MAPPING event
      */
-    public static function getMovedIssueMapping($prj_id, $issue_id, $mapping, $old_prj_id)
+    public static function getMovedIssueMapping(int $prj_id, int $issue_id, array $mapping, int $old_prj_id): array
     {
-        if (!$backend = self::getBackend($prj_id)) {
-            return $mapping;
-        }
+        $arguments = [
+            'old_prj_id' => $old_prj_id,
+        ];
+        $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
+        $event->setResult($mapping);
+        EventManager::dispatch(SystemEvents::ISSUE_MOVE_MAPPING, $event);
 
-        return $backend->getMovedIssueMapping($prj_id, $issue_id, $mapping, $old_prj_id);
+        return $event->getResult();
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -279,27 +279,19 @@ class Workflow
      * @param   array $new_assignees the new assignees of this issue
      * @param   bool $remote_assignment if this issue was remotely assigned
      * @since 3.4.2 emits ISSUE_ASSIGNMENT_CHANGE event
-     * @deprecated since 3.4.2
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 emits EventContext event
      */
-    public static function handleAssignmentChange($prj_id, $issue_id, $usr_id, $issue_details, $new_assignees, $remote_assignment = false): void
+    public static function handleAssignmentChange(int $prj_id, int $issue_id, int $usr_id, array $issue_details, $new_assignees, bool $remote_assignment = false): void
     {
         $arguments = [
-            'prj_id' => (int)$prj_id,
-            'issue_id' => (int)$issue_id,
-            'usr_id' => (int)$usr_id,
             'issue_details' => $issue_details,
-            'new_assignees' => $new_assignees,
+            'new_assignees' => $new_assignees ?: [],
             'remote_assignment' => $remote_assignment,
         ];
 
-        $event = new GenericEvent(null, $arguments);
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
         EventManager::dispatch(SystemEvents::ISSUE_ASSIGNMENT_CHANGE, $event);
-
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleAssignmentChange($prj_id, $issue_id, $usr_id, $issue_details, $new_assignees, $remote_assignment);
     }
 
     /**

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -99,24 +99,6 @@ class Workflow
     }
 
     /**
-     * Checks whether the given project ID is setup to use workflow integration
-     * or not.
-     *
-     * @param   int $prj_id The project ID
-     * @return  bool
-     * @deprecated this method is not used by eventum
-     */
-    public static function hasWorkflowIntegration($prj_id)
-    {
-        $backend = self::_getBackendNameByProject($prj_id);
-        if (empty($backend)) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Is called when an issue is updated.
      *
      * @param   int $prj_id the project ID

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -373,10 +373,15 @@ class Workflow
      * @param   int $issue_id the ID of the issue
      * @since 3.8.13 emits MAIL_ASSOCIATED_MANUAL event
      * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.8.13 adds $target and $sup_ids to make method actually useful
      */
-    public static function handleManualEmailAssociation(int $prj_id, int $issue_id): void
+    public static function handleManualEmailAssociation(int $prj_id, int $issue_id, string $target, array $sup_ids): void
     {
-        $event = new EventContext($prj_id, $issue_id, null, []);
+        $arguments = [
+            'target' => $target,
+            'sup_ids' => $sup_ids,
+        ];
+        $event = new EventContext($prj_id, $issue_id, null, $arguments);
         EventManager::dispatch(SystemEvents::MAIL_ASSOCIATED_MANUAL, $event);
     }
 

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -232,14 +232,17 @@ class Workflow
      * @param   int $usr_id the id of the user who changed the issue
      * @param   array $old_details the old details of the issue
      * @param   array $changes The changes that were applied to this issue (the $_POST)
+     * @since 3.8.13 emits ISSUE_UPDATED_SEVERITY event
+     * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      */
-    public static function handleSeverityChange($prj_id, $issue_id, $usr_id, $old_details, $changes): void
+    public static function handleSeverityChange(int $prj_id, int $issue_id, int $usr_id, array $old_details, array $changes): void
     {
-        $backend = self::getBackend($prj_id);
-        if (!$backend) {
-            return;
-        }
-        $backend->handleSeverityChange($prj_id, $issue_id, $usr_id, $old_details, $changes);
+        $arguments = [
+            'old_details' => $old_details,
+            'changes' => $changes,
+        ];
+        $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
+        EventManager::dispatch(SystemEvents::ISSUE_UPDATED_SEVERITY, $event);
     }
 
     /**

--- a/lib/eventum/workflow/class.abstract_workflow_backend.php
+++ b/lib/eventum/workflow/class.abstract_workflow_backend.php
@@ -546,7 +546,6 @@ abstract class Abstract_Workflow_Backend
      *
      * @param   int $prj_id The ID of the project
      * @return  array An array of patterns and replacements
-     * @deprecated use ATTACHMENT_ATTACH_FILE event instead
      */
     public function getLinkFilters($prj_id)
     {

--- a/src/Controller/AssociateController.php
+++ b/src/Controller/AssociateController.php
@@ -89,16 +89,14 @@ class AssociateController extends BaseController
     // FIXME: get rid of $_POST
     public function associateAction(): void
     {
-        if ($this->target === 'email') {
-            $res = Support::associate($this->usr_id, $this->issue_id, $this->items);
-            if ($res == 1) {
-                Workflow::handleManualEmailAssociation($this->prj_id, $this->issue_id);
+        if (in_array($this->target, ['email', 'reference'], true)) {
+            if ($this->target === 'email') {
+                $res = Support::associate($this->usr_id, $this->issue_id, $this->items);
+            } else {
+                $res = Support::associateEmail($this->usr_id, $this->issue_id, $this->items);
             }
-            $this->tpl->assign('associate_result', $res);
-        } elseif ($this->target === 'reference') {
-            $res = Support::associateEmail($this->usr_id, $this->issue_id, $this->items);
             if ($res == 1) {
-                Workflow::handleManualEmailAssociation($this->prj_id, $this->issue_id);
+                Workflow::handleManualEmailAssociation($this->prj_id, $this->issue_id, $this->target, $this->items);
             }
             $this->tpl->assign('associate_result', $res);
         } else {

--- a/src/Event/EventContext.php
+++ b/src/Event/EventContext.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Event;
+
+use Symfony\Component\EventDispatcher\GenericEvent;
+
+class EventContext extends GenericEvent
+{
+    /** @var int */
+    public $prj_id;
+    /** @var int */
+    public $issue_id;
+    /** @var int */
+    public $usr_id;
+
+    public function __construct(int $prj_id, int $issue_id, int $usr_id, $arguments = [], $subject = null)
+    {
+        parent::__construct($subject, $arguments);
+        $this->setArgument('prj_id', $this->prj_id = $prj_id);
+        $this->setArgument('issue_id', $this->issue_id = $issue_id);
+        $this->setArgument('usr_id', $this->usr_id = $usr_id);
+    }
+
+    public function getProjectId(): int
+    {
+        return $this->prj_id;
+    }
+
+    public function getIssueId(): int
+    {
+        return $this->issue_id;
+    }
+
+    public function getUserId(): int
+    {
+        return $this->usr_id;
+    }
+}

--- a/src/Event/EventContext.php
+++ b/src/Event/EventContext.php
@@ -19,12 +19,12 @@ class EventContext extends GenericEvent
 {
     /** @var int */
     public $prj_id;
-    /** @var int */
+    /** @var int|null */
     public $issue_id;
-    /** @var int */
+    /** @var int|null */
     public $usr_id;
 
-    public function __construct(int $prj_id, int $issue_id, int $usr_id, $arguments = [], $subject = null)
+    public function __construct(int $prj_id, ?int $issue_id, ?int $usr_id, $arguments = [], $subject = null)
     {
         parent::__construct($subject, $arguments);
         $this->setArgument('prj_id', $this->prj_id = $prj_id);
@@ -37,12 +37,12 @@ class EventContext extends GenericEvent
         return $this->prj_id;
     }
 
-    public function getIssueId(): int
+    public function getIssueId(): ?int
     {
         return $this->issue_id;
     }
 
-    public function getUserId(): int
+    public function getUserId(): ?int
     {
         return $this->usr_id;
     }

--- a/src/Event/EventContext.php
+++ b/src/Event/EventContext.php
@@ -17,33 +17,26 @@ use Symfony\Component\EventDispatcher\GenericEvent;
 
 class EventContext extends GenericEvent
 {
-    /** @var int */
-    public $prj_id;
-    /** @var int|null */
-    public $issue_id;
-    /** @var int|null */
-    public $usr_id;
-
     public function __construct(int $prj_id, ?int $issue_id, ?int $usr_id, $arguments = [], $subject = null)
     {
         parent::__construct($subject, $arguments);
-        $this->setArgument('prj_id', $this->prj_id = $prj_id);
-        $this->setArgument('issue_id', $this->issue_id = $issue_id);
-        $this->setArgument('usr_id', $this->usr_id = $usr_id);
+        $this->setArgument('prj_id', $prj_id);
+        $this->setArgument('issue_id', $issue_id);
+        $this->setArgument('usr_id', $usr_id);
     }
 
     public function getProjectId(): int
     {
-        return $this->prj_id;
+        return $this->getArgument('prj_id');
     }
 
     public function getIssueId(): ?int
     {
-        return $this->issue_id;
+        return $this->getArgument('issue_id');
     }
 
     public function getUserId(): ?int
     {
-        return $this->usr_id;
+        return $this->getArgument('usr_id');
     }
 }

--- a/src/Event/ResultableEvent.php
+++ b/src/Event/ResultableEvent.php
@@ -14,14 +14,13 @@
 namespace Eventum\Event;
 
 use InvalidArgumentException;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
  * Event which has state.
  *
  * Event consumers should call setResult() to indicate they want that value to be outcome.
  */
-class ResultableEvent extends GenericEvent
+class ResultableEvent extends EventContext
 {
     /**
      * @var mixed any data except null

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -276,6 +276,12 @@ final class SystemEvents
 
     /**
      * @since 3.8.13
+     * @see Workflow::canUpdateIssue()
+     */
+    public const ACCESS_ISSUE_UPDATE = 'access.issue.update';
+
+    /**
+     * @since 3.8.13
      * @see Workflow::canChangeAccessLevel()
      */
     public const ACCESS_ISSUE_CHANGE_ACCESS = 'access.issue.change_access';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -149,6 +149,12 @@ final class SystemEvents
     public const ISSUE_UPDATED_BEFORE = 'issue.updated.before';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handlePriorityChange
+     */
+    public const ISSUE_UPDATED_PRIORITY = 'issue.updated.priority';
+
+    /**
      * @since 3.6.0
      * @see Issue::markAsDuplicate
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -233,6 +233,12 @@ final class SystemEvents
     public const ACCESS_ISSUE_NOTE = 'access.issue.note';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::canCloneIssue()
+     */
+    public const ACCESS_ISSUE_CLONE = 'access.issue.clone';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -227,6 +227,12 @@ final class SystemEvents
     public const ACCESS_ISSUE_EMAIL = 'access.issue.email';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::canSendNote()
+     */
+    public const ACCESS_ISSUE_NOTE = 'access.issue.note';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -221,6 +221,12 @@ final class SystemEvents
     public const ISSUE_EMAIL_CREATE_OPTIONS = 'issue.email.create.options';
 
     /**
+     * @since 3.5.0
+     * @see Workflow::preStatusChange
+     */
+    public const ISSUE_STATUS_BEFORE = 'issue.status.before';
+
+    /**
      * @since 3.6.3
      * @see Workflow::getAllowedStatuses()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -299,6 +299,12 @@ final class SystemEvents
     public const AUTHORIZED_REPLIER_ADD = 'authorized_replier.add';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::getActiveGroup()
+     */
+    public const GROUP_ACTIVE = 'group.active';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -25,6 +25,12 @@ final class SystemEvents
     public const ATTACHMENT_ATTACH_FILE = 'attachment.attach.file';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handleAttachment
+     */
+    public const ATTACHMENT_ATTACHMENT_GROUP = 'attachment.attach.group';
+
+    /**
      * Event fired when history entry is added
      *
      * @since 3.3.0

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -155,6 +155,12 @@ final class SystemEvents
     public const ISSUE_UPDATED_PRIORITY = 'issue.updated.priority';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handlePriorityChange
+     */
+    public const ISSUE_UPDATED_SEVERITY = 'issue.updated.severity';
+
+    /**
      * @since 3.6.0
      * @see Issue::markAsDuplicate
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -132,6 +132,12 @@ final class SystemEvents
     public const NOTIFICATION_NOTIFY_ADDRESS = 'notification.notify.address';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::getAdditionalEmailAddresses()
+     */
+    public const NOTIFICATION_NOTIFY_ADDRESSES_EXTRA = 'notification.notify.addresses.extra';
+
+    /**
      * @since 3.6.3
      * @see Workflow::handleSubscription()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -251,6 +251,18 @@ final class SystemEvents
     public const ISSUE_FIELDS_DISPLAY = 'issue.fields.display';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handleIssueMovedFromProject
+     */
+    public const ISSUE_MOVE_FROM_PROJECT = 'issue.move.from_project';
+
+    /**
+     * @since 3.8.13
+     * @see Workflow::handleIssueMovedToProject
+     */
+    public const ISSUE_MOVE_TO_PROJECT = 'issue.move.to_project';
+
+    /**
      * @since 3.8.11
      * @see Workflow::canAccessIssue()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -239,6 +239,12 @@ final class SystemEvents
     public const ACCESS_ISSUE_CLONE = 'access.issue.clone';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::canChangeAccessLevel()
+     */
+    public const ACCESS_ISSUE_CHANGE_ACCESS = 'access.issue.change_access';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -245,6 +245,12 @@ final class SystemEvents
     public const ISSUE_LINK_FILTERS = 'issue.link.filters';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::getIssueFieldsToDisplay
+     */
+    public const ISSUE_FIELDS_DISPLAY = 'issue.fields.display';
+
+    /**
      * @since 3.8.11
      * @see Workflow::canAccessIssue()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -156,6 +156,12 @@ final class SystemEvents
     public const PROJECT_NOTIFICATION_AUTO_ADD = 'project.notification.auto_add';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::getNotificationActions
+     */
+    public const NOTIFICATION_ACTIONS = 'notitication.actions';
+
+    /**
      * @since 3.4.2
      */
     public const IRC_NOTIFY = 'irc.notify';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -114,6 +114,12 @@ final class SystemEvents
     public const MAIL_CREATED = 'mail.created';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handleManualEmailAssociation
+     */
+    public const MAIL_ASSOCIATED_MANUAL = 'mail.associated.manual';
+
+    /**
      * @since 3.6.0
      * @see Workflow::shouldEmailAddress()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -120,6 +120,12 @@ final class SystemEvents
     public const MAIL_ASSOCIATED_MANUAL = 'mail.associated.manual';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handleCustomFieldsUpdated()
+     */
+    public const CUSTOM_FIELDS_UPDATED = 'custom_field.updated';
+
+    /**
      * @since 3.6.0
      * @see Workflow::shouldEmailAddress()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -299,6 +299,12 @@ final class SystemEvents
     public const REMINDER_ACTION_PERFORM = 'reminder.action.perform';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::prePage()
+     */
+    public const PAGE_BEFORE = 'page.before';
+
+    /**
      * @since 3.4.2
      */
     public const IRC_FORMAT_MESSAGE = 'irc.format.message';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -102,6 +102,12 @@ final class SystemEvents
     public const MAIL_QUEUE_ERROR = 'mail.queue.error';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::modifyMailQueue
+     */
+    public const MAIL_QUEUE_MODIFY = 'mail.queue.modify';
+
+    /**
      * @since 3.4.2
      * @see Workflow::handleNewEmail()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -257,6 +257,12 @@ final class SystemEvents
     public const ACCESS_ISSUE = 'access.issue';
 
     /**
+     * @since 3.8.11
+     * @see Workflow::getAccessLevels()
+     */
+    public const ACCESS_LEVELS = 'access.levels';
+
+    /**
      * @since 3.8.13
      * @see Workflow::canEmailIssue()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -263,6 +263,12 @@ final class SystemEvents
     public const ISSUE_MOVE_TO_PROJECT = 'issue.move.to_project';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::getMovedIssueMapping
+     */
+    public const ISSUE_MOVE_MAPPING = 'issue.move.mapping';
+
+    /**
      * @since 3.8.11
      * @see Workflow::canAccessIssue()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -144,6 +144,12 @@ final class SystemEvents
     public const NOTIFICATION_HANDLE_SUBSCRIPTION = 'notification.handle.subscription';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::shouldAutoAddToNotificationList
+     */
+    public const PROJECT_NOTIFICATION_AUTO_ADD = 'project.notification.auto_add';
+
+    /**
      * @since 3.4.2
      */
     public const IRC_NOTIFY = 'irc.notify';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -209,6 +209,12 @@ final class SystemEvents
     public const ISSUE_UPDATED = 'issue.updated';
 
     /**
+     * @since 3.5.0
+     * @see Workflow::getIssueIDForNewEmail()
+     */
+    public const ISSUE_EMAIL_CREATE_OPTIONS = 'issue.email.create.options';
+
+    /**
      * @since 3.6.3
      * @see Workflow::getAllowedStatuses()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -245,6 +245,12 @@ final class SystemEvents
     public const ACCESS_ISSUE_CHANGE_ACCESS = 'access.issue.change_access';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::handleAuthorizedReplierAdded()
+     */
+    public const AUTHORIZED_REPLIER_ADD = 'authorized_replier.add';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -264,6 +264,12 @@ final class SystemEvents
 
     /**
      * @since 3.8.13
+     * @see Workflow::getAdditionalAccessSQL()
+     */
+    public const ACCESS_LISTING_SQL = 'access.listing.sql';
+
+    /**
+     * @since 3.8.13
      * @see Workflow::canEmailIssue()
      */
     public const ACCESS_ISSUE_EMAIL = 'access.issue.email';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -221,6 +221,12 @@ final class SystemEvents
     public const ACCESS_ISSUE = 'access.issue';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::canEmailIssue()
+     */
+    public const ACCESS_ISSUE_EMAIL = 'access.issue.email';
+
+    /**
      * @since 3.5.0
      * @see Workflow::handleNewNote()
      */

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -288,6 +288,12 @@ final class SystemEvents
 
     /**
      * @since 3.8.13
+     * @see Workflow::ACCESS_ISSUE_UPDATE()
+     */
+    public const ACCESS_ISSUE_CHANGE_ASSIGNEE = 'access.issue.change_assignee';
+
+    /**
+     * @since 3.8.13
      * @see Workflow::handleAuthorizedReplierAdded()
      */
     public const AUTHORIZED_REPLIER_ADD = 'authorized_replier.add';

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -257,6 +257,12 @@ final class SystemEvents
     public const NOTE_CREATED = 'note.created';
 
     /**
+     * @since 3.8.13
+     * @see Workflow::preNoteInsert
+     */
+    public const NOTE_INSERT_BEFORE = 'note.insert.before';
+
+    /**
      * @since 3.4.2
      * @see Notification::notifyNewIssue()
      */

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -106,6 +106,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_FIELDS_DISPLAY => 'getIssueFieldsToDisplay',
             /** @see WorkflowLegacyExtension::addLinkFilters */
             SystemEvents::ISSUE_LINK_FILTERS => 'addLinkFilters',
+            /** @see WorkflowLegacyExtension::canUpdateIssue */
+            SystemEvents::ACCESS_ISSUE_UPDATE => 'canUpdateIssue',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -542,6 +544,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         /** @var LinkFilter $linkFilter */
         $linkFilter = $event->getSubject();
         $linkFilter->addRules($backend->getLinkFilters($event->getProjectId()));
+    }
+
+    /**
+     * @see Workflow::canUpdateIssue
+     */
+    public function canUpdateIssue(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->canUpdateIssue($event->getProjectId(), $event->getIssueId(), $event->getUserId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -56,6 +56,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_ASSIGNMENT_CHANGE => 'handleAssignmentChange',
             /** @see WorkflowLegacyExtension::handleNewIssue */
             SystemEvents::ISSUE_CREATED => 'handleNewIssue',
+            /** @see WorkflowLegacyExtension::handleManualEmailAssociation */
+            SystemEvents::MAIL_ASSOCIATED_MANUAL => 'handleManualEmailAssociation',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -187,6 +189,18 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $has_TAM = $event['has_TAM'];
         $has_RR = $event['has_RR'];
         $backend->handleNewIssue($event->getProjectId(), $event->getIssueId(), $has_TAM, $has_RR);
+    }
+
+    /**
+     * @see Workflow::handleManualEmailAssociation
+     */
+    public function handleManualEmailAssociation(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $backend->handleManualEmailAssociation($event->getProjectId(), $event->getIssueId());
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -19,6 +19,7 @@ use Eventum\Event\EventContext;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\Extension\Provider;
+use Eventum\Mail\MailMessage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Symfony\Component\EventDispatcher\GenericEvent;
 use Workflow;
@@ -75,6 +76,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::NOTIFICATION_NOTIFY_ADDRESSES_EXTRA => 'getAdditionalEmailAddresses',
             /** @see WorkflowLegacyExtension::canEmailIssue */
             SystemEvents::ACCESS_ISSUE_EMAIL => 'canEmailIssue',
+            /** @see WorkflowLegacyExtension::canSendNote */
+            SystemEvents::ACCESS_ISSUE_NOTE => 'canSendNote',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -263,6 +266,26 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $address = $event->getSubject();
         $email = $address->getEmail();
         $result = $backend->canEmailIssue($event->getProjectId(), $event->getIssueId(), $email);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::canSendNote
+     */
+    public function canSendNote(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var Address $address */
+        $address = $event->getSubject();
+        $email = $address->getEmail();
+        /** @var MailMessage $mailMessage */
+        $mail = $event['mail'];
+        $result = $backend->canSendNote($event->getProjectId(), $event->getIssueId(), $email, $mail);
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -58,6 +58,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_CREATED => 'handleNewIssue',
             /** @see WorkflowLegacyExtension::handleManualEmailAssociation */
             SystemEvents::MAIL_ASSOCIATED_MANUAL => 'handleManualEmailAssociation',
+            /** @see WorkflowLegacyExtension::handleNewNote */
+            SystemEvents::NOTE_CREATED => 'handleNewNote',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -189,6 +191,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $has_TAM = $event['has_TAM'];
         $has_RR = $event['has_RR'];
         $backend->handleNewIssue($event->getProjectId(), $event->getIssueId(), $has_TAM, $has_RR);
+    }
+
+    /**
+     * @see Workflow::handleNewNote
+     */
+    public function handleNewNote(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $closing = $event['closing'];
+        $note_id = $event['note_id'];
+        $backend->handleNewNote($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $closing, $note_id);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -50,6 +50,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_UPDATED_PRIORITY => 'handlePriorityChange',
             /** @see WorkflowLegacyExtension::handleSeverityChange */
             SystemEvents::ISSUE_UPDATED_SEVERITY => 'handleSeverityChange',
+            /** @see WorkflowLegacyExtension::handleBlockedEmail */
+            SystemEvents::EMAIL_BLOCKED => 'handleBlockedEmail',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -137,6 +139,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $old_details = $event['old_details'];
         $changes = $event['changes'];
         $backend->handleSeverityChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $old_details, $changes);
+    }
+
+    /**
+     * @see Workflow::handleBlockedEmail
+     */
+    public function handleBlockedEmail(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $email_details = $event['email_details'];
+        $type = $event['type'];
+        $backend->handleBlockedEmail($event->getProjectId(), $event->getIssueId(), $email_details, $type);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -82,6 +82,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE_CLONE => 'canCloneIssue',
             /** @see WorkflowLegacyExtension::canChangeAccessLevel */
             SystemEvents::ACCESS_ISSUE_CHANGE_ACCESS => 'canChangeAccessLevel',
+            /** @see WorkflowLegacyExtension::handleAuthorizedReplierAdded */
+            SystemEvents::AUTHORIZED_REPLIER_ADD => 'handleAuthorizedReplierAdded',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -322,6 +324,29 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $result = $backend->canChangeAccessLevel($event->getProjectId(), $event->getIssueId(), $event->getUserId());
         if ($result !== null) {
             $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::canChangeAccessLevel
+     */
+    public function handleAuthorizedReplierAdded(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var Address $address */
+        $address = $event->getSubject();
+        $email = $address->getEmail();
+        $result = $backend->handleAuthorizedReplierAdded($event->getProjectId(), $event->getIssueId(), $email);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+
+        // assign back, in case it was modified
+        if ($email !== $address->getEmail()) {
+            $event['email'] = $email;
         }
     }
 

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -66,6 +66,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_CLOSED => 'handleIssueClosed',
             /** @see WorkflowLegacyExtension::handleCustomFieldsUpdated */
             SystemEvents::CUSTOM_FIELDS_UPDATED => 'handleCustomFieldsUpdated',
+            /** @see WorkflowLegacyExtension::handleSubscription */
+            SystemEvents::NOTIFICATION_HANDLE_SUBSCRIPTION => 'handleSubscription',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -182,6 +184,29 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $new = $event['new'];
         $changed = $event['changed'];
         $backend->handleCustomFieldsUpdated($event->getProjectId(), $event->getIssueId(), $old, $new, $changed);
+    }
+
+    /**
+     * @see Workflow::handleSubscription
+     */
+    public function handleSubscription(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $subscriber_usr_id = $event['subscriber_usr_id'];
+        $email = $event['email'];
+        $actions = $event['actions'];
+
+        $result = $backend->handleSubscription($event->getProjectId(), $event->getIssueId(), $subscriber_usr_id, $email, $actions);
+
+        // assign back, in case these were modified
+        $event['subscriber_usr_id'] = $subscriber_usr_id;
+        $event['email'] = $email;
+        $event['actions'] = $actions;
+
+        $event->setResult($result);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -89,6 +89,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::MAIL_PROCESS_BEFORE => 'preEmailDownload',
             /** @see WorkflowLegacyExtension::preNoteInsert */
             SystemEvents::NOTE_INSERT_BEFORE => 'preNoteInsert',
+            /** @see WorkflowLegacyExtension::shouldAutoAddToNotificationList */
+            SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD => 'shouldAutoAddToNotificationList',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -391,6 +393,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
 
         // assign back, in case it was modified
         $event['data'] = $data;
+    }
+
+    /**
+     * @see Workflow::shouldAutoAddToNotificationList
+     */
+    public function shouldAutoAddToNotificationList(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->shouldAutoAddToNotificationList($event->getProjectId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -122,6 +122,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_MOVE_FROM_PROJECT => 'handleIssueMovedFromProject',
             /** @see WorkflowLegacyExtension::handleIssueMovedToProject */
             SystemEvents::ISSUE_MOVE_TO_PROJECT => 'handleIssueMovedToProject',
+            /** @see WorkflowLegacyExtension::getMovedIssueMapping */
+            SystemEvents::ISSUE_MOVE_MAPPING => 'getMovedIssueMapping',
         ];
     }
 
@@ -716,6 +718,23 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
 
         $prj_id = $event['old_prj_id'];
         $backend->handleIssueMovedToProject($event->getProjectId(), $event->getIssueId(), $prj_id);
+    }
+
+    /**
+     * @see Workflow::getMovedIssueMapping
+     */
+    public function getMovedIssueMapping(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $mapping = $event->getResult();
+        $old_prj_id = $event['old_prj_id'];
+        $result = $backend->getMovedIssueMapping($event->getProjectId(), $event->getIssueId(), $mapping, $old_prj_id);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -54,6 +54,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::EMAIL_BLOCKED => 'handleBlockedEmail',
             /** @see WorkflowLegacyExtension::handleAssignmentChange */
             SystemEvents::ISSUE_ASSIGNMENT_CHANGE => 'handleAssignmentChange',
+            /** @see WorkflowLegacyExtension::handleNewIssue */
+            SystemEvents::ISSUE_CREATED => 'handleNewIssue',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -171,6 +173,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $remote_assignment = $event['remote_assignment'];
 
         $backend->handleAssignmentChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $issue_details, $new_assignees, $remote_assignment);
+    }
+
+    /**
+     * @see Workflow::handleNewIssue
+     */
+    public function handleNewIssue(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $has_TAM = $event['has_TAM'];
+        $has_RR = $event['has_RR'];
+        $backend->handleNewIssue($event->getProjectId(), $event->getIssueId(), $has_TAM, $has_RR);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -19,6 +19,7 @@ use Eventum\Event\EventContext;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\Extension\Provider;
+use Eventum\LinkFilter\LinkFilter;
 use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailMessage;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
@@ -103,6 +104,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::NOTIFICATION_ACTIONS => 'getNotificationActions',
             /** @see WorkflowLegacyExtension::getIssueFieldsToDisplay */
             SystemEvents::ISSUE_FIELDS_DISPLAY => 'getIssueFieldsToDisplay',
+            /** @see WorkflowLegacyExtension::addLinkFilters */
+            SystemEvents::ISSUE_LINK_FILTERS => 'addLinkFilters',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -525,6 +528,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         if ($result !== null) {
             $event->setResult($result);
         }
+    }
+
+    /**
+     * @see Workflow::addLinkFilters
+     */
+    public function addLinkFilters(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var LinkFilter $linkFilter */
+        $linkFilter = $event->getSubject();
+        $linkFilter->addRules($backend->getLinkFilters($event->getProjectId()));
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -14,6 +14,8 @@
 namespace Eventum\Extension\Legacy;
 
 use Abstract_Workflow_Backend;
+use Eventum\Attachment\AttachmentGroup;
+use Eventum\Event\EventContext;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\Extension\Provider;
@@ -40,6 +42,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_UPDATED => 'handleIssueUpdated',
             /** @see WorkflowLegacyExtension::preIssueUpdated */
             SystemEvents::ISSUE_UPDATED_BEFORE => 'preIssueUpdated',
+            /** @see WorkflowLegacyExtension::handleAttachment */
+            SystemEvents::ATTACHMENT_ATTACHMENT_GROUP => 'handleAttachment',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -70,6 +74,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         if ($result !== true) {
             $event->stopPropagation();
         }
+    }
+
+    /**
+     * @see Workflow::handleAttachment
+     */
+    public function handleAttachment(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var AttachmentGroup $attachmentGroup */
+        $attachmentGroup = $event->getSubject();
+        $backend->handleAttachment($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $attachmentGroup);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -78,6 +78,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE_EMAIL => 'canEmailIssue',
             /** @see WorkflowLegacyExtension::canSendNote */
             SystemEvents::ACCESS_ISSUE_NOTE => 'canSendNote',
+            /** @see WorkflowLegacyExtension::canCloneIssue */
+            SystemEvents::ACCESS_ISSUE_CLONE => 'canCloneIssue',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -286,6 +288,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         /** @var MailMessage $mailMessage */
         $mail = $event['mail'];
         $result = $backend->canSendNote($event->getProjectId(), $event->getIssueId(), $email, $mail);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::canCloneIssue
+     */
+    public function canCloneIssue(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->canCloneIssue($event->getProjectId(), $event->getIssueId(), $event->getUserId());
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -68,6 +68,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::CUSTOM_FIELDS_UPDATED => 'handleCustomFieldsUpdated',
             /** @see WorkflowLegacyExtension::handleSubscription */
             SystemEvents::NOTIFICATION_HANDLE_SUBSCRIPTION => 'handleSubscription',
+            /** @see WorkflowLegacyExtension::shouldEmailAddress */
+            SystemEvents::NOTIFICATION_NOTIFY_ADDRESS => 'shouldEmailAddress',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -207,6 +209,23 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $event['actions'] = $actions;
 
         $event->setResult($result);
+    }
+
+    /**
+     * @see Workflow::shouldEmailAddress
+     */
+    public function shouldEmailAddress(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $address = $event['address'];
+        $type = $event['type'];
+        $result = $backend->shouldEmailAddress($event->getProjectId(), $address, $event->getIssueId(), $type);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -48,6 +48,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ATTACHMENT_ATTACH_FILE => 'shouldAttachFile',
             /** @see WorkflowLegacyExtension::handlePriorityChange */
             SystemEvents::ISSUE_UPDATED_PRIORITY => 'handlePriorityChange',
+            /** @see WorkflowLegacyExtension::handleSeverityChange */
+            SystemEvents::ISSUE_UPDATED_SEVERITY => 'handleSeverityChange',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -121,6 +123,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $old_details = $event['old_details'];
         $changes = $event['changes'];
         $backend->handlePriorityChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $old_details, $changes);
+    }
+
+    /**
+     * @see Workflow::handleSeverityChange
+     */
+    public function handleSeverityChange(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $old_details = $event['old_details'];
+        $changes = $event['changes'];
+        $backend->handleSeverityChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $old_details, $changes);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -99,6 +99,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_STATUS_BEFORE => 'preStatusChange',
             /** @see WorkflowLegacyExtension::prePage */
             SystemEvents::PAGE_BEFORE => 'prePage',
+            /** @see WorkflowLegacyExtension::getNotificationActions */
+            SystemEvents::NOTIFICATION_ACTIONS => 'getNotificationActions',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -488,6 +490,23 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
 
         $page_name = $event->getSubject();
         $backend->prePage($event->getProjectId(), $page_name);
+    }
+
+    /**
+     * @see Workflow::getNotificationActions
+     */
+    public function getNotificationActions(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $source = $event['source'];
+        $email = $event['email'];
+        $result = $backend->getNotificationActions($event->getProjectId(), $event->getIssueId(), $email, $source);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -97,6 +97,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::MAIL_QUEUE_MODIFY => 'modifyMailQueue',
             /** @see WorkflowLegacyExtension::preStatusChange */
             SystemEvents::ISSUE_STATUS_BEFORE => 'preStatusChange',
+            /** @see WorkflowLegacyExtension::prePage */
+            SystemEvents::PAGE_BEFORE => 'prePage',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -473,6 +475,19 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $event['issue_id'] = $issue_id;
         $event['status_id'] = $status_id;
         $event['notify'] = $notify;
+    }
+
+    /**
+     * @see Workflow::prePage
+     */
+    public function prePage(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $page_name = $event->getSubject();
+        $backend->prePage($event->getProjectId(), $page_name);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -116,6 +116,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_LEVELS => 'getAccessLevels',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
+            /** @see WorkflowLegacyExtension::getAdditionalAccessSQL */
+            SystemEvents::ACCESS_LISTING_SQL => 'getAdditionalAccessSQL',
         ];
     }
 
@@ -708,6 +710,22 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->canAccessIssue($event['prj_id'], $event['issue_id'], $event['usr_id']);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::getAdditionalAccessSQL
+     */
+    public function getAdditionalAccessSQL(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->getAdditionalAccessSQL($event->getProjectId(), $event->getUserId());
+
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -112,6 +112,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE => 'canChangeAssignee',
             /** @see WorkflowLegacyExtension::getActiveGroup */
             SystemEvents::GROUP_ACTIVE => 'getActiveGroup',
+            /** @see WorkflowLegacyExtension::getAccessLevels */
+            SystemEvents::ACCESS_LEVELS => 'getAccessLevels',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -590,6 +592,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->getActiveGroup($event->getProjectId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::getAccessLevels
+     */
+    public function getAccessLevels(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->getAccessLevels($event->getProjectId());
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -70,6 +70,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::NOTIFICATION_HANDLE_SUBSCRIPTION => 'handleSubscription',
             /** @see WorkflowLegacyExtension::shouldEmailAddress */
             SystemEvents::NOTIFICATION_NOTIFY_ADDRESS => 'shouldEmailAddress',
+            /** @see WorkflowLegacyExtension::getAdditionalEmailAddresses */
+            SystemEvents::NOTIFICATION_NOTIFY_ADDRESSES_EXTRA => 'getAdditionalEmailAddresses',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -223,6 +225,23 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $address = $event['address'];
         $type = $event['type'];
         $result = $backend->shouldEmailAddress($event->getProjectId(), $address, $event->getIssueId(), $type);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::shouldEmailAddress
+     */
+    public function getAdditionalEmailAddresses(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $eventName = $event['eventName'];
+        $extra = $event['extra'];
+        $result = $backend->getAdditionalEmailAddresses($event->getProjectId(), $event->getIssueId(), $eventName, $extra);
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -101,6 +101,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::PAGE_BEFORE => 'prePage',
             /** @see WorkflowLegacyExtension::getNotificationActions */
             SystemEvents::NOTIFICATION_ACTIONS => 'getNotificationActions',
+            /** @see WorkflowLegacyExtension::getIssueFieldsToDisplay */
+            SystemEvents::ISSUE_FIELDS_DISPLAY => 'getIssueFieldsToDisplay',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -504,6 +506,22 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $source = $event['source'];
         $email = $event['email'];
         $result = $backend->getNotificationActions($event->getProjectId(), $event->getIssueId(), $email, $source);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::getIssueFieldsToDisplay
+     */
+    public function getIssueFieldsToDisplay(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $location = $event->getSubject();
+        $result = $backend->getIssueFieldsToDisplay($event->getProjectId(), $event->getIssueId(), $location);
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -110,6 +110,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE_UPDATE => 'canUpdateIssue',
             /** @see WorkflowLegacyExtension::canChangeAssignee */
             SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE => 'canChangeAssignee',
+            /** @see WorkflowLegacyExtension::getActiveGroup */
+            SystemEvents::GROUP_ACTIVE => 'getActiveGroup',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -573,6 +575,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->canUpdateIssue($event->getProjectId(), $event->getIssueId(), $event->getUserId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::getActiveGroup
+     */
+    public function getActiveGroup(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->getActiveGroup($event->getProjectId());
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -87,6 +87,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::AUTHORIZED_REPLIER_ADD => 'handleAuthorizedReplierAdded',
             /** @see WorkflowLegacyExtension::preEmailDownload */
             SystemEvents::MAIL_PROCESS_BEFORE => 'preEmailDownload',
+            /** @see WorkflowLegacyExtension::preNoteInsert */
+            SystemEvents::NOTE_INSERT_BEFORE => 'preNoteInsert',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -369,6 +371,26 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         if ($result === -1) {
             $event->stopPropagation();
         }
+    }
+
+    /**
+     * @see Workflow::preNoteInsert
+     */
+    public function preNoteInsert(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var array $data */
+        $data = $event->getSubject();
+        $result = $backend->preNoteInsert($event->getProjectId(), $event->getIssueId(), $data);
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+
+        // assign back, in case it was modified
+        $event['data'] = $data;
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -118,6 +118,10 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
             /** @see WorkflowLegacyExtension::getAdditionalAccessSQL */
             SystemEvents::ACCESS_LISTING_SQL => 'getAdditionalAccessSQL',
+            /** @see WorkflowLegacyExtension::handleIssueMovedFromProject */
+            SystemEvents::ISSUE_MOVE_FROM_PROJECT => 'handleIssueMovedFromProject',
+            /** @see WorkflowLegacyExtension::handleIssueMovedToProject */
+            SystemEvents::ISSUE_MOVE_TO_PROJECT => 'handleIssueMovedToProject',
         ];
     }
 
@@ -686,6 +690,32 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $reason = $event['reason'];
 
         $backend->handleIssueClosed($event->getProjectId(), $event->getIssueId(), $send_notification, $resolution_id, $status_id, $reason, $event->getUserId());
+    }
+
+    /**
+     * @see Workflow::handleIssueMovedFromProject
+     */
+    public function handleIssueMovedFromProject(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $prj_id = $event['new_prj_id'];
+        $backend->handleIssueMovedFromProject($event->getProjectId(), $event->getIssueId(), $prj_id);
+    }
+
+    /**
+     * @see Workflow::handleIssueMovedToProject
+     */
+    public function handleIssueMovedToProject(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $prj_id = $event['old_prj_id'];
+        $backend->handleIssueMovedToProject($event->getProjectId(), $event->getIssueId(), $prj_id);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -64,6 +64,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_ALLOWED_STATUSES => 'getAllowedStatuses',
             /** @see WorkflowLegacyExtension::handleIssueClosed */
             SystemEvents::ISSUE_CLOSED => 'handleIssueClosed',
+            /** @see WorkflowLegacyExtension::handleCustomFieldsUpdated */
+            SystemEvents::CUSTOM_FIELDS_UPDATED => 'handleCustomFieldsUpdated',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -165,6 +167,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $email_details = $event['email_details'];
         $type = $event['type'];
         $backend->handleBlockedEmail($event->getProjectId(), $event->getIssueId(), $email_details, $type);
+    }
+
+    /**
+     * @see Workflow::handleCustomFieldsUpdated
+     */
+    public function handleCustomFieldsUpdated(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $old = $event['old'];
+        $new = $event['new'];
+        $changed = $event['changed'];
+        $backend->handleCustomFieldsUpdated($event->getProjectId(), $event->getIssueId(), $old, $new, $changed);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -108,6 +108,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_LINK_FILTERS => 'addLinkFilters',
             /** @see WorkflowLegacyExtension::canUpdateIssue */
             SystemEvents::ACCESS_ISSUE_UPDATE => 'canUpdateIssue',
+            /** @see WorkflowLegacyExtension::canChangeAssignee */
+            SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE => 'canChangeAssignee',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -346,6 +348,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->canChangeAccessLevel($event->getProjectId(), $event->getIssueId(), $event->getUserId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::canChangeAssignee
+     */
+    public function canChangeAssignee(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->canChangeAssignee($event->getProjectId(), $event->getIssueId(), $event->getUserId());
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -44,6 +44,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_UPDATED_BEFORE => 'preIssueUpdated',
             /** @see WorkflowLegacyExtension::handleAttachment */
             SystemEvents::ATTACHMENT_ATTACHMENT_GROUP => 'handleAttachment',
+            /** @see WorkflowLegacyExtension::shouldAttachFile */
+            SystemEvents::ATTACHMENT_ATTACH_FILE => 'shouldAttachFile',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -88,6 +90,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         /** @var AttachmentGroup $attachmentGroup */
         $attachmentGroup = $event->getSubject();
         $backend->handleAttachment($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $attachmentGroup);
+    }
+
+    /**
+     * @see Workflow::shouldAttachFile
+     */
+    public function shouldAttachFile(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var array $attachment */
+        $attachment = $event->getSubject();
+        $result = $backend->shouldAttachFile($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $attachment);
+        $event->setResult($result);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -91,6 +91,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::NOTE_INSERT_BEFORE => 'preNoteInsert',
             /** @see WorkflowLegacyExtension::shouldAutoAddToNotificationList */
             SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD => 'shouldAutoAddToNotificationList',
+            /** @see WorkflowLegacyExtension::getIssueIDForNewEmail */
+            SystemEvents::ISSUE_EMAIL_CREATE_OPTIONS => 'getIssueIDForNewEmail',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -405,6 +407,24 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->shouldAutoAddToNotificationList($event->getProjectId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::getIssueIDForNewEmail
+     */
+    public function getIssueIDForNewEmail(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var MailMessage $mail */
+        $mail = $event->getSubject();
+        $account = $event['account'];
+        $result = $backend->getIssueIDForNewEmail($event->getProjectId(), $account, $mail);
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -132,25 +132,27 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
     /**
      * @see Workflow::handleIssueUpdated
      */
-    public function handleIssueUpdated(GenericEvent $event): void
+    public function handleIssueUpdated(EventContext $event): void
     {
         if (!$backend = $this->getBackend($event)) {
             return;
         }
 
-        $backend->handleIssueUpdated($event['prj_id'], $event['issue_id'], $event['usr_id'], $event['old_details'], $event['raw_post']);
+        $old_details = $event['old_details'];
+        $changes = $event['raw_post'];
+        $backend->handleIssueUpdated($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $old_details, $changes);
     }
 
     /**
      * @see Workflow::preIssueUpdated
      */
-    public function preIssueUpdated(GenericEvent $event): void
+    public function preIssueUpdated(EventContext $event): void
     {
         if (!$backend = $this->getBackend($event)) {
             return;
         }
 
-        $result = $backend->preIssueUpdated($event['prj_id'], $event['issue_id'], $event['usr_id'], $event['changes']);
+        $result = $backend->preIssueUpdated($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $event['changes']);
         if ($result !== true) {
             $event->stopPropagation();
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -93,6 +93,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD => 'shouldAutoAddToNotificationList',
             /** @see WorkflowLegacyExtension::getIssueIDForNewEmail */
             SystemEvents::ISSUE_EMAIL_CREATE_OPTIONS => 'getIssueIDForNewEmail',
+            /** @see WorkflowLegacyExtension::modifyMailQueue */
+            SystemEvents::MAIL_QUEUE_MODIFY => 'modifyMailQueue',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -428,6 +430,24 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         if ($result !== null) {
             $event->setResult($result);
         }
+    }
+
+    /**
+     * @see Workflow::modifyMailQueue
+     */
+    public function modifyMailQueue(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var MailMessage $mail */
+        $mail = $event->getSubject();
+        /** @var Address $recipient */
+        $address = $event['address'];
+        /** @var array $options */
+        $options = $event['options'];
+        $backend->modifyMailQueue($event->getProjectId(), $address->getEmail(), $mail, $options);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -52,6 +52,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_UPDATED_SEVERITY => 'handleSeverityChange',
             /** @see WorkflowLegacyExtension::handleBlockedEmail */
             SystemEvents::EMAIL_BLOCKED => 'handleBlockedEmail',
+            /** @see WorkflowLegacyExtension::handleAssignmentChange */
+            SystemEvents::ISSUE_ASSIGNMENT_CHANGE => 'handleAssignmentChange',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -153,6 +155,22 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $email_details = $event['email_details'];
         $type = $event['type'];
         $backend->handleBlockedEmail($event->getProjectId(), $event->getIssueId(), $email_details, $type);
+    }
+
+    /**
+     * @see Workflow::handleAssignmentChange
+     */
+    public function handleAssignmentChange(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $issue_details = $event['issue_details'];
+        $new_assignees = $event['new_assignees'];
+        $remote_assignment = $event['remote_assignment'];
+
+        $backend->handleAssignmentChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $issue_details, $new_assignees, $remote_assignment);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -60,6 +60,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::MAIL_ASSOCIATED_MANUAL => 'handleManualEmailAssociation',
             /** @see WorkflowLegacyExtension::handleNewNote */
             SystemEvents::NOTE_CREATED => 'handleNewNote',
+            /** @see WorkflowLegacyExtension::getAllowedStatuses */
+            SystemEvents::ISSUE_ALLOWED_STATUSES => 'getAllowedStatuses',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -205,6 +207,19 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $closing = $event['closing'];
         $note_id = $event['note_id'];
         $backend->handleNewNote($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $closing, $note_id);
+    }
+
+    /**
+     * @see Workflow::getAllowedStatuses
+     */
+    public function getAllowedStatuses(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->getAllowedStatuses($event->getProjectId(), $event->getIssueId());
+        $event->setResult($result);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -80,6 +80,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ACCESS_ISSUE_NOTE => 'canSendNote',
             /** @see WorkflowLegacyExtension::canCloneIssue */
             SystemEvents::ACCESS_ISSUE_CLONE => 'canCloneIssue',
+            /** @see WorkflowLegacyExtension::canChangeAccessLevel */
+            SystemEvents::ACCESS_ISSUE_CHANGE_ACCESS => 'canChangeAccessLevel',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -303,6 +305,21 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         $result = $backend->canCloneIssue($event->getProjectId(), $event->getIssueId(), $event->getUserId());
+        if ($result !== null) {
+            $event->setResult($result);
+        }
+    }
+
+    /**
+     * @see Workflow::canChangeAccessLevel
+     */
+    public function canChangeAccessLevel(ResultableEvent $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $result = $backend->canChangeAccessLevel($event->getProjectId(), $event->getIssueId(), $event->getUserId());
         if ($result !== null) {
             $event->setResult($result);
         }

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -62,6 +62,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::NOTE_CREATED => 'handleNewNote',
             /** @see WorkflowLegacyExtension::getAllowedStatuses */
             SystemEvents::ISSUE_ALLOWED_STATUSES => 'getAllowedStatuses',
+            /** @see WorkflowLegacyExtension::handleIssueClosed */
+            SystemEvents::ISSUE_CLOSED => 'handleIssueClosed',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -220,6 +222,23 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
 
         $result = $backend->getAllowedStatuses($event->getProjectId(), $event->getIssueId());
         $event->setResult($result);
+    }
+
+    /**
+     * @see Workflow::handleIssueClosed
+     */
+    public function handleIssueClosed(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $send_notification = $event['send_notification'];
+        $resolution_id = $event['resolution_id'];
+        $status_id = $event['status_id'];
+        $reason = $event['reason'];
+
+        $backend->handleIssueClosed($event->getProjectId(), $event->getIssueId(), $send_notification, $resolution_id, $status_id, $reason, $event->getUserId());
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -46,6 +46,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ATTACHMENT_ATTACHMENT_GROUP => 'handleAttachment',
             /** @see WorkflowLegacyExtension::shouldAttachFile */
             SystemEvents::ATTACHMENT_ATTACH_FILE => 'shouldAttachFile',
+            /** @see WorkflowLegacyExtension::handlePriorityChange */
+            SystemEvents::ISSUE_UPDATED_PRIORITY => 'handlePriorityChange',
             /** @see WorkflowLegacyExtension::canAccessIssue */
             SystemEvents::ACCESS_ISSUE => 'canAccessIssue',
         ];
@@ -105,6 +107,20 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $attachment = $event->getSubject();
         $result = $backend->shouldAttachFile($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $attachment);
         $event->setResult($result);
+    }
+
+    /**
+     * @see Workflow::handlePriorityChange
+     */
+    public function handlePriorityChange(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        $old_details = $event['old_details'];
+        $changes = $event['changes'];
+        $backend->handlePriorityChange($event->getProjectId(), $event->getIssueId(), $event->getUserId(), $old_details, $changes);
     }
 
     /**

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -60,6 +60,8 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
             SystemEvents::ISSUE_ASSIGNMENT_CHANGE => 'handleAssignmentChange',
             /** @see WorkflowLegacyExtension::handleNewIssue */
             SystemEvents::ISSUE_CREATED => 'handleNewIssue',
+            /** @see WorkflowLegacyExtension::handleNewEmail */
+            SystemEvents::MAIL_CREATED => 'handleNewEmail',
             /** @see WorkflowLegacyExtension::handleManualEmailAssociation */
             SystemEvents::MAIL_ASSOCIATED_MANUAL => 'handleManualEmailAssociation',
             /** @see WorkflowLegacyExtension::handleNewNote */
@@ -648,6 +650,22 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         $has_TAM = $event['has_TAM'];
         $has_RR = $event['has_RR'];
         $backend->handleNewIssue($event->getProjectId(), $event->getIssueId(), $has_TAM, $has_RR);
+    }
+
+    /**
+     * @see Workflow::handleNewEmail
+     */
+    public function handleNewEmail(EventContext $event): void
+    {
+        if (!$backend = $this->getBackend($event)) {
+            return;
+        }
+
+        /** @var MailMessage $mail */
+        $mail = $event->getSubject();
+        $closing = $event['closing'];
+        $row = $event['data'];
+        $backend->handleNewEmail($event->getProjectId(), $event->getIssueId(), $mail, $row, $closing);
     }
 
     /**


### PR DESCRIPTION
This way if your installation does not use Workflow, you can completely skip loading `WorkflowLegacyExtension`.

- [x] handleIssueUpdated
- [x] preIssueUpdated
- [x] handleAttachment
- [x] shouldAttachFile
- [x] handlePriorityChange
- [x] handleSeverityChange
- [x] handleBlockedEmail
- [x] handleAssignmentChange
- [x] handleNewIssue
- [x] handleNewEmail
- [x] handleManualEmailAssociation
- [x] handleNewNote
- [x] getAllowedStatuses
- [x] handleIssueClosed
- [x] handleCustomFieldsUpdated
- [x] handleSubscription
- [x] shouldEmailAddress
- [x] getAdditionalEmailAddresses
- [x] canEmailIssue
- [x] canSendNote
- [x] canCloneIssue
- [x] canChangeAccessLevel
- [x] handleAuthorizedReplierAdded
- [x] preEmailDownload
- [x] preNoteInsert
- [x] shouldAutoAddToNotificationList
- [x] getIssueIDForNewEmail
- [x] modifyMailQueue
- [x] preStatusChange
- [x] prePage
- [x] getNotificationActions
- [x] getIssueFieldsToDisplay
- [x] addLinkFilters
- [x] canUpdateIssue
- [x] canChangeAssignee
- [x] getActiveGroup
- [x] getAccessLevels
- [x] canAccessIssue
- [x] getAdditionalAccessSQL
- [x] handleIssueMovedFromProject
- [x] handleIssueMovedToProject
- [x] getMovedIssueMapping

NOTE: EventDispatcher added in #272
