### PR TITLE
Fix privilege check when closing issues

### DIFF
--- a/src/Controller/CloseController.php
+++ b/src/Controller/CloseController.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Controller;
 
+use Access;
 use Auth;
 use Contract;
 use CRM;
@@ -72,8 +73,7 @@ class CloseController extends BaseController
         $this->prj_id = Auth::getCurrentProject();
         $this->role_id = Auth::getCurrentRole();
 
-        // FIXME: ROLE_CUSTOMER check superfluous regarding Issue::canAccess?
-        return !($this->role_id === User::ROLE_CUSTOMER || !Issue::canAccess($this->issue_id, $this->usr_id));
+        return Access::canUpdateIssue($this->issue_id, $this->usr_id);
     }
 
     /**


### PR DESCRIPTION
The privilege check in CloseController is insufficient, it does not
verify that the user actually has permissions to update the issue. A
user with 'Viewer' or 'Reporter' role can close issues by entering the
close.php URL.