### PR TITLE
Move Markdown code to own namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Upgrading] for details how to upgrade.
 - Implement `getIssueCloser` in Doctrine, #869
 - Drop deprecated `config/config.php`, #704
 - Add attributes and footnotes support to markdown rendering, #871
+- Move Markdown code to own namespace, #874
 
 [3.9.0]: https://github.com/eventum/eventum/compare/v3.9.0...master
 

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -16,7 +16,7 @@ use Eventum\Db\Adapter\AdapterInterface;
 use Eventum\Db\DatabaseException;
 use Eventum\LinkFilter\IssueLinkFilter;
 use Eventum\LinkFilter\LinkFilter;
-use Eventum\Markdown\Markdown;
+use Eventum\Markdown\MarkdownRenderer;
 
 /**
  * Class to handle parsing content for links.
@@ -257,7 +257,7 @@ class Link_Filter
         static $parser;
 
         if (!$parser) {
-            $parser = new Markdown();
+            $parser = new MarkdownRenderer();
         }
 
         if ($inline) {

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -16,7 +16,7 @@ use Eventum\Db\Adapter\AdapterInterface;
 use Eventum\Db\DatabaseException;
 use Eventum\LinkFilter\IssueLinkFilter;
 use Eventum\LinkFilter\LinkFilter;
-use Eventum\Markdown;
+use Eventum\Markdown\Markdown;
 
 /**
  * Class to handle parsing content for links.

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -16,7 +16,8 @@ use Eventum\Db\Adapter\AdapterInterface;
 use Eventum\Db\DatabaseException;
 use Eventum\LinkFilter\IssueLinkFilter;
 use Eventum\LinkFilter\LinkFilter;
-use Eventum\Markdown\MarkdownRenderer;
+use Eventum\Markdown\MarkdownRendererInterface;
+use Eventum\ServiceContainer;
 
 /**
  * Class to handle parsing content for links.
@@ -257,7 +258,7 @@ class Link_Filter
         static $parser;
 
         if (!$parser) {
-            $parser = new MarkdownRenderer();
+            $parser = ServiceContainer::get(MarkdownRendererInterface::class);
         }
 
         if ($inline) {

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -255,17 +255,13 @@ class Link_Filter
 
     public static function markdownFormat(string $text, bool $inline = false): string
     {
-        static $parser;
-
-        if (!$parser) {
-            $parser = ServiceContainer::get(MarkdownRendererInterface::class);
-        }
-
         if ($inline) {
-            return $parser->renderInline($text);
+            $renderer = ServiceContainer::get(MarkdownRendererInterface::RENDER_INLINE);
+        } else {
+            $renderer = ServiceContainer::get(MarkdownRendererInterface::RENDER_BLOCK);
         }
 
-        return $parser->render($text);
+        return $renderer->render($text);
     }
 
     /**

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -397,7 +397,7 @@ final class SystemEvents
      * Event to allow configuring markdown renderer.
      *
      * @since 3.6.3
-     * @see \Eventum\Markdown\MarkdownRenderer::applyExtensions
+     * @see \Eventum\ServiceProvider\MarkdownServiceProvider::applyExtensions
      */
     public const MARKDOWN_ENVIRONMENT_CONFIGURE = 'markdown.environment.configure';
 

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -397,7 +397,7 @@ final class SystemEvents
      * Event to allow configuring markdown renderer.
      *
      * @since 3.6.3
-     * @see \Eventum\Markdown::applyExtensions
+     * @see \Eventum\Markdown\Markdown::applyExtensions
      */
     public const MARKDOWN_ENVIRONMENT_CONFIGURE = 'markdown.environment.configure';
 

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -397,7 +397,7 @@ final class SystemEvents
      * Event to allow configuring markdown renderer.
      *
      * @since 3.6.3
-     * @see \Eventum\Markdown\Markdown::applyExtensions
+     * @see \Eventum\Markdown\MarkdownRenderer::applyExtensions
      */
     public const MARKDOWN_ENVIRONMENT_CONFIGURE = 'markdown.environment.configure';
 

--- a/src/Markdown/CommonMark/UserLookup.php
+++ b/src/Markdown/CommonMark/UserLookup.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\CommonMark;
+namespace Eventum\Markdown\CommonMark;
 
 use Eventum\Db\Doctrine;
 use Eventum\Model\Entity\User;

--- a/src/Markdown/CommonMark/UserMentionGenerator.php
+++ b/src/Markdown/CommonMark/UserMentionGenerator.php
@@ -11,7 +11,7 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\CommonMark;
+namespace Eventum\Markdown\CommonMark;
 
 use League\CommonMark\Extension\Mention\Generator\MentionGeneratorInterface;
 use League\CommonMark\Extension\Mention\Mention;

--- a/src/Markdown/Markdown.php
+++ b/src/Markdown/Markdown.php
@@ -11,11 +11,12 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum;
+namespace Eventum\Markdown;
 
-use Eventum\CommonMark\UserMentionGenerator;
 use Eventum\Config\Paths;
+use Eventum\Event;
 use Eventum\EventDispatcher\EventManager;
+use Eventum\Markdown\CommonMark\UserMentionGenerator;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
 use League\CommonMark\CommonMarkConverter;

--- a/src/Markdown/MarkdownRenderer.php
+++ b/src/Markdown/MarkdownRenderer.php
@@ -35,7 +35,7 @@ use Misc;
 use Setup;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
-final class Markdown
+final class MarkdownRenderer implements MarkdownRendererInterface
 {
     private const PURIFIER_CACHE_DIR = Paths::APP_CACHE_PATH . '/purifier';
     /**

--- a/src/Markdown/MarkdownRenderer.php
+++ b/src/Markdown/MarkdownRenderer.php
@@ -13,41 +13,19 @@
 
 namespace Eventum\Markdown;
 
-use Eventum\Event;
-use Eventum\EventDispatcher\EventManager;
-use Eventum\Markdown\CommonMark\UserMentionGenerator;
 use HTMLPurifier;
-use League\CommonMark\CommonMarkConverter;
-use League\CommonMark\Environment;
-use League\CommonMark\Extension\Attributes\AttributesExtension;
-use League\CommonMark\Extension\Autolink\AutolinkExtension;
-use League\CommonMark\Extension\CommonMarkCoreExtension;
-use League\CommonMark\Extension\Footnote\FootnoteExtension;
-use League\CommonMark\Extension\HeadingPermalink\HeadingPermalinkExtension;
-use League\CommonMark\Extension\InlinesOnly\InlinesOnlyExtension;
-use League\CommonMark\Extension\Mention\MentionExtension;
-use League\CommonMark\Extension\Table\TableExtension;
-use League\CommonMark\Extension\TaskList\TaskListExtension;
 use League\CommonMark\MarkdownConverterInterface;
-use Setup;
-use Symfony\Component\EventDispatcher\GenericEvent;
 
 final class MarkdownRenderer implements MarkdownRendererInterface
 {
-    /**
-     * Use moderately sane value
-     *
-     * @see https://commonmark.thephpleague.com/security/#nesting-level
-     */
-    private const MAX_NESTING_LEVEL = 500;
-
     /** @var HTMLPurifier */
     private $purifier;
-    /** @var MarkdownConverterInterface[] */
-    private $converter = [];
+    /** @var MarkdownConverterInterface */
+    private $converter;
 
-    public function __construct(HTMLPurifier $purifier)
+    public function __construct(MarkdownConverterInterface $converter, HTMLPurifier $purifier)
     {
+        $this->converter = $converter;
         $this->purifier = $purifier;
     }
 
@@ -57,79 +35,9 @@ final class MarkdownRenderer implements MarkdownRendererInterface
             return $text;
         }
 
-        $html = $this->getConverter(false)->convertToHtml($text);
+        $html = $this->converter->convertToHtml($text);
         $html = $this->purifier->purify($html);
 
         return $html;
-    }
-
-    public function renderInline(string $text): string
-    {
-        if (!$text) {
-            return $text;
-        }
-
-        $html = $this->getConverter(true)->convertToHtml($text);
-        $html = $this->purifier->purify($html);
-
-        return $html;
-    }
-
-    private function getConverter(bool $inline): MarkdownConverterInterface
-    {
-        return $this->converter[(int)$inline] ?? $this->converter[(int)$inline] = $this->createConverter($inline);
-    }
-
-    private function createConverter(bool $inline): MarkdownConverterInterface
-    {
-        $config = [
-            'renderer' => [
-                'block_separator' => "\n",
-                'inner_separator' => "\n",
-                'soft_break' => "<br />\n",
-            ],
-            'html_input' => Environment::HTML_INPUT_ALLOW,
-            'allow_unsafe_links' => false,
-            'max_nesting_level' => self::MAX_NESTING_LEVEL,
-            'heading_permalink' => [
-                'inner_contents' => '¶',
-                'insert' => 'after',
-            ],
-
-            // https://commonmark.thephpleague.com/1.5/extensions/mentions/
-            'mentions' => [
-                'eventum_handle' => [
-                    'symbol' => '@',
-                    'regex' => '/^[A-Za-z0-9_]{1,255}(?!\w)/',
-                    'generator' => new UserMentionGenerator(Setup::getBaseUrl()),
-                ],
-            ],
-        ];
-
-        $environment = new Environment($config);
-        if ($inline) {
-            $environment->addExtension(new InlinesOnlyExtension());
-        } else {
-            $environment->addExtension(new CommonMarkCoreExtension());
-        }
-
-        $this->applyExtensions($environment);
-
-        return new CommonMarkConverter([], $environment);
-    }
-
-    private function applyExtensions(Environment $environment): void
-    {
-        $environment->addExtension(new AutolinkExtension());
-        $environment->addExtension(new TaskListExtension());
-        $environment->addExtension(new TableExtension());
-        $environment->addExtension(new HeadingPermalinkExtension());
-        $environment->addExtension(new AttributesExtension());
-        $environment->addExtension(new FootnoteExtension());
-        $environment->addExtension(new MentionExtension());
-
-        // allow extensions to apply behaviour
-        $event = new GenericEvent($environment);
-        EventManager::dispatch(Event\SystemEvents::MARKDOWN_ENVIRONMENT_CONFIGURE, $event);
     }
 }

--- a/src/Markdown/MarkdownRendererInterface.php
+++ b/src/Markdown/MarkdownRendererInterface.php
@@ -15,7 +15,8 @@ namespace Eventum\Markdown;
 
 interface MarkdownRendererInterface
 {
-    public function render(string $text): string;
+    public const RENDER_BLOCK = self::class . '::block';
+    public const RENDER_INLINE = self::class . '::inline';
 
-    public function renderInline(string $text): string;
+    public function render(string $text): string;
 }

--- a/src/Markdown/MarkdownRendererInterface.php
+++ b/src/Markdown/MarkdownRendererInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Markdown;
+
+interface MarkdownRendererInterface
+{
+    public function render(string $text): string;
+
+    public function renderInline(string $text): string;
+}

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -28,6 +28,7 @@ class ServiceContainer
             $container = new Container();
             $container->register(new ServiceProvider\ServiceProvider());
             $container->register(new ServiceProvider\FulltextSearchService());
+            $container->register(new ServiceProvider\MarkdownServiceProvider());
             $container->register(new ServiceProvider\ConsoleCommandsService());
         }
 

--- a/src/ServiceProvider/MarkdownServiceProvider.php
+++ b/src/ServiceProvider/MarkdownServiceProvider.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\ServiceProvider;
+
+use Eventum\Config\Paths;
+use Eventum\Markdown;
+use HTMLPurifier;
+use HTMLPurifier_HTML5Config;
+use Misc;
+use Pimple\Container;
+use Pimple\ServiceProviderInterface;
+
+class MarkdownServiceProvider implements ServiceProviderInterface
+{
+    private const PURIFIER_CACHE_DIR = Paths::APP_CACHE_PATH . '/purifier';
+
+    public function register(Container $app): void
+    {
+        $app[Markdown\MarkdownRendererInterface::class] = static function ($app) {
+            return new Markdown\MarkdownRenderer($app[HTMLPurifier::class]);
+        };
+
+        $app[HTMLPurifier::class] = static function () {
+            return self::createPurifier();
+        };
+    }
+
+    private static function createPurifier(): HTMLPurifier
+    {
+        $config = HTMLPurifier_HTML5Config::createDefault();
+
+        $config->set('AutoFormat.AutoParagraph', true);
+        // remove empty tag pairs
+        $config->set('AutoFormat.RemoveEmpty', true);
+        // remove empty, even if it contains an &nbsp;
+        $config->set('AutoFormat.RemoveEmpty.RemoveNbsp', true);
+        // preserve html comments
+        $config->set('HTML.AllowedCommentsRegexp', '/.+/');
+
+        // disable tidy processing, even if extension present
+        $config->set('Output.TidyFormat', false);
+
+        // disable useless normalizer we do not need
+        $config->set('Core.NormalizeNewlines', false);
+
+        // allow tasklist <input> checkboxes
+        // https://github.com/ezyang/htmlpurifier/issues/213#issuecomment-487206892
+        $config->set('HTML.Trusted', true);
+        $config->set('HTML.ForbiddenElements', ['script', 'noscript']);
+
+        // Absolute path with no trailing slash to store serialized definitions in.
+        $config->set('Cache.SerializerPath', Misc::ensureDir(self::PURIFIER_CACHE_DIR));
+
+        return new HTMLPurifier($config);
+    }
+}

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -13,23 +13,18 @@
 
 namespace Eventum\Test;
 
-use Eventum\Markdown\MarkdownRenderer;
+use Eventum\Markdown\MarkdownRendererInterface;
+use Eventum\ServiceProvider\MarkdownServiceProvider;
 use Generator;
+use Pimple\Container;
 
 /**
  * @group db
  */
 class MarkdownTest extends TestCase
 {
-    /** @var MarkdownRenderer */
+    /** @var MarkdownRendererInterface */
     private $renderer;
-
-    private function getRenderer(): MarkdownRenderer
-    {
-        static $renderer;
-
-        return $renderer ?: $renderer = new MarkdownRenderer();
-    }
 
     public function setUp(): void
     {
@@ -73,5 +68,13 @@ class MarkdownTest extends TestCase
                 $this->readDataFile("markdown/$testName.html"),
             ];
         }
+    }
+
+    private function getRenderer(): MarkdownRendererInterface
+    {
+        $container = new Container();
+        $container->register(new MarkdownServiceProvider());
+
+        return $container[MarkdownRendererInterface::RENDER_BLOCK];
     }
 }

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Test;
 
-use Eventum\Markdown;
+use Eventum\Markdown\Markdown;
 use Generator;
 
 /**

--- a/tests/MarkdownTest.php
+++ b/tests/MarkdownTest.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Test;
 
-use Eventum\Markdown\Markdown;
+use Eventum\Markdown\MarkdownRenderer;
 use Generator;
 
 /**
@@ -21,14 +21,14 @@ use Generator;
  */
 class MarkdownTest extends TestCase
 {
-    /** @var Markdown */
+    /** @var MarkdownRenderer */
     private $renderer;
 
-    private function getRenderer(): Markdown
+    private function getRenderer(): MarkdownRenderer
     {
         static $renderer;
 
-        return $renderer ?: $renderer = new Markdown();
+        return $renderer ?: $renderer = new MarkdownRenderer();
     }
 
     public function setUp(): void


### PR DESCRIPTION
This is internal cleanup. Moves Markdown instantiation to ServiceProvider.