### PR TITLE
Setup symfony/monolog-bundle for improved console error logging

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -72,8 +72,11 @@
         "symfony/framework-bundle": "^4.2",
         "symfony/http-foundation": "^2.7 || ^3.0 || ^4.0",
         "symfony/ldap": "^2.7 || ^3.3 || ^4.0",
+        "symfony/monolog-bridge": "^4.4",
+        "symfony/monolog-bundle": "^3.5",
         "symfony/security-bundle": "^4.3",
         "symfony/security-csrf": "^3.4 || ^4.0",
+        "symfony/var-dumper": "^4.4",
         "symfony/var-exporter": "^4.2",
         "theorchard/monolog-cascade": "^0.5.0",
         "willdurand/email-reply-parser": "^2.7.0",
@@ -101,8 +104,7 @@
         "sentry/sentry": "^1.7",
         "symfony/browser-kit": "^4.2",
         "symfony/phpunit-bridge": "^5.0",
-        "symfony/thanks": "^1.0",
-        "symfony/var-dumper": "^2.7 || ^3.3 || ^4.1.2"
+        "symfony/thanks": "^1.0"
     },
     "suggest": {
         "ext-imap": "Support for fetching mail over IMAP/POP3"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "dbe6c59df30f60590b6bc8399daa7bd8",
+    "content-hash": "5576fa56f76b7641113395ce9edb31b0",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -5001,6 +5001,150 @@
                 }
             ],
             "time": "2020-04-16T14:49:30+00:00"
+        },
+        {
+            "name": "symfony/monolog-bridge",
+            "version": "v4.4.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/monolog-bridge.git",
+                "reference": "224355f29abfb8b00a4c5fb22bdaff5c47e82105"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/monolog-bridge/zipball/224355f29abfb8b00a4c5fb22bdaff5c47e82105",
+                "reference": "224355f29abfb8b00a4c5fb22bdaff5c47e82105",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "^1.25.1",
+                "php": "^7.1.3",
+                "symfony/http-kernel": "^4.3",
+                "symfony/service-contracts": "^1.1|^2"
+            },
+            "conflict": {
+                "symfony/console": "<3.4",
+                "symfony/http-foundation": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "^3.4|^4.0|^5.0",
+                "symfony/http-client": "^4.4|^5.0",
+                "symfony/security-core": "^3.4|^4.0|^5.0",
+                "symfony/var-dumper": "^3.4|^4.0|^5.0"
+            },
+            "suggest": {
+                "symfony/console": "For the possibility to show log messages in console commands depending on verbosity settings.",
+                "symfony/http-kernel": "For using the debugging handlers together with the response life cycle of the HTTP kernel.",
+                "symfony/var-dumper": "For using the debugging handlers like the console handler or the log server handler."
+            },
+            "type": "symfony-bridge",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.4-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bridge\\Monolog\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Monolog Bridge",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-04-12T16:14:02+00:00"
+        },
+        {
+            "name": "symfony/monolog-bundle",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/monolog-bundle.git",
+                "reference": "dd80460fcfe1fa2050a7103ad818e9d0686ce6fd"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/monolog-bundle/zipball/dd80460fcfe1fa2050a7103ad818e9d0686ce6fd",
+                "reference": "dd80460fcfe1fa2050a7103ad818e9d0686ce6fd",
+                "shasum": ""
+            },
+            "require": {
+                "monolog/monolog": "~1.22 || ~2.0",
+                "php": ">=5.6",
+                "symfony/config": "~3.4 || ~4.0 || ^5.0",
+                "symfony/dependency-injection": "~3.4.10 || ^4.0.10 || ^5.0",
+                "symfony/http-kernel": "~3.4 || ~4.0 || ^5.0",
+                "symfony/monolog-bridge": "~3.4 || ~4.0 || ^5.0"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4 || ~4.0 || ^5.0",
+                "symfony/phpunit-bridge": "^3.4.19 || ^4.0 || ^5.0",
+                "symfony/yaml": "~3.4 || ~4.0 || ^5.0"
+            },
+            "type": "symfony-bundle",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Bundle\\MonologBundle\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "http://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony MonologBundle",
+            "homepage": "http://symfony.com",
+            "keywords": [
+                "log",
+                "logging"
+            ],
+            "time": "2019-11-13T13:11:14+00:00"
         },
         {
             "name": "symfony/options-resolver",

--- a/res/bundles.php
+++ b/res/bundles.php
@@ -15,4 +15,5 @@ return [
     Symfony\Bundle\FrameworkBundle\FrameworkBundle::class => ['all' => true],
     Symfony\Bundle\SecurityBundle\SecurityBundle::class => ['all' => true],
     Doctrine\Bundle\DoctrineBundle\DoctrineBundle::class => ['all' => true],
+    Symfony\Bundle\MonologBundle\MonologBundle::class => ['all' => true],
 ];

--- a/res/packages/dev/monolog.yml
+++ b/res/packages/dev/monolog.yml
@@ -1,0 +1,35 @@
+monolog:
+  handlers:
+    main:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+      channels: ["!event"]
+    # uncomment to get logging in your browser
+    # you may have to allow bigger header sizes in your Web server configuration
+    #firephp:
+    #    type: firephp
+    #    level: info
+    #chromephp:
+    #    type: chromephp
+    #    level: info
+    console:
+      type: console
+      process_psr_3_messages: false
+      channels: ["!event", "!doctrine", "!console"]
+
+      # optionally configure the mapping between verbosity levels and log levels
+      # verbosity_levels:
+      #     VERBOSITY_NORMAL: NOTICE
+
+    # Uncomment to log deprecations
+    deprecation:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+    deprecation_filter:
+      type: filter
+      handler: deprecation
+      max_level: info
+      channels: ["php"]
+
+# vim:ts=2:sw=2:et

--- a/res/packages/prod/monolog.yml
+++ b/res/packages/prod/monolog.yml
@@ -1,0 +1,28 @@
+monolog:
+  handlers:
+    main:
+      type: fingers_crossed
+      action_level: error
+      handler: nested
+      excluded_http_codes: [404, 405]
+      buffer_size: 50 # How many messages should be saved? Prevent memory leaks
+    nested:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+    console:
+      type: console
+      process_psr_3_messages: false
+      channels: ["!event", "!doctrine"]
+
+    # Uncomment to log deprecations
+    #deprecation:
+    #    type: stream
+    #    path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+    #deprecation_filter:
+    #    type: filter
+    #    handler: deprecation
+    #    max_level: info
+    #    channels: ["php"]
+
+# vim:ts=2:sw=2:et

--- a/res/packages/test/monolog.yml
+++ b/res/packages/test/monolog.yml
@@ -1,0 +1,14 @@
+monolog:
+  handlers:
+    main:
+      type: fingers_crossed
+      action_level: error
+      handler: nested
+      excluded_http_codes: [404, 405]
+      channels: ["!event"]
+    nested:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.log"
+      level: debug
+
+# vim:ts=2:sw=2:et

--- a/src/Console/Command/AttachmentMigrateCommand.php
+++ b/src/Console/Command/AttachmentMigrateCommand.php
@@ -42,7 +42,7 @@ class AttachmentMigrateCommand extends SymfonyCommand
     public const USAGE = self::DEFAULT_COMMAND . ' [source_adapter] [target_adapter] [--chunksize=] [--limit=] [--migrate] [--verify]';
     private const DEFAULT_CHUNKSIZE = 100;
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var AdapterInterface */
     private $db;

--- a/src/Console/Command/ExportIssuesCommand.php
+++ b/src/Console/Command/ExportIssuesCommand.php
@@ -25,7 +25,7 @@ class ExportIssuesCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'export:issues';
     public const USAGE = self::DEFAULT_COMMAND . ' [issueId] [filename]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     protected function configure(): void
     {

--- a/src/Console/Command/ExtensionEnableCommand.php
+++ b/src/Console/Command/ExtensionEnableCommand.php
@@ -29,7 +29,7 @@ class ExtensionEnableCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'extension:enable';
     public const USAGE = self::DEFAULT_COMMAND . ' [filename] [classname]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var OutputInterface */
     private $output;

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -32,7 +32,7 @@ class LdapSyncCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'ldap:sync';
     public const USAGE = self::DEFAULT_COMMAND . ' [--dry-run] [--create-users] [--no-update] [--no-disable]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var LdapAdapter */
     private $ldap;

--- a/src/Console/Command/ListCommand.php
+++ b/src/Console/Command/ListCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Console\Command;
+
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ListCommand extends \Symfony\Component\Console\Command\ListCommand
+{
+    protected function configure(): void
+    {
+        parent::configure();
+
+        $this
+            ->addOption('all', 'a', InputOption::VALUE_NONE, 'Show all commands not just Eventum builtin');
+    }
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        if (!$input->getOption('all')) {
+            $this->hideCommands();
+        }
+
+        return parent::execute($input, $output);
+    }
+
+    /**
+     * Hide commands from bundle, as they are not usable.
+     *
+     * @see https://symfony.com/doc/current/console/hide_commands.html
+     */
+    private function hideCommands(): void
+    {
+        $hiddenNamespaces = [
+            'assets',
+            'cache',
+            'config',
+            'debug',
+            'doctrine',
+            'lint',
+            'router',
+            'secrets',
+            'security',
+        ];
+
+        /** @var Application $app */
+        $app = $this->getApplication();
+        $commands = $app->all();
+
+        foreach ($commands as $commandName => $command) {
+            $namespace = $app->extractNamespace($commandName, 1);
+            if (!in_array($namespace, $hiddenNamespaces, 1)) {
+                continue;
+            }
+            $command->setHidden(true);
+        }
+    }
+}

--- a/src/Console/Command/ListCommand.php
+++ b/src/Console/Command/ListCommand.php
@@ -38,34 +38,21 @@ class ListCommand extends \Symfony\Component\Console\Command\ListCommand
     }
 
     /**
-     * Hide commands from bundle, as they are not usable.
+     * Show only commands from eventum namespace
      *
      * @see https://symfony.com/doc/current/console/hide_commands.html
      */
     private function hideCommands(): void
     {
-        $hiddenNamespaces = [
-            'assets',
-            'cache',
-            'config',
-            'debug',
-            'doctrine',
-            'lint',
-            'router',
-            'secrets',
-            'security',
-        ];
-
         /** @var Application $app */
         $app = $this->getApplication();
         $commands = $app->all();
 
         foreach ($commands as $commandName => $command) {
             $namespace = $app->extractNamespace($commandName, 1);
-            if (!in_array($namespace, $hiddenNamespaces, 1)) {
-                continue;
+            if ($namespace !== 'eventum') {
+                $command->setHidden(true);
             }
-            $command->setHidden(true);
         }
     }
 }

--- a/src/Console/Command/MailDownloadCommand.php
+++ b/src/Console/Command/MailDownloadCommand.php
@@ -36,7 +36,7 @@ class MailDownloadCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'mail:download';
     public const USAGE = self::DEFAULT_COMMAND . ' [username] [hostname] [mailbox] [--limit=] [--no-lock]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /**
      * Limit amount of emails to process.

--- a/src/Console/Command/MailQueueProcessCommand.php
+++ b/src/Console/Command/MailQueueProcessCommand.php
@@ -24,7 +24,7 @@ class MailQueueProcessCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'mail-queue:process';
     public const USAGE = self::DEFAULT_COMMAND;
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var string */
     private $lock_name = 'process_mail_queue';

--- a/src/Console/Command/MailQueueTruncateCommand.php
+++ b/src/Console/Command/MailQueueTruncateCommand.php
@@ -25,7 +25,7 @@ class MailQueueTruncateCommand extends SymfonyCommand
     public const USAGE = self::DEFAULT_COMMAND . ' [-q|--quiet] [--interval=]';
     private const DEFAULT_INTERVAL = '1 month';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     protected function configure(): void
     {

--- a/src/Console/Command/MailRouteCommand.php
+++ b/src/Console/Command/MailRouteCommand.php
@@ -26,7 +26,7 @@ class MailRouteCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'mail:route';
     public const USAGE = self::DEFAULT_COMMAND . '  [filename]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     protected function configure(): void
     {

--- a/src/Console/Command/MonitorCommand.php
+++ b/src/Console/Command/MonitorCommand.php
@@ -37,7 +37,7 @@ class MonitorCommand extends SymfonyCommand
     public const STATE_UNKNOWN = 3;
     public const STATE_DEPENDENT = 4;
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var OutputInterface */
     private $output;

--- a/src/Console/Command/ReminderCheckCommand.php
+++ b/src/Console/Command/ReminderCheckCommand.php
@@ -27,7 +27,7 @@ class ReminderCheckCommand extends SymfonyCommand
     public const DEFAULT_COMMAND = 'reminder:check';
     public const USAGE = self::DEFAULT_COMMAND . ' [--debug]';
 
-    protected static $defaultName = self::DEFAULT_COMMAND;
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
 
     /** @var OutputInterface */
     private $output;


### PR DESCRIPTION
This improves coloring and var dumper for context arguments.

The Symfony console commands are prefixed with eventum now:

```
➔ ./bin/console.php -e prod
Symfony 4.4.8 (env: prod, debug: false)

Usage:
  command [options] [arguments]

Options:
  -h, --help            Display this help message
  -q, --quiet           Do not output any message
  -V, --version         Display this application version
      --ansi            Force ANSI output
      --no-ansi         Disable ANSI output
  -n, --no-interaction  Do not ask any interactive question
  -e, --env=ENV         The Environment name. [default: "prod"]
      --no-debug        Switches off debug mode.
  -v|vv|vvv, --verbose  Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug

Available commands:
 eventum
  eventum:attachment:migrate
  eventum:export:issues
  eventum:extension:enable
  eventum:ldap:sync
  eventum:mail-queue:process
  eventum:mail-queue:truncate
  eventum:mail:download
  eventum:mail:route
  eventum:reminder:check
  eventum:system:monitor
```