### PR TITLE
Use container for Silly console application

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 
 - Move JavaScript classes (CustomField, ExpandableCell, GrowingFileField, Validation) to modules, #839
 - Move workflow handling to WorkflowLegacyExtension extension, #832
+- Use container for Silly console application, #844
 
 ## [3.8.12] - 2020-05-14
 

--- a/bin/check_reminders.php
+++ b/bin/check_reminders.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\ReminderCheckCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/download_emails.php
+++ b/bin/download_emails.php
@@ -21,6 +21,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\MailDownloadCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/export-issues.php
+++ b/bin/export-issues.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\ExportIssuesCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/extension.php
+++ b/bin/extension.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\ExtensionEnableCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/ldapsync.php
+++ b/bin/ldapsync.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\LdapSyncCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/migrate_storage_adapter.php
+++ b/bin/migrate_storage_adapter.php
@@ -26,6 +26,6 @@ use Eventum\Console\Command\AttachmentMigrateCommand as Command;
 require_once __DIR__ . '/../init.php';
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/monitor.php
+++ b/bin/monitor.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\MonitorCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/process_all_emails.php
+++ b/bin/process_all_emails.php
@@ -18,6 +18,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\MailRouteCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/process_mail_queue.php
+++ b/bin/process_mail_queue.php
@@ -19,6 +19,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\MailQueueProcessCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/bin/truncate_mail_queue.php
+++ b/bin/truncate_mail_queue.php
@@ -17,6 +17,6 @@ use Eventum\Console\Application;
 use Eventum\Console\Command\MailQueueTruncateCommand as Command;
 
 $app = new Application();
-$app->command(Command::USAGE, [new Command(), 'execute']);
+$app->command(Command::USAGE, Command::class);
 $app->setDefaultCommand(Command::DEFAULT_COMMAND, true);
 $app->run();

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -14,14 +14,15 @@
 namespace Eventum\Console;
 
 use Eventum\EventDispatcher\EventManager;
+use Eventum\ServiceContainer;
 use Silly\Application as BaseApplication;
 
 class Application extends BaseApplication
 {
     public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
     {
-        $this->setDispatcher(EventManager::getEventDispatcher());
-
         parent::__construct($name, $version);
+        $this->setDispatcher(EventManager::getEventDispatcher());
+        $this->useContainer(ServiceContainer::getContainer());
     }
 }

--- a/src/Console/Command/AttachmentMigrateCommand.php
+++ b/src/Console/Command/AttachmentMigrateCommand.php
@@ -33,6 +33,7 @@ class AttachmentMigrateCommand extends Command
 {
     public const DEFAULT_COMMAND = 'attachment:migrate';
     public const USAGE = self::DEFAULT_COMMAND . ' [source_adapter] [target_adapter] [--chunksize=] [--limit=] [--migrate] [--verify]';
+    private const DEFAULT_CHUNKSIZE = 100;
 
     /** @var AdapterInterface */
     private $db;
@@ -46,8 +47,9 @@ class AttachmentMigrateCommand extends Command
     /** @var string */
     private $target_adapter;
 
-    public function execute(OutputInterface $output, $source_adapter, $target_adapter, $migrate, $verify, $limit, $chunksize = 100): void
+    public function __invoke(OutputInterface $output, $source_adapter, $target_adapter, $migrate, $verify, $limit, $chunksize): void
     {
+        $chunksize = $chunksize ?: self::DEFAULT_CHUNKSIZE;
         $this->output = $output;
         $this->assertInput($source_adapter, $target_adapter, $migrate, $verify);
 

--- a/src/Console/Command/ExportIssuesCommand.php
+++ b/src/Console/Command/ExportIssuesCommand.php
@@ -22,7 +22,7 @@ class ExportIssuesCommand extends Command
     public const DEFAULT_COMMAND = 'export:issues';
     public const USAGE = self::DEFAULT_COMMAND . ' [issueId] [filename]';
 
-    public function execute(OutputInterface $output, ?int $issueId, ?string $fileName): void
+    public function __invoke(OutputInterface $output, ?int $issueId, ?string $fileName): void
     {
         $this->output = $output;
 

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -29,7 +29,7 @@ class ExtensionEnableCommand
     /** @var OutputInterface */
     private $output;
 
-    public function execute(OutputInterface $output, $filename, $classname): void
+    public function __invoke(OutputInterface $output, $filename, $classname): void
     {
         $this->output = $output;
         $this->setupExtension($filename, $classname);

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -32,7 +32,7 @@ class LdapSyncCommand extends Command
     /** @var bool */
     private $dryrun;
 
-    public function execute(OutputInterface $output, $dryrun = false, $createUsers, $noUpdate, $noDisable): void
+    public function __invoke(OutputInterface $output, $dryrun = false, $createUsers, $noUpdate, $noDisable): void
     {
         $this->output = $output;
         $this->dryrun = $dryrun;

--- a/src/Console/Command/MailDownloadCommand.php
+++ b/src/Console/Command/MailDownloadCommand.php
@@ -38,10 +38,10 @@ class MailDownloadCommand
      */
     private $limit = 0;
 
-    public function execute(?string $username, ?string $hostname, ?string $mailbox, bool $noLock, int $limit = 0): void
+    public function __invoke(?string $username, ?string $hostname, ?string $mailbox, ?bool $noLock, ?int $limit): void
     {
         $account_id = $this->getAccountId($username, $hostname, $mailbox);
-        $this->limit = $limit;
+        $this->limit = $limit ?: 0;
 
         if (!$noLock) {
             $lock = new ConcurrentLock('download_emails_' . $account_id);

--- a/src/Console/Command/MailQueueProcessCommand.php
+++ b/src/Console/Command/MailQueueProcessCommand.php
@@ -24,7 +24,7 @@ class MailQueueProcessCommand
     /** @var string */
     private $lock_name = 'process_mail_queue';
 
-    public function execute(): void
+    public function __invoke(): void
     {
         $lock = new ConcurrentLock($this->lock_name);
         $lock->synchronized(

--- a/src/Console/Command/MailQueueTruncateCommand.php
+++ b/src/Console/Command/MailQueueTruncateCommand.php
@@ -20,9 +20,11 @@ class MailQueueTruncateCommand
 {
     public const DEFAULT_COMMAND = 'mail-queue:truncate';
     public const USAGE = self::DEFAULT_COMMAND . ' [-q|--quiet] [--interval=]';
+    private const DEFAULT_INTERVAL = '1 month';
 
-    public function execute(OutputInterface $output, $quiet, $interval = '1 month'): void
+    public function __invoke(OutputInterface $output, $quiet, $interval): void
     {
+        $interval = $interval ?: self::DEFAULT_INTERVAL;
         Mail_Queue::truncate($interval);
 
         if (!$quiet) {

--- a/src/Console/Command/MailRouteCommand.php
+++ b/src/Console/Command/MailRouteCommand.php
@@ -28,7 +28,7 @@ class MailRouteCommand
      * @param string $filename optional filename to load
      * @return int Program exit code
      */
-    public function execute(OutputInterface $output, $filename)
+    public function __invoke(OutputInterface $output, $filename): int
     {
         // take input from first argument if specified
         // otherwise read from STDIN

--- a/src/Console/Command/MonitorCommand.php
+++ b/src/Console/Command/MonitorCommand.php
@@ -40,7 +40,7 @@ class MonitorCommand
     /** @var int */
     private $errors = 0;
 
-    public function execute(OutputInterface $output, $quiet)
+    public function __invoke(OutputInterface $output, $quiet): int
     {
         $this->output = $output;
 

--- a/src/Console/Command/ReminderCheckCommand.php
+++ b/src/Console/Command/ReminderCheckCommand.php
@@ -33,7 +33,7 @@ class ReminderCheckCommand
     /** @var int[] */
     private $triggered_issues = [];
 
-    public function execute(OutputInterface $output, $debug): void
+    public function __invoke(OutputInterface $output, $debug): void
     {
         $this->output = $output;
 

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -15,6 +15,8 @@ namespace Eventum;
 
 use Eventum\Config\Config;
 use Pimple\Container;
+use Pimple\Psr11\Container as PsrContainer;
+use Psr\Container\ContainerInterface;
 
 class ServiceContainer
 {
@@ -26,6 +28,18 @@ class ServiceContainer
             $container = new Container();
             $container->register(new ServiceProvider\ServiceProvider());
             $container->register(new ServiceProvider\FulltextSearchService());
+            $container->register(new ServiceProvider\ConsoleCommandsService());
+        }
+
+        return $container;
+    }
+
+    public static function getContainer(): ContainerInterface
+    {
+        static $container;
+
+        if (!$container) {
+            $container = new PsrContainer(self::getInstance());
         }
 
         return $container;

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -39,6 +39,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\MonitorCommand::class] = static function () {
             return new Command\MonitorCommand();
         };
+        $app[Command\MailRouteCommand::class] = static function () {
+            return new Command\MailRouteCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -30,6 +30,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\ExtensionEnableCommand::class] = static function () {
             return new Command\ExtensionEnableCommand();
         };
+        $app[Command\LdapSyncCommand::class] = static function () {
+            return new Command\LdapSyncCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -45,6 +45,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\MailQueueProcessCommand::class] = static function () {
             return new Command\MailQueueProcessCommand();
         };
+        $app[Command\MailQueueTruncateCommand::class] = static function () {
+            return new Command\MailQueueTruncateCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\ServiceProvider;
+
+use Eventum\Console\Command;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class ConsoleCommandsService implements ServiceProviderInterface
+{
+    public function register(Container $app): void
+    {
+    }
+}

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -36,6 +36,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\AttachmentMigrateCommand::class] = static function () {
             return new Command\AttachmentMigrateCommand();
         };
+        $app[Command\MonitorCommand::class] = static function () {
+            return new Command\MonitorCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -42,6 +42,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\MailRouteCommand::class] = static function () {
             return new Command\MailRouteCommand();
         };
+        $app[Command\MailQueueProcessCommand::class] = static function () {
+            return new Command\MailQueueProcessCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -24,6 +24,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\ReminderCheckCommand::class] = static function () {
             return new Command\ReminderCheckCommand();
         };
+        $app[Command\ExportIssuesCommand::class] = static function () {
+            return new Command\ExportIssuesCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -21,6 +21,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
 {
     public function register(Container $app): void
     {
+        $app[Command\ReminderCheckCommand::class] = static function () {
+            return new Command\ReminderCheckCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -27,6 +27,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\ExportIssuesCommand::class] = static function () {
             return new Command\ExportIssuesCommand();
         };
+        $app[Command\ExtensionEnableCommand::class] = static function () {
+            return new Command\ExtensionEnableCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -21,5 +21,8 @@ class ConsoleCommandsService implements ServiceProviderInterface
 {
     public function register(Container $app): void
     {
+        $app[Command\MailDownloadCommand::class] = static function () {
+            return new Command\MailDownloadCommand();
+        };
     }
 }

--- a/src/ServiceProvider/ConsoleCommandsService.php
+++ b/src/ServiceProvider/ConsoleCommandsService.php
@@ -33,6 +33,9 @@ class ConsoleCommandsService implements ServiceProviderInterface
         $app[Command\LdapSyncCommand::class] = static function () {
             return new Command\LdapSyncCommand();
         };
+        $app[Command\AttachmentMigrateCommand::class] = static function () {
+            return new Command\AttachmentMigrateCommand();
+        };
         $app[Command\MailDownloadCommand::class] = static function () {
             return new Command\MailDownloadCommand();
         };


### PR DESCRIPTION
To lazy init, and most importantly release `::execute()` name for symfony/cli compatibility.