### PR TITLE
Fix category/priority mapping when moving an issue between projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 Upgrading to 3.8.x versions requires that you upgrade to the latest 3.5.x version first.
 
+- Fix category/priority mapping when moving an issue between projects, #864
+
 [3.8.17]: https://github.com/eventum/eventum/compare/v3.8.16...master
 
 ## [3.8.16] - 2020-06-04

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -1492,8 +1492,9 @@ class Issue
         $new_prc_id = array_search($iss_prc_title, $new_iss_prc_list);
         if ($new_prc_id === false) {
             // use the first category listed in the new project
-            $mapping['iss_prc_id'] = key($new_iss_prc_list);
+            $new_prc_id = key($new_iss_prc_list);
         }
+        $mapping['iss_prc_id'] = $new_prc_id;
 
         // set new priority
         $new_iss_pri_list = Priority::getAssocList($new_prj_id);
@@ -1501,8 +1502,9 @@ class Issue
         $new_pri_id = array_search($iss_pri_title, $new_iss_pri_list);
         if ($new_pri_id === false) {
             // use the first category listed in the new project
-            $mapping['iss_pri_id'] = key($new_iss_pri_list);
+            $new_pri_id = key($new_iss_pri_list);
         }
+        $mapping['iss_pri_id'] = $new_pri_id;
 
         return Workflow::getMovedIssueMapping($new_prj_id, $issue_id, $mapping, $current_details['iss_prj_id']);
     }


### PR DESCRIPTION
If a matching category or priority was found in the target project the
new values were accidentally not applied. This feature was broken since
commit 019bb91d.