### PR TITLE
Markdown preview and help link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to the latest 3.5.x version first.
 
+- Markdown preview and help link, #860
+
 [3.8.16]: https://github.com/eventum/eventum/compare/v3.8.15...master
 
 ## [3.8.15] - 2020-06-02

--- a/res/assets/scripts/Eventum.js
+++ b/res/assets/scripts/Eventum.js
@@ -379,4 +379,22 @@ export class Eventum {
             }
         }
     }
+
+    showPreview(input_id, preview_id) {
+        const $input = $(input_id);
+        $input.hide();
+
+        const $preview = $(preview_id);
+        $preview.load(this.rel_url + 'get_remote_data.php?action=preview', { source: $input.val() });
+        $preview.show();
+    }
+
+    hidePreview(input_id, preview_id) {
+        const $input = $(input_id);
+        $input.show();
+
+        const $preview = $(preview_id);
+        $preview.hide();
+    }
+
 }

--- a/src/Controller/RemoteDataController.php
+++ b/src/Controller/RemoteDataController.php
@@ -105,6 +105,10 @@ class RemoteDataController extends BaseController
                 $res = $this->getIssueDescription($this->list_id);
                 break;
 
+            case 'preview':
+                $res = $this->getPreview();
+                break;
+
             default:
                 $res = 'ERROR: Unable to call function ' . htmlspecialchars($this->action);
         }
@@ -242,6 +246,18 @@ class RemoteDataController extends BaseController
         $raw = $res['maq_headers'] . "\n" . $res['maq_body'];
 
         return nl2br(htmlspecialchars($raw, ENT_SUBSTITUTE));
+    }
+
+    /**
+     * Renders an HTML preview of a markdown message.
+     *
+     * @return  string the rendered message
+     */
+    private function getPreview(): string
+    {
+        $request = $this->getRequest();
+        $source = (string) $request->get('source');
+        return !empty($source) ? $this->processText($source) : "";
     }
 
     private function processText($text)

--- a/templates/add_phone_entry.tpl.html
+++ b/templates/add_phone_entry.tpl.html
@@ -139,8 +139,12 @@ $().ready(function() {
               <tr>
                 <th width="190" nowrap>{t}Description{/t}</th>
                 <td>
-                  <textarea name="description" rows="8" style="width: 97%"></textarea>
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}</a>
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}</a>
+                  <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
+                  <textarea id="description" name="description" rows="8" style="width: 97%"></textarea>
                   {include file="error_icon.tpl.html" field="description"}
+                  <div id="preview" style="width: 97%"></div>
                 </td>
               </tr>
               <tr class="buttons">

--- a/templates/bulk_update.tpl.html
+++ b/templates/bulk_update.tpl.html
@@ -82,7 +82,11 @@
 
               <div id="close_message_popup" style="display: none">
                   <label for="closed_message">{t}Closed Message{/t}</label><br />
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#closed_message_popup', '#preview')">{t}[Write]{/t}</a>
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#closed_message_popup', '#preview')">{t}[Preview]{/t}</a>
+                  <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                   <textarea id="closed_message_popup" name="closed_message_popup" rows="8" cols="80">Issue Bulk closed</textarea>
+                  <div id="preview"></div>
                   <br />
                   <input id="closed_set_message" type="button" value="{t}Set Message{/t}">
               </div>

--- a/templates/include/new_form.tpl.html
+++ b/templates/include/new_form.tpl.html
@@ -185,13 +185,17 @@
         {t}Description{/t} * {include file="help_link.tpl.html" topic="report_description"}
       </th>
       <td>
+        <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}<a>
+        <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}<a>
+        <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
         {if $new_issue_id != ''}
             {assign var='issue_description' value=''}
         {elseif $issue_description|default:'' == ''}
             {assign var='issue_description' value=$defaults.description|default:''}
         {/if}
-        <textarea name="description" rows="10" tabindex="{$tabindex++}" style="width: 97%">{$issue_description|default:''}</textarea>
+        <textarea id="description" name="description" rows="10" tabindex="{$tabindex++}" style="width: 97%">{$issue_description|default:''}</textarea>
         {include file="error_icon.tpl.html" field="description"}
+        <div id="preview" style="width: 97%"></div>
       </td>
     </tr>
 

--- a/templates/manage/email_responses.tpl.html
+++ b/templates/manage/email_responses.tpl.html
@@ -77,8 +77,13 @@
               {t}Response Body{/t}
             </th>
             <td>
-              <textarea name="response_body" cols="50" rows="10">{$info.ere_response_body|default:''|escape:"html"}</textarea>
+              <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#response_body', '#preview')">{t}[Write]{/t}</a>
+              <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#response_body', '#preview')">{t}[Preview]{/t}</a>
+              <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
+              <br>
+              <textarea id="response_body" name="response_body" cols="50" rows="10">{$info.ere_response_body|default:''|escape:"html"}</textarea>
               {include file="error_icon.tpl.html" field="response_body"}
+              <div id="preview"></div>
             </td>
           </tr>
           <tr class="buttons">

--- a/templates/manage/faq.tpl.html
+++ b/templates/manage/faq.tpl.html
@@ -141,8 +141,13 @@
           {t}Message{/t}
         </th>
         <td>
-          <textarea name="message" cols="50" rows="10">{$info.faq_message|escape:"html"|default:''}</textarea>
+          <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#message', '#preview')">{t}[Write]{/t}</a>
+          <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#message', '#preview')">{t}[Preview]{/t}</a>
+          <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
+          <br>
+          <textarea id="message" name="message" cols="50" rows="10">{$info.faq_message|escape:"html"|default:''}</textarea>
           {include file="error_icon.tpl.html" field="message"}
+          <div id="preview"></div>
         </td>
       </tr>
       <tr class="buttons">

--- a/templates/manage/news.tpl.html
+++ b/templates/manage/news.tpl.html
@@ -93,8 +93,13 @@ function checkDelete()
       {t}Message{/t}:
     </th>
     <td>
-      <textarea name="message" cols="50" rows="10">{$info.nws_message|escape:"html"|default:''}</textarea>
+      <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#message', '#preview')">{t}[Write]{/t}</a>
+      <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#message', '#preview')">{t}[Preview]{/t}</a>
+      <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
+      <br>
+      <textarea id="message" name="message" cols="50" rows="10">{$info.nws_message|escape:"html"|default:''}</textarea>
       {include file="error_icon.tpl.html" field="message"}
+      <div id="preview"></div>
     </td>
   </tr>
   <tr class="buttons">

--- a/templates/post_note.tpl.html
+++ b/templates/post_note.tpl.html
@@ -130,11 +130,15 @@
         </tr>
         <tr>
             <td colspan="2">
+                <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#note', '#preview')">{t}[Write]{/t}</a>
+                <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#note', '#preview')">{t}[Preview]{/t}</a>
+                <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                 <textarea id="note" name="note" rows="16" style="width: 97%">{$note.not_body|default:""|escape:"html"}{if $core.current_user_prefs.auto_append_note_sig}
 
 
 {$core.current_user_prefs.email_signature|escape:"html"}{/if}</textarea>
                 {include file="error_icon.tpl.html" field="note"}
+                <div id="preview" style="width: 97%"></div>
             </td>
         </tr>
         <tr>

--- a/templates/update_form.tpl.html
+++ b/templates/update_form.tpl.html
@@ -225,7 +225,11 @@
                       {$issue.iss_description|textFormat:$issue.iss_id}
                     </span>
                     {else}
-                    <textarea name="description" rows="20" style="width: 97%">{$issue.iss_original_description|escape:"html"}</textarea>
+                    <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}</a>
+                    <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}</a>
+                    <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
+                    <textarea id="description" name="description" rows="20" style="width: 97%">{$issue.iss_original_description|escape:"html"}</textarea>
+                    <div id="preview" style="width: 97%"></div>
                     {/if}
                     {include file="error_icon.tpl.html" field="description"}
                 </td>


### PR DESCRIPTION
Implement Markdown preview and add a help link for the Markdown syntax
to the following text areas:

- New/update issue description
- Internal note
- Bulk close message
- Phone call description
- Manage news
- Manage internal FAQ
- Manage canned email responses

Notes:
- This is pretty basic and has room for improvement, but it works pretty well.
- I'm unsure about the (mis)use of `RemoteDataController` which is otherwise only used for expandable cells.