### PR TITLE
Update PHP requirement to 7.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ jobs:
       language:
         - node_js
         - php
-      php: "7.1"
+      php: "7.2"
       node_js: "10"
       script:
         - node --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 sudo: required
-dist: trusty
+dist: xenial
 
 # disable the default submodule logic
 git:
@@ -28,7 +28,6 @@ jobs:
     # TODO: would be nice to have two separate stages, one for build, and other for actually publishing
     - stage: release
       name: GitHub Release
-      dist: xenial
       language:
         - node_js
         - php

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details how to upgrade.
 
+- Update PHP requirement to 7.2, #868
+
 [3.9.0]: https://github.com/eventum/eventum/compare/v3.9.0...master
 
 ## [3.8.17] - 2020-06-20

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## [3.9.0]
 
-Upgrading to 3.9.x versions requires that you upgrade to the latest 3.5.x version first.
+See [Upgrading] for details how to upgrade.
 
 [3.9.0]: https://github.com/eventum/eventum/compare/v3.9.0...master
 
@@ -2040,3 +2040,5 @@ This release uses Composer for PHP Class autoloader.
 ## 1.1 - 2004-06-05
 
 - Initial release (João; Bryan)
+
+[Upgrading]: docs/wiki/Upgrading.md

--- a/bin/releng/bump.sh
+++ b/bin/releng/bump.sh
@@ -14,7 +14,7 @@ cat <<EOF | patch -p1
  
 +## [$new]
 +
-+Upgrading to 3.9.x versions requires that you upgrade to the latest 3.5.x version first.
++See [Upgrading] for details how to upgrade.
 +
 +[$new]: https://github.com/eventum/eventum/compare/v$old...master
 +

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.1.3 || ^8.0",
+        "php": "^7.2.0 || ^8.0",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",
@@ -111,7 +111,7 @@
     "config": {
         "autoloader-suffix": "EventumCore",
         "platform": {
-            "php": "7.1.3",
+            "php": "7.2.5",
             "ext-mongodb": "1.5.0"
         },
         "sort-packages": true

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b562e90880a44dba14eb0a7e9597f599",
+    "content-hash": "281b5052abbd0d47fb322fa12a8819a5",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -8134,7 +8134,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.1.3 || ^8.0",
+        "php": "^7.2.0 || ^8.0",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",
@@ -8153,7 +8153,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.1.3",
+        "php": "7.2.5",
         "ext-mongodb": "1.5.0"
     },
     "plugin-api-version": "1.1.0"

--- a/docs/wiki/Upgrading.md
+++ b/docs/wiki/Upgrading.md
@@ -15,6 +15,7 @@ See 2.2 upgrade instructions how to convert database to UTF-8.
 
 When upgrading to a new version of Eventum, please follow these instructions:
 
+1.  Check the [requirements](Prerequisites.md) for the version
 1.  Backup your copy of Eventum - files and data.
 2.  Extract your new Eventum copy over your existing folder structure
 3.  Run the upgrade scripts described in below

--- a/docs/wiki/Upgrading.md
+++ b/docs/wiki/Upgrading.md
@@ -26,7 +26,10 @@ When upgrading to a new version of Eventum, please follow these instructions:
 -   Rename your current Eventum dir to `eventum.old`
 -   Extract Eventum release tarball and rename it to `eventum` directory.
 -   Copy all config files from old version to new version: `eventum.old/config` to `eventum/config`
--   If your workflow API, customer API or custom field files to were in `lib/eventum` copy them to `config/`: - `eventum.old/lib/eventum/workflow/` -> `eventum/config/workflow/` - `eventum.old/lib/eventum/customer/` -> `eventum/config/customer/` - `eventum.old/lib/eventum/custom_field/` -> `eventum/config/custom_field/`
+-   If your workflow API, customer API or custom field files to were in `lib/eventum` copy them to `config/`:
+    - `eventum.old/lib/eventum/workflow/` -> `eventum/config/workflow/`
+    - `eventum.old/lib/eventum/customer/` -> `eventum/config/customer/`
+    - `eventum.old/lib/eventum/custom_field/` -> `eventum/config/custom_field/`
 -   Ensure your database database partition has enough disk space and run upgrade script: `php bin/upgrade.php` (`upgrade/update-database.php` in older versions)
 -   Modify your workflow/customer classes not to require any Eventum core classes, they are autoloaded now. So you can just remove such lines:
 
@@ -35,7 +38,7 @@ require_once(APP_INC_PATH."workflow/class.abstract_workflow_backend.php");
 require_once(APP_INC_PATH."customer/class.abstract_customer_backend.php");
 ```
 
--   Update your cron jobs to point to the scripts in the new location (see [INSTALL](System-Admin%3A-Doing-a-fresh-install)).
+-   Update your cron jobs to point to the scripts in the new location (see [INSTALL](System-Admin/Doing-a-fresh-install.md)).
     Previously the scripts were in 'crons', now in 'bin', eg:
 
 ```
@@ -52,9 +55,13 @@ require_once(APP_INC_PATH."customer/class.abstract_customer_backend.php");
 
 -   Since 3.2.0 MySQL extension was changed from mysql/mysqli to [PDO_MySQL](https://github.com/eventum/eventum/pull/252):
 
+## Upgrading from versions before 3.5
+
+You need to upgrade to 3.5.0 first before you can upgrade to versions 3.5.x and above
+
 ## Upgrading from versions before 3.2
 
-You need to upgrade to 3.2.0 first before you can upgrade to 3.2.x versions. [#270](https://github.com/eventum/eventum/pull/270)
+You need to upgrade to 3.2.0 first before you can upgrade to versions 3.2.x and above. [#270](https://github.com/eventum/eventum/pull/270)
 
 ## Upgrading from versions before 3.0
 


### PR DESCRIPTION
- PHP 7.1 is [EOL] since 1 Dec 2019.
- Updating to 7.2 allows us to [upgrade Symfony components to 5.1][1]
- Allows to update [phinx to 0.12][2]
- I've been using 7.2 in production for quite a while
- The current recommended PHP version is 7.3

[EOL]: https://www.php.net/eol.php
[1]: https://github.com/symfony/symfony/blob/v5.1.2/composer.json#L19
[2]: https://github.com/cakephp/phinx/blob/0.12.1/composer.json#L28