### PR TITLE
Remove dangerous feature: removing emails when deleting email account

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to latest 3.5.x version first.
 
+- Remove dangerous feature: removing emails when deleting email account, #853
+
 [3.8.14]: https://github.com/eventum/eventum/compare/v3.8.13...master
 
 ## [3.8.13] - 2020-05-24

--- a/lib/eventum/class.email_account.php
+++ b/lib/eventum/class.email_account.php
@@ -193,8 +193,6 @@ class Email_Account
             return false;
         }
 
-        Support::removeEmailByAccounts($items);
-
         return true;
     }
 

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -307,32 +307,6 @@ class Support
     }
 
     /**
-     * Method used to remove all support email entries associated with
-     * a specified list of support email accounts.
-     *
-     * @param   array $ids The list of support email accounts
-     * @return  bool
-     */
-    public static function removeEmailByAccounts($ids)
-    {
-        if (count($ids) < 1) {
-            return true;
-        }
-
-        $stmt = 'DELETE FROM
-                    `support_email`
-                 WHERE
-                    sup_ema_id IN (' . DB_Helper::buildList($ids) . ')';
-        try {
-            DB_Helper::getInstance()->query($stmt);
-        } catch (DatabaseException $e) {
-            return false;
-        }
-
-        return true;
-    }
-
-    /**
      * Method used to build the server URI to connect to.
      *
      * @param   array $info The email server information


### PR DESCRIPTION
Missed a similar scenario when deleting email account:
- https://github.com/eventum/eventum/pull/206

This is also probably too slow, to execute, and would require manual cleanup (optimize tables) if someone really wants to deleted emails related to an email account.