### PR TITLE
Replace jquery-cookie with a js-cookie npm module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - With this release, we reached [11000th] commit! 💯
 - Use cmd-ctrl-enter from node package, #842
 - Use jquery datatables from webpack bundle, #843
+- Replace jquery-cookie with a js-cookie npm module, #836
 
 [3.8.13]: https://github.com/eventum/eventum/compare/v3.8.12...master
 [11000th]: https://github.com/eventum/eventum/tree/8a9b4c15ba6986331c99fd0f83a757d4594bfb19

--- a/composer.json
+++ b/composer.json
@@ -93,7 +93,6 @@
         "alcaeus/mongo-php-adapter": "^1.1",
         "balbuf/composer-git-merge-driver": "^1.1",
         "components/jquery": "~1.8.3",
-        "components/jquery-cookie": "~1.4.1",
         "eventum/rpc": "^4.3.0",
         "jasig/phpcas": "~1.3.3",
         "maximebf/debugbar": "1.*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8109e4f0dff10334337f36fe11e0b4a",
+    "content-hash": "dbe6c59df30f60590b6bc8399daa7bd8",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -7145,52 +7145,6 @@
             "description": "jQuery JavaScript Library",
             "homepage": "http://jquery.com",
             "time": "2013-04-05T19:32:49+00:00"
-        },
-        {
-            "name": "components/jquery-cookie",
-            "version": "1.4.1.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/Gta-Cool/jquery-cookie.git",
-                "reference": "0a10666155fd3aab9be5735b0ba83a4dccf59d78"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/Gta-Cool/jquery-cookie/zipball/0a10666155fd3aab9be5735b0ba83a4dccf59d78",
-                "reference": "0a10666155fd3aab9be5735b0ba83a4dccf59d78",
-                "shasum": ""
-            },
-            "require": {
-                "components/jquery": "*",
-                "robloach/component-installer": "*"
-            },
-            "type": "component",
-            "extra": {
-                "component": {
-                    "scripts": [
-                        "jquery.cookie.js"
-                    ]
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Klaus Hartl",
-                    "homepage": "https://github.com/carhartl"
-                }
-            ],
-            "description": "A simple, lightweight jQuery plugin for reading, writing and deleting cookies",
-            "homepage": "https://github.com/carhartl/jquery-cookie",
-            "keywords": [
-                "JS",
-                "cookie",
-                "javascript",
-                "jquery"
-            ],
-            "time": "2014-07-02T18:35:35+00:00"
         },
         {
             "name": "eventum/rpc",

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -157,7 +157,7 @@ Eventum.toggle_section_visibility = function(id) {
 
     $('#' + id + '_link').text(link_title);
 
-    $.cookie('visibility_' + id, display, {expires: Eventum.expires});
+    Cookie.set('visibility_' + id, display);
 };
 
 Eventum.close_and_refresh = function(noparent)

--- a/htdocs/js/main.js
+++ b/htdocs/js/main.js
@@ -136,6 +136,7 @@ Eventum.setupTrimmedEmailToggle = function () {
         .on('click', Eventum.TrimmedEmailToggleFunction);
 };
 
+/** @deprecated: jquery-cookie, no longer used */
 Eventum.expires = new Date(new Date().getTime() + (56 * 86400000));
 Eventum.checkClose = false;
 Eventum.closeConfirmMessage = 'Do you want to close this window?';

--- a/htdocs/js/page.js
+++ b/htdocs/js/page.js
@@ -362,7 +362,7 @@ issue_view.toggle_issue_section = function(id)
 
     $('#toggle_' + id).text(link_title);
 
-    $.cookie('visibility_' + id, display, {expires: Eventum.expires});
+    Cookie.set('visibility_' + id, display);
 };
 
 issue_view.openHistory = function()

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "jquery": "1.9.x",
     "jquery-form": "^4.2.2",
     "jquery-ui": "^1.12.1",
+    "js-cookie": "^2.2.1",
     "laravel-mix": "^5.0.4",
     "resolve-url-loader": "^3.1.1",
     "sass": "^1.26.3",

--- a/res/assets/scripts/Cookie.js
+++ b/res/assets/scripts/Cookie.js
@@ -1,0 +1,31 @@
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+export class Cookie {
+    constructor(cookies) {
+        this.attributes = {
+            expires: new Date(new Date().getTime() + (56 * 86400000)),
+        }
+        this.cookies = cookies;
+    }
+
+    get(name) {
+        return this.cookies.get(name);
+    }
+
+    set(name, value) {
+        this.cookies.set(name, value, this.attributes);
+    }
+
+    remove(name) {
+        this.cookies.remove(name, this.attributes);
+    }
+}

--- a/res/assets/scripts/bootstrap.js
+++ b/res/assets/scripts/bootstrap.js
@@ -13,8 +13,10 @@ import { ExpandableCell } from "./ExpandableCell.js";
 import { CustomField } from "./CustomField.js";
 import { GrowingFileField } from "./GrowingFileField.js";
 import { Validation } from "./Validation.js";
+import { Cookie } from "./Cookie.js";
 
 window.ExpandableCell = new ExpandableCell();
 window.CustomField = new CustomField();
 window.GrowingFileField = new GrowingFileField();
 window.Validation = new Validation();
+window.Cookie = new Cookie(Cookies.noConflict());

--- a/templates/email_drafts.tpl.html
+++ b/templates/email_drafts.tpl.html
@@ -23,7 +23,7 @@ function showAllDrafts(thisBox)
     } else {
         showValue = 0;
     }
-    $.cookie('show_all_drafts', showValue, { expires: Eventum.expires });
+    Cookie.set('show_all_drafts', showValue);
     document.location.href = document.location.href;
 }
 //-->

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -106,7 +106,7 @@ mix.scripts([
     'node_modules/jquery/jquery-migrate.js',
     'node_modules/block-ui/jquery.blockUI.js',
     'node_modules/jquery-form/src/jquery.form.js',
-    'htdocs/components/jquery-cookie/jquery.cookie.js',
+    'node_modules/js-cookie/src/js.cookie.js',
     'node_modules/jquery-ui/jquery-ui.js',
     'node_modules/chosen-js/chosen.jquery.js',
     'node_modules/dropzone/dist/dropzone.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -3900,6 +3900,11 @@ jquery@1.9.x, "jquery@>=1.5.0 <4.0", jquery@>=1.7, jquery@>=1.7.2, jquery@>=1.7.
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=
 
+js-cookie@^2.2.1:
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/js-cookie/-/js-cookie-2.2.1.tgz#69e106dc5d5806894562902aa5baec3744e9b2b8"
+  integrity sha512-HvdH2LzI/EAZcUwA8+0nKNtWHqS+ZmijLA30RwZA0bo7ToCckjK5MkGhjED9KoRcXO6BaGI3I9UIzSA1FKFPOQ==
+
 "js-tokens@^3.0.0 || ^4.0.0", js-tokens@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-4.0.0.tgz#19203fb59991df98e3a287050d4647cdeaf32499"


### PR DESCRIPTION
The usage is rather minimal:

```
➔ git grep -F '.cookie'
composer.lock:                        "jquery.cookie.js"
htdocs/js/main.js:    $.cookie('visibility_' + id, display, {expires: Eventum.expires});
htdocs/js/page.js:    $.cookie('visibility_' + id, display, {expires: Eventum.expires});
templates/email_drafts.tpl.html:    $.cookie('show_all_drafts', showValue, { expires: Eventum.expires });
templates/email_drafts.tpl.html:        <input type="checkbox" name="show_all_drafts" id="show_all_drafts" value="1" {if $smarty.cookies.show_all_drafts|default:0 == 1}checked{/if} onClick="showAllDrafts(this)"><label for="show_all_drafts">{t}Show All Drafts{/t}</label>
webpack.mix.js:    'htdocs/components/jquery-cookie/jquery.cookie.js',
```

When implementing, prefer composition over inheritance:
- https://github.com/js-cookie/js-cookie/wiki/Design-Patterns-To-Use-With-JavaScript-Cookie#design-patterns-to-use-with-javascript-cookie