### PR TITLE
Make commands available from Symfony Console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version fi
 - Use cmd-ctrl-enter from node package, #842
 - Use jquery datatables from webpack bundle, #843
 - Replace jquery-cookie with a js-cookie npm module, #836
+- Make commands available from Symfony Console, #845
 
 [3.8.13]: https://github.com/eventum/eventum/compare/v3.8.12...master
 [11000th]: https://github.com/eventum/eventum/tree/8a9b4c15ba6986331c99fd0f83a757d4594bfb19

--- a/src/Console/Command/Command.php
+++ b/src/Console/Command/Command.php
@@ -13,26 +13,15 @@
 
 namespace Eventum\Console\Command;
 
+use Eventum\Console\ConsoleTrait;
 use Symfony\Component\Console\Output\OutputInterface;
 
 abstract class Command
 {
+    use ConsoleTrait;
+
     // compact constants for writeln
     protected const DEBUG = OutputInterface::VERBOSITY_DEBUG;
     protected const VERBOSE = OutputInterface::VERBOSITY_VERBOSE;
     protected const VERY_VERBOSE = OutputInterface::VERBOSITY_VERY_VERBOSE;
-
-    /** @var OutputInterface */
-    protected $output;
-
-    /**
-     * Writes a message to the output and adds a newline at the end.
-     *
-     * @param string|array $messages The message as an array of lines of a single string
-     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
-     */
-    protected function writeln($messages, $options = 0): void
-    {
-        $this->output->writeln($messages, $options);
-    }
 }

--- a/src/Console/Command/ExportIssuesCommand.php
+++ b/src/Console/Command/ExportIssuesCommand.php
@@ -15,17 +15,37 @@ namespace Eventum\Console\Command;
 
 use Eventum\Db\Doctrine;
 use Eventum\Export\IssueExport;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ExportIssuesCommand extends Command
+class ExportIssuesCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'export:issues';
     public const USAGE = self::DEFAULT_COMMAND . ' [issueId] [filename]';
 
-    public function __invoke(OutputInterface $output, ?int $issueId, ?string $fileName): void
-    {
-        $this->output = $output;
+    protected static $defaultName = self::DEFAULT_COMMAND;
 
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('issueId', InputArgument::REQUIRED)
+            ->addArgument('fileName', InputArgument::REQUIRED);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $issueId = $input->getArgument('issueId');
+        $fileName = $input->getArgument('fileName');
+
+        $this($issueId, $fileName);
+
+        return 0;
+    }
+
+    public function __invoke(?int $issueId, ?string $fileName): void
+    {
         if ($issueId) {
             $this->exportIssue($issueId, $fileName ?: 'output.csv');
         }

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -19,15 +19,37 @@ use InvalidArgumentException;
 use LogicException;
 use ReflectionException;
 use Setup;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ExtensionEnableCommand
+class ExtensionEnableCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'extension:enable';
     public const USAGE = self::DEFAULT_COMMAND . ' [filename] [classname]';
 
+    protected static $defaultName = self::DEFAULT_COMMAND;
+
     /** @var OutputInterface */
     private $output;
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('filename', InputArgument::REQUIRED)
+            ->addArgument('classname', InputArgument::REQUIRED);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filename = $input->getArgument('filename');
+        $classname = $input->getArgument('classname');
+
+        $this($output, $filename, $classname);
+
+        return 0;
+    }
 
     public function __invoke(OutputInterface $output, $filename, $classname): void
     {

--- a/src/Console/Command/MailQueueProcessCommand.php
+++ b/src/Console/Command/MailQueueProcessCommand.php
@@ -15,14 +15,26 @@ namespace Eventum\Console\Command;
 
 use Eventum\ConcurrentLock;
 use Mail_Queue;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
 
-class MailQueueProcessCommand
+class MailQueueProcessCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'mail-queue:process';
     public const USAGE = self::DEFAULT_COMMAND;
 
+    protected static $defaultName = self::DEFAULT_COMMAND;
+
     /** @var string */
     private $lock_name = 'process_mail_queue';
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this();
+
+        return 0;
+    }
 
     public function __invoke(): void
     {

--- a/src/Console/Command/MailQueueTruncateCommand.php
+++ b/src/Console/Command/MailQueueTruncateCommand.php
@@ -14,13 +14,35 @@
 namespace Eventum\Console\Command;
 
 use Mail_Queue;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MailQueueTruncateCommand
+class MailQueueTruncateCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'mail-queue:truncate';
     public const USAGE = self::DEFAULT_COMMAND . ' [-q|--quiet] [--interval=]';
     private const DEFAULT_INTERVAL = '1 month';
+
+    protected static $defaultName = self::DEFAULT_COMMAND;
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('interval', null, InputOption::VALUE_REQUIRED)
+            ->addOption('quiet', 'q', InputOption::VALUE_NONE);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $interval = $input->getOption('interval') ?: self::DEFAULT_INTERVAL;
+        $quiet = $input->getOption('quiet');
+
+        $this($output, $quiet, $interval);
+
+        return 0;
+    }
 
     public function __invoke(OutputInterface $output, $quiet, $interval): void
     {

--- a/src/Console/Command/MailRouteCommand.php
+++ b/src/Console/Command/MailRouteCommand.php
@@ -16,12 +16,32 @@ namespace Eventum\Console\Command;
 use Eventum\Mail\Exception\RoutingException;
 use Eventum\Mail\MailMessage;
 use Routing;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MailRouteCommand
+class MailRouteCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'mail:route';
     public const USAGE = self::DEFAULT_COMMAND . '  [filename]';
+
+    protected static $defaultName = self::DEFAULT_COMMAND;
+
+    protected function configure(): void
+    {
+        $this
+            ->addArgument('filename', InputArgument::OPTIONAL);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $filename = $input->getArgument('filename');
+
+        $this($output, $filename);
+
+        return 0;
+    }
 
     /**
      * @param OutputInterface $output

--- a/src/Console/Command/MonitorCommand.php
+++ b/src/Console/Command/MonitorCommand.php
@@ -20,9 +20,12 @@ use Eventum\Db\DatabaseException;
 use Exception;
 use Mail_Queue;
 use Setup;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class MonitorCommand
+class MonitorCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'system:monitor';
     public const USAGE = self::DEFAULT_COMMAND . ' [-q|--quiet]';
@@ -34,11 +37,26 @@ class MonitorCommand
     public const STATE_UNKNOWN = 3;
     public const STATE_DEPENDENT = 4;
 
+    protected static $defaultName = self::DEFAULT_COMMAND;
+
     /** @var OutputInterface */
     private $output;
 
     /** @var int */
     private $errors = 0;
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('quiet', 'q', InputOption::VALUE_NONE);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $quiet = $input->getOption('quiet');
+
+        return $this($output, $quiet);
+    }
 
     public function __invoke(OutputInterface $output, $quiet): int
     {

--- a/src/Console/Command/ReminderCheckCommand.php
+++ b/src/Console/Command/ReminderCheckCommand.php
@@ -17,12 +17,17 @@ use Eventum\ConcurrentLock;
 use Reminder;
 use Reminder_Action;
 use Reminder_Condition;
+use Symfony\Component\Console\Command\Command as SymfonyCommand;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Output\OutputInterface;
 
-class ReminderCheckCommand
+class ReminderCheckCommand extends SymfonyCommand
 {
     public const DEFAULT_COMMAND = 'reminder:check';
     public const USAGE = self::DEFAULT_COMMAND . ' [--debug]';
+
+    protected static $defaultName = self::DEFAULT_COMMAND;
 
     /** @var OutputInterface */
     private $output;
@@ -32,6 +37,21 @@ class ReminderCheckCommand
 
     /** @var int[] */
     private $triggered_issues = [];
+
+    protected function configure(): void
+    {
+        $this
+            ->addOption('debug', null, InputOption::VALUE_NONE);
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $debug = $input->getOption('debug');
+
+        $this($output, $debug);
+
+        return 0;
+    }
 
     public function __invoke(OutputInterface $output, $debug): void
     {

--- a/src/Console/ConsoleTrait.php
+++ b/src/Console/ConsoleTrait.php
@@ -1,0 +1,33 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Console;
+
+use Symfony\Component\Console\Output\OutputInterface;
+
+trait ConsoleTrait
+{
+    /** @var OutputInterface */
+    protected $output;
+
+    /**
+     * Writes a message to the output and adds a newline at the end.
+     *
+     * @param string|array $messages The message as an array of lines of a single string
+     * @param int $options A bitmask of options (one of the OUTPUT or VERBOSITY constants), 0 is considered the same as self::OUTPUT_NORMAL | self::VERBOSITY_NORMAL
+     */
+    protected function writeln($messages, $options = 0): void
+    {
+        $this->output->writeln($messages, $options);
+    }
+}


### PR DESCRIPTION
The commands now available via `bin/console.php` as well:

```
➔ git grep const.DEFAULT_COMMAND
src/Console/Command/AttachmentMigrateCommand.php:    public const DEFAULT_COMMAND = 'attachment:migrate';
src/Console/Command/ExportIssuesCommand.php:    public const DEFAULT_COMMAND = 'export:issues';
src/Console/Command/ExtensionEnableCommand.php:    public const DEFAULT_COMMAND = 'extension:enable';
src/Console/Command/LdapSyncCommand.php:    public const DEFAULT_COMMAND = 'ldap:sync';
src/Console/Command/MailDownloadCommand.php:    public const DEFAULT_COMMAND = 'mail:download';
src/Console/Command/MailQueueProcessCommand.php:    public const DEFAULT_COMMAND = 'mail-queue:process';
src/Console/Command/MailQueueTruncateCommand.php:    public const DEFAULT_COMMAND = 'mail-queue:truncate';
src/Console/Command/MailRouteCommand.php:    public const DEFAULT_COMMAND = 'mail:route';
src/Console/Command/MonitorCommand.php:    public const DEFAULT_COMMAND = 'system:monitor';
src/Console/Command/ReminderCheckCommand.php:    public const DEFAULT_COMMAND = 'reminder:check';
```