### PR TITLE
Allow choosing Auth adapters from Extension provides

### DIFF
--- a/docs/examples/extension/Auth/NullAuthAdapter.php
+++ b/docs/examples/extension/Auth/NullAuthAdapter.php
@@ -1,0 +1,72 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Example\Auth;
+
+use Eventum\Auth\Adapter\AdapterInterface;
+
+class NullAuthAdapter implements AdapterInterface
+{
+    public function verifyPassword(string $login, string $password): bool
+    {
+        return false;
+    }
+
+    public function updatePassword(int $usr_id, string $password): bool
+    {
+        return false;
+    }
+
+    public function userExists(string $login): bool
+    {
+        return false;
+    }
+
+    public function getUserId(string $login): ?int
+    {
+        return null;
+    }
+
+    public function canUserUpdateName(int $usr_id): bool
+    {
+        return false;
+    }
+
+    public function canUserUpdateEmail(int $usr_id): bool
+    {
+        return false;
+    }
+
+    public function canUserUpdatePassword(int $usr_id): bool
+    {
+        return false;
+    }
+
+    public function getExternalLoginURL(): ?string
+    {
+        return null;
+    }
+
+    public function autoRedirectToExternalLogin(): bool
+    {
+        return false;
+    }
+
+    public function checkAuthentication(): void
+    {
+    }
+
+    public function logout(): void
+    {
+    }
+}

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -15,6 +15,7 @@ namespace Example;
 
 use Eventum\Extension\ClassLoader;
 use Eventum\Extension\Provider;
+use Example\Auth\NullAuthAdapter;
 
 /**
  * Example Eventum Extension.
@@ -171,6 +172,7 @@ class ExampleExtension implements
     public function getAvailableAuthAdapters(): array
     {
         return [
+            NullAuthAdapter::class,
         ];
     }
 }

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -29,6 +29,7 @@ class ExampleExtension implements
     Provider\AutoloadProvider,
     Provider\CrmProvider,
     Provider\CustomFieldProvider,
+    Provider\AuthAdapterProvider,
     Provider\PartnerProvider,
     Provider\SubscriberProvider,
     Provider\WorkflowProvider
@@ -158,6 +159,18 @@ class ExampleExtension implements
             Subscriber\GitlabLinkSubscriber::class,
             Subscriber\HistorySubscriber::class,
             Subscriber\UserSubscriber::class,
+        ];
+    }
+
+    /**
+     * Return class names implementing Auth\Adapter\AdapterInterface
+     *
+     * @return string[]
+     * @see \Eventum\Extension\Provider\AuthAdapterProvider
+     */
+    public function getAvailableAuthAdapters(): array
+    {
+        return [
         ];
     }
 }

--- a/src/Auth/Adapter/ChainAdapter.php
+++ b/src/Auth/Adapter/ChainAdapter.php
@@ -152,12 +152,12 @@ class ChainAdapter implements AdapterInterface
     {
         foreach ($this->adapters as $adapter) {
             $redirect = $adapter->autoRedirectToExternalLogin();
-            if ($redirect !== null) {
+            if ($redirect !== false) {
                 return $redirect;
             }
         }
 
-        return null;
+        return false;
     }
 
     /**

--- a/src/Auth/Adapter/Factory.php
+++ b/src/Auth/Adapter/Factory.php
@@ -13,6 +13,8 @@
 
 namespace Eventum\Auth\Adapter;
 
+use Eventum\Extension\ExtensionManager;
+use Eventum\ServiceContainer;
 use InvalidArgumentException;
 use ReflectionClass;
 use Traversable;
@@ -57,7 +59,7 @@ abstract class Factory
      */
     public static function getAdapterList(): array
     {
-        return [
+        $adapters = [
             MysqlAdapter::class => [],
             LdapAdapter::class => [],
             CasAdapter::class => [],
@@ -68,5 +70,17 @@ abstract class Factory
                 ],
             ],
         ];
+
+        /** @var ExtensionManager $em */
+        $em = ServiceContainer::get(ExtensionManager::class);
+        foreach ($em->getAvailableAuthAdapters() as $className => $options) {
+            if (is_numeric($className)) {
+                $className = $options;
+                $options = [];
+            }
+            $adapters[$className] = $options;
+        }
+
+        return $adapters;
     }
 }

--- a/src/Controller/Manage/AuthController.php
+++ b/src/Controller/Manage/AuthController.php
@@ -15,9 +15,11 @@ namespace Eventum\Controller\Manage;
 
 use Eventum\Auth\Adapter\Factory;
 use Eventum\Auth\AuthException;
+use Eventum\ServiceContainer;
 use ReflectionClass;
 use Setup;
 use User;
+use Zend\Config\Config;
 
 class AuthController extends ManageBaseController
 {
@@ -95,8 +97,8 @@ class AuthController extends ManageBaseController
 
     private function getAuthAdapterConfig(): array
     {
-        /** @var \Zend\Config\Config $config */
-        $config = Setup::get()['auth'];
+        /** @var Config $config */
+        $config = ServiceContainer::getConfig()['auth'];
         $configOptions = $config['options']->toArray();
         $adapters = [];
         $options = [];
@@ -105,7 +107,7 @@ class AuthController extends ManageBaseController
         foreach ($adapterList as $adapterClass => $defaultOptions) {
             $reflection = new ReflectionClass($adapterClass);
             $displayName = $reflection->getConstant('displayName');
-            $adapters[$adapterClass] = $displayName;
+            $adapters[$adapterClass] = $displayName ?: $adapterClass;
             $options[$adapterClass] = $configOptions[$adapterClass] ?? $defaultOptions;
         }
 

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Extension;
 
+use ArrayIterator;
 use Eventum\Logger\LoggerTrait;
 use Eventum\ServiceContainer;
 use Generator;
@@ -101,6 +102,21 @@ class ExtensionManager implements Provider\RouteProvider
         return $this->createInstances(__FUNCTION__, static function (Provider\ExtensionProvider $extension) {
             return $extension instanceof Provider\SubscriberProvider;
         });
+    }
+
+    /**
+     * Return instances of Partner implementations.
+     */
+    public function getAvailableAuthAdapters(): iterable
+    {
+        /** @var Provider\RouteProvider[] $extensions */
+        $extensions = $this->filterExtensions(static function (Provider\ExtensionProvider $extension) {
+            return $extension instanceof Provider\AuthAdapterProvider;
+        });
+
+        foreach ($extensions as $extension) {
+            yield from new ArrayIterator($extension->getAvailableAuthAdapters());
+        }
     }
 
     public function configureRoutes(RouteCollectionBuilder $routes): void

--- a/src/Extension/Provider/AuthAdapterProvider.php
+++ b/src/Extension/Provider/AuthAdapterProvider.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension\Provider;
+
+interface AuthAdapterProvider extends ExtensionProvider
+{
+    /**
+     * Return class names implementing Auth\Adapter\AdapterInterface
+     *
+     * @return string[]
+     * @since 3.8.13
+     */
+    public function getAvailableAuthAdapters(): array;
+}


### PR DESCRIPTION
Allows an extension to provide class names that implement `Auth\Adapter\AdapterInterface`.


```php
<?php

namespace Example;

use Eventum\Extension\ClassLoader;
use Eventum\Extension\Provider;
use Example\Auth\NullAuthAdapter;

/**
 * Example Eventum Extension.
 *
 * To enable this extension, write to config/setup.php:
 *
 * 'extensions' => [
 *   'Eventum\\Extension\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
 * ],
 */
class ExampleExtension implements Provider\AuthAdapterProvider
{
    /**
     * Return class names implementing Auth\Adapter\AdapterInterface
     *
     * @return string[]
     * @see \Eventum\Extension\Provider\AuthAdapterProvider
     */
    public function getAvailableAuthAdapters(): array
    {
        return [
            NullAuthAdapter::class,
        ];
    }
}

```

Refs:
- https://github.com/eventum/eventum/issues/847