### PR TITLE
Switch to use laminas/laminas-mail instead of zendframework/zend-mail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details how to upgrade.
 
+- Switch to use `laminas/laminas-mail` instead of `zendframework/zend-mail`, #876
+
 [3.9.2]: https://github.com/eventum/eventum/compare/v3.9.1...master
 
 ## [3.9.1] - 2020-07-13

--- a/build.xml
+++ b/build.xml
@@ -14,7 +14,7 @@
 				<exclude name=".idea/**"/>
 				<exclude name="releases/**"/>
 				<exclude name="var/**"/>
-				<exclude name="vendor/zendframework/zend-mail/src/Transport/Null.php"/>
+				<exclude name="vendor/laminas/laminas-mail/src/Transport/Null.php"/>
 			</fileset>
 		</phplint>
 	</target>
@@ -122,14 +122,14 @@
 				<exclude name="Exception/**"/>
 			</fileset>
 
-			<fileset dir="${vendor}/zendframework/zend-validator/src">
+			<fileset dir="${vendor}/laminas/laminas-validator/src">
 				<include name="Barcode*/**"/>
 				<include name="Db/**"/>
 				<include name="File/**"/>
 				<include name="Sitemap/**"/>
 			</fileset>
 
-			<fileset dir="${vendor}/zendframework/zend-mail/src">
+			<fileset dir="${vendor}/laminas/laminas-mail/src">
 				<!-- NULL is reserved keyword in php 7.0 -->
 				<include name="Transport/Null.php"/>
 			</fileset>

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,8 @@
         "horde/util": "dev-patch-1 as 2.5.8",
         "ircmaxell/random-lib": "^1.2",
         "laminas/laminas-config": "^3.3",
+        "laminas/laminas-mail": "^2.11",
+        "laminas/laminas-servicemanager": "^3.4",
         "league/commonmark": "^1.5",
         "league/flysystem": "^1.0",
         "league/html-to-markdown": "^4.8",
@@ -83,12 +85,9 @@
         "symfony/var-exporter": "^4.2",
         "theorchard/monolog-cascade": "^0.5.0",
         "willdurand/email-reply-parser": "^2.7.0",
-        "xemlock/htmlpurifier-html5": "^0.1.10",
-        "zendframework/zend-mail": "2.10.x-dev",
-        "zendframework/zend-servicemanager": "^3.4"
+        "xemlock/htmlpurifier-html5": "^0.1.10"
     },
     "replace": {
-        "laminas/laminas-stdlib": "3.2.1",
         "laminas/laminas-zendframework-bridge": "1.0.4",
         "paragonie/random_compat": "9.99.99",
         "symfony/polyfill-ctype": "1.99",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "60dd85ea5c0b2d5dbed9b8a3344efc83",
+    "content-hash": "be631626bccd4d161ece19a028b80346",
     "packages": [
         {
             "name": "cakephp/collection",
@@ -1984,6 +1984,388 @@
                 "laminas"
             ],
             "time": "2019-12-31T16:30:11+00:00"
+        },
+        {
+            "name": "laminas/laminas-loader",
+            "version": "2.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "reference": "5d01c2c237ae9e68bec262f339947e2ea18979bc",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-loader": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.6.x-dev",
+                    "dev-develop": "2.7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "time": "2019-12-31T17:18:27+00:00"
+        },
+        {
+            "name": "laminas/laminas-mail",
+            "version": "2.11.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mail.git",
+                "reference": "4c5545637eea3dc745668ddff1028692ed004c4b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mail/zipball/4c5545637eea3dc745668ddff1028692ed004c4b",
+                "reference": "4c5545637eea3dc745668ddff1028692ed004c4b",
+                "shasum": ""
+            },
+            "require": {
+                "ext-iconv": "*",
+                "laminas/laminas-loader": "^2.5",
+                "laminas/laminas-mime": "^2.5",
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "laminas/laminas-validator": "^2.10.2",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "true/punycode": "^2.1"
+            },
+            "replace": {
+                "zendframework/zend-mail": "^2.10.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-crypt": "^2.6 || ^3.0",
+                "laminas/laminas-servicemanager": "^2.7.10 || ^3.3.1",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4"
+            },
+            "suggest": {
+                "laminas/laminas-crypt": "Crammd5 support in SMTP Auth",
+                "laminas/laminas-servicemanager": "^2.7.10 || ^3.3.1 when using SMTP to deliver messages"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.11.x-dev",
+                    "dev-develop": "2.12.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Mail",
+                    "config-provider": "Laminas\\Mail\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mail\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mail"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-06-30T20:17:23+00:00"
+        },
+        {
+            "name": "laminas/laminas-mime",
+            "version": "2.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-mime.git",
+                "reference": "e45a7d856bf7b4a7b5bd00d6371f9961dc233add"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-mime/zipball/e45a7d856bf7b4a7b5bd00d6371f9961dc233add",
+                "reference": "e45a7d856bf7b4a7b5bd00d6371f9961dc233add",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-stdlib": "^2.7 || ^3.0",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-mime": "^2.7.2"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-mail": "^2.6",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.14 || ^7.5.20"
+            },
+            "suggest": {
+                "laminas/laminas-mail": "Laminas\\Mail component"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.7.x-dev",
+                    "dev-develop": "2.8.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Mime\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Create and parse MIME messages and parts",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "mime"
+            ],
+            "time": "2020-03-29T13:12:07+00:00"
+        },
+        {
+            "name": "laminas/laminas-servicemanager",
+            "version": "3.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-servicemanager.git",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "reference": "0d4c8628a71fae9f7bd0b1b74b76382e5e9a04b1",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.2",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0",
+                "psr/container": "^1.0"
+            },
+            "provide": {
+                "container-interop/container-interop-implementation": "^1.2",
+                "psr/container-implementation": "^1.0"
+            },
+            "replace": {
+                "zendframework/zend-servicemanager": "^3.4.0"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "mikey179/vfsstream": "^1.6.5",
+                "ocramius/proxy-manager": "^1.0 || ^2.0",
+                "phpbench/phpbench": "^0.13.0",
+                "phpunit/phpunit": "^5.7.25 || ^6.4.4"
+            },
+            "suggest": {
+                "laminas/laminas-stdlib": "laminas-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances",
+                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services"
+            },
+            "bin": [
+                "bin/generate-deps-for-config-factory",
+                "bin/generate-factory-for-class"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.3-dev",
+                    "dev-develop": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\ServiceManager\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Factory-Driven Dependency Injection Container",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "PSR-11",
+                "dependency-injection",
+                "di",
+                "dic",
+                "laminas",
+                "service-manager",
+                "servicemanager"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2020-05-11T14:43:22+00:00"
+        },
+        {
+            "name": "laminas/laminas-stdlib",
+            "version": "3.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-stdlib.git",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-stdlib/zipball/2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "reference": "2b18347625a2f06a1a485acfbc870f699dbe51c6",
+                "shasum": ""
+            },
+            "require": {
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^5.6 || ^7.0"
+            },
+            "replace": {
+                "zendframework/zend-stdlib": "self.version"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "phpbench/phpbench": "^0.13",
+                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.2.x-dev",
+                    "dev-develop": "3.3.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Stdlib\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "SPL extensions, array utilities, error handlers, and more",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "stdlib"
+            ],
+            "time": "2019-12-31T17:51:15+00:00"
+        },
+        {
+            "name": "laminas/laminas-validator",
+            "version": "2.13.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-validator.git",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-validator/zipball/93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "reference": "93593684e70b8ed1e870cacd34ca32b0c0ace185",
+                "shasum": ""
+            },
+            "require": {
+                "container-interop/container-interop": "^1.1",
+                "laminas/laminas-stdlib": "^3.2.1",
+                "laminas/laminas-zendframework-bridge": "^1.0",
+                "php": "^7.1"
+            },
+            "replace": {
+                "zendframework/zend-validator": "^2.13.0"
+            },
+            "require-dev": {
+                "laminas/laminas-cache": "^2.6.1",
+                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-config": "^2.6",
+                "laminas/laminas-db": "^2.7",
+                "laminas/laminas-filter": "^2.6",
+                "laminas/laminas-http": "^2.5.4",
+                "laminas/laminas-i18n": "^2.6",
+                "laminas/laminas-math": "^2.6",
+                "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
+                "laminas/laminas-session": "^2.8",
+                "laminas/laminas-uri": "^2.5",
+                "phpunit/phpunit": "^7.5.20 || ^8.5.2",
+                "psr/http-client": "^1.0",
+                "psr/http-factory": "^1.0",
+                "psr/http-message": "^1.0"
+            },
+            "suggest": {
+                "laminas/laminas-db": "Laminas\\Db component, required by the (No)RecordExists validator",
+                "laminas/laminas-filter": "Laminas\\Filter component, required by the Digits validator",
+                "laminas/laminas-i18n": "Laminas\\I18n component to allow translation of validation error messages",
+                "laminas/laminas-i18n-resources": "Translations of validator messages",
+                "laminas/laminas-math": "Laminas\\Math component, required by the Csrf validator",
+                "laminas/laminas-servicemanager": "Laminas\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
+                "laminas/laminas-session": "Laminas\\Session component, ^2.8; required by the Csrf validator",
+                "laminas/laminas-uri": "Laminas\\Uri component, required by the Uri and Sitemap\\Loc validators",
+                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.13.x-dev",
+                    "dev-develop": "2.14.x-dev"
+                },
+                "laminas": {
+                    "component": "Laminas\\Validator",
+                    "config-provider": "Laminas\\Validator\\ConfigProvider"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Validator\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "validator"
+            ],
+            "time": "2020-03-31T18:57:01+00:00"
         },
         {
             "name": "league/commonmark",
@@ -7019,388 +7401,6 @@
                 "xss"
             ],
             "time": "2019-08-07T17:19:21+00:00"
-        },
-        {
-            "name": "zendframework/zend-loader",
-            "version": "2.6.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-loader.git",
-                "reference": "91da574d29b58547385b2298c020b257310898c6"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-loader/zipball/91da574d29b58547385b2298c020b257310898c6",
-                "reference": "91da574d29b58547385b2298c020b257310898c6",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.4",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.6.x-dev",
-                    "dev-develop": "2.7.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Loader\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Autoloading and plugin loading strategies",
-            "keywords": [
-                "ZendFramework",
-                "loader",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-loader",
-            "time": "2019-09-04T19:38:14+00:00"
-        },
-        {
-            "name": "zendframework/zend-mail",
-            "version": "dev-develop-2.10",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/eventum/zend-mail.git",
-                "reference": "f8aa846157951793c226e0fe5ae32a0a82f5f1db"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/eventum/zend-mail/zipball/f8aa846157951793c226e0fe5ae32a0a82f5f1db",
-                "reference": "f8aa846157951793c226e0fe5ae32a0a82f5f1db",
-                "shasum": ""
-            },
-            "require": {
-                "ext-iconv": "*",
-                "php": "^5.6 || ^7.0",
-                "true/punycode": "^2.1",
-                "zendframework/zend-loader": "^2.5",
-                "zendframework/zend-mime": "^2.5",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0",
-                "zendframework/zend-validator": "^2.10.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.25 || ^6.4.4 || ^7.1.4",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-config": "^2.6",
-                "zendframework/zend-crypt": "^2.6 || ^3.0",
-                "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1"
-            },
-            "suggest": {
-                "zendframework/zend-crypt": "Crammd5 support in SMTP Auth",
-                "zendframework/zend-servicemanager": "^2.7.10 || ^3.3.1 when using SMTP to deliver messages"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.10.x-dev",
-                    "dev-develop-2.10": "2.10.x-dev",
-                    "dev-develop": "2.11.x-dev"
-                },
-                "zf": {
-                    "component": "Zend\\Mail",
-                    "config-provider": "Zend\\Mail\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Mail\\": "src/"
-                }
-            },
-            "autoload-dev": {
-                "psr-4": {
-                    "ZendTest\\Mail\\": "test/"
-                }
-            },
-            "scripts": {
-                "check": [
-                    "@cs-check",
-                    "@test"
-                ],
-                "cs-check": [
-                    "phpcs"
-                ],
-                "cs-fix": [
-                    "phpcbf"
-                ],
-                "test": [
-                    "phpunit --colors=always"
-                ],
-                "test-coverage": [
-                    "phpunit --colors=always --coverage-clover clover.xml"
-                ]
-            },
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Provides generalized functionality to compose and send both text and MIME-compliant multipart e-mail messages",
-            "keywords": [
-                "mail",
-                "zendframework",
-                "zf"
-            ],
-            "support": {
-                "docs": "https://docs.zendframework.com/zend-mail/",
-                "issues": "https://github.com/zendframework/zend-mail/issues",
-                "source": "https://github.com/zendframework/zend-mail",
-                "rss": "https://github.com/zendframework/zend-mail/releases.atom",
-                "chat": "https://zendframework-slack.herokuapp.com",
-                "forum": "https://discourse.zendframework.com/c/questions/components"
-            },
-            "time": "2019-07-06T10:34:36+00:00"
-        },
-        {
-            "name": "zendframework/zend-mime",
-            "version": "2.7.2",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-mime.git",
-                "reference": "c91e0350be53cc9d29be15563445eec3b269d7c1"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-mime/zipball/c91e0350be53cc9d29be15563445eec3b269d7c1",
-                "reference": "c91e0350be53cc9d29be15563445eec3b269d7c1",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0",
-                "zendframework/zend-stdlib": "^2.7 || ^3.0"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^5.7.21 || ^6.3",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-mail": "^2.6"
-            },
-            "suggest": {
-                "zendframework/zend-mail": "Zend\\Mail component"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.7.x-dev",
-                    "dev-develop": "2.8.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Mime\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Create and parse MIME messages and parts",
-            "keywords": [
-                "ZendFramework",
-                "mime",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-mime",
-            "time": "2019-10-16T19:30:37+00:00"
-        },
-        {
-            "name": "zendframework/zend-servicemanager",
-            "version": "3.4.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-servicemanager.git",
-                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-servicemanager/zipball/a1ed6140d0d3ee803fec96582593ed024950067b",
-                "reference": "a1ed6140d0d3ee803fec96582593ed024950067b",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.2",
-                "php": "^5.6 || ^7.0",
-                "psr/container": "^1.0",
-                "zendframework/zend-stdlib": "^3.2.1"
-            },
-            "provide": {
-                "container-interop/container-interop-implementation": "^1.2",
-                "psr/container-implementation": "^1.0"
-            },
-            "require-dev": {
-                "mikey179/vfsstream": "^1.6.5",
-                "ocramius/proxy-manager": "^1.0 || ^2.0",
-                "phpbench/phpbench": "^0.13.0",
-                "phpunit/phpunit": "^5.7.25 || ^6.4.4",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "suggest": {
-                "ocramius/proxy-manager": "ProxyManager 1.* to handle lazy initialization of services",
-                "zendframework/zend-stdlib": "zend-stdlib ^2.5 if you wish to use the MergeReplaceKey or MergeRemoveKey features in Config instances"
-            },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.3-dev",
-                    "dev-develop": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\ServiceManager\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Factory-Driven Dependency Injection Container",
-            "keywords": [
-                "PSR-11",
-                "ZendFramework",
-                "dependency-injection",
-                "di",
-                "dic",
-                "service-manager",
-                "servicemanager",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-servicemanager",
-            "time": "2018-12-22T06:05:09+00:00"
-        },
-        {
-            "name": "zendframework/zend-stdlib",
-            "version": "3.2.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-stdlib.git",
-                "reference": "66536006722aff9e62d1b331025089b7ec71c065"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-stdlib/zipball/66536006722aff9e62d1b331025089b7ec71c065",
-                "reference": "66536006722aff9e62d1b331025089b7ec71c065",
-                "shasum": ""
-            },
-            "require": {
-                "php": "^5.6 || ^7.0"
-            },
-            "require-dev": {
-                "phpbench/phpbench": "^0.13",
-                "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.2",
-                "zendframework/zend-coding-standard": "~1.0.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "3.2.x-dev",
-                    "dev-develop": "3.3.x-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Stdlib\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "SPL extensions, array utilities, error handlers, and more",
-            "keywords": [
-                "ZendFramework",
-                "stdlib",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-stdlib",
-            "time": "2018-08-28T21:34:05+00:00"
-        },
-        {
-            "name": "zendframework/zend-validator",
-            "version": "2.13.0",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/zendframework/zend-validator.git",
-                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/zendframework/zend-validator/zipball/b54acef1f407741c5347f2a97f899ab21f2229ef",
-                "reference": "b54acef1f407741c5347f2a97f899ab21f2229ef",
-                "shasum": ""
-            },
-            "require": {
-                "container-interop/container-interop": "^1.1",
-                "php": "^7.1",
-                "zendframework/zend-stdlib": "^3.2.1"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^6.0.8 || ^5.7.15",
-                "psr/http-client": "^1.0",
-                "psr/http-factory": "^1.0",
-                "psr/http-message": "^1.0",
-                "zendframework/zend-cache": "^2.6.1",
-                "zendframework/zend-coding-standard": "~1.0.0",
-                "zendframework/zend-config": "^2.6",
-                "zendframework/zend-db": "^2.7",
-                "zendframework/zend-filter": "^2.6",
-                "zendframework/zend-http": "^2.5.4",
-                "zendframework/zend-i18n": "^2.6",
-                "zendframework/zend-math": "^2.6",
-                "zendframework/zend-servicemanager": "^2.7.5 || ^3.0.3",
-                "zendframework/zend-session": "^2.8",
-                "zendframework/zend-uri": "^2.5"
-            },
-            "suggest": {
-                "psr/http-message": "psr/http-message, required when validating PSR-7 UploadedFileInterface instances via the Upload and UploadFile validators",
-                "zendframework/zend-db": "Zend\\Db component, required by the (No)RecordExists validator",
-                "zendframework/zend-filter": "Zend\\Filter component, required by the Digits validator",
-                "zendframework/zend-i18n": "Zend\\I18n component to allow translation of validation error messages",
-                "zendframework/zend-i18n-resources": "Translations of validator messages",
-                "zendframework/zend-math": "Zend\\Math component, required by the Csrf validator",
-                "zendframework/zend-servicemanager": "Zend\\ServiceManager component to allow using the ValidatorPluginManager and validator chains",
-                "zendframework/zend-session": "Zend\\Session component, ^2.8; required by the Csrf validator",
-                "zendframework/zend-uri": "Zend\\Uri component, required by the Uri and Sitemap\\Loc validators"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "2.13.x-dev",
-                    "dev-develop": "2.14.x-dev"
-                },
-                "zf": {
-                    "component": "Zend\\Validator",
-                    "config-provider": "Zend\\Validator\\ConfigProvider"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Zend\\Validator\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "description": "Validation classes for a wide range of domains, and the ability to chain validators to create complex validation criteria",
-            "keywords": [
-                "ZendFramework",
-                "validator",
-                "zf"
-            ],
-            "abandoned": "laminas/laminas-validator",
-            "time": "2019-12-28T04:07:18+00:00"
         }
     ],
     "packages-dev": [
@@ -8191,8 +8191,7 @@
     "minimum-stability": "dev",
     "stability-flags": {
         "horde/text-flowed": 20,
-        "horde/util": 20,
-        "zendframework/zend-mail": 20
+        "horde/util": 20
     },
     "prefer-stable": true,
     "prefer-lowest": false,

--- a/db/migrations/20180306202659_eventum_maq_message_id.php
+++ b/db/migrations/20180306202659_eventum_maq_message_id.php
@@ -14,8 +14,8 @@
 use Eventum\Db\AbstractMigration;
 use Eventum\Mail\MailMessage;
 use Eventum\Monolog\Logger;
+use Laminas\Mail\Headers;
 use Psr\Log\LoggerInterface;
-use Zend\Mail\Headers;
 
 class EventumMaqMessageId extends AbstractMigration
 {
@@ -120,7 +120,7 @@ class EventumMaqMessageId extends AbstractMigration
     private function setMessageId($maq_id, $messageId): void
     {
         // NOTE: no method to quote from phinx,
-        // but $messageId should be sql safe after it came from Zend\Mail
+        // but $messageId should be sql safe after it came from Laminas\Mail
         $this->query("UPDATE `mail_queue` SET maq_message_id='{$messageId}' WHERE maq_id={$maq_id}");
     }
 }

--- a/docs/examples/extension/Subscriber/ShouldEmailAddressSubscriber.php
+++ b/docs/examples/extension/Subscriber/ShouldEmailAddressSubscriber.php
@@ -15,8 +15,8 @@ namespace Example\Subscriber;
 
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
+use Laminas\Mail\Address;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
-use Zend\Mail\Address;
 
 class ShouldEmailAddressSubscriber implements EventSubscriberInterface
 {

--- a/lib/eventum/class.mail_helper.php
+++ b/lib/eventum/class.mail_helper.php
@@ -16,7 +16,7 @@ use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
 use Eventum\Mail\MessageIdGenerator;
 use Eventum\ServiceContainer;
-use Zend\Mail\Address;
+use Laminas\Mail\Address;
 
 class Mail_Helper
 {
@@ -115,7 +115,7 @@ class Mail_Helper
      *
      * @param Address|string $address The email address(es) value
      * @param   bool $multiple If multiple addresses should be returned
-     * @throws \Zend\Mail\Header\Exception\InvalidArgumentException
+     * @throws \Laminas\Mail\Header\Exception\InvalidArgumentException
      * @return string[]|string The name or an array of names if multiple is true
      */
     public static function getName($address, $multiple = false)

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -16,8 +16,8 @@ use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
+use Laminas\Mail\Address;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Zend\Mail\Address;
 
 class Mail_Queue
 {

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -24,7 +24,7 @@ use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailMessage;
 use Eventum\ServiceContainer;
-use Zend\Mail\Address;
+use Laminas\Mail\Address;
 
 /**
  * @deprecated workflow backend concept is deprecated, use event subscribers

--- a/lib/eventum/search/class.sphinx_fulltext_search.php
+++ b/lib/eventum/search/class.sphinx_fulltext_search.php
@@ -138,7 +138,7 @@ class Sphinx_Fulltext_Search extends Abstract_Fulltext_Search
                         $documents = [$email['sup_subject'] . "\n" . $email['message']];
                         $res = $this->sphinx->BuildExcerpts($documents, 'email_stemmed', $this->keywords, $excerpt_options);
                         $excerpt['email'][Support::getSequenceByID($match['match_id'])] = $this->cleanUpExcerpt($res[0]);
-                    } catch (Zend\Mail\Header\Exception\InvalidArgumentException $e) {
+                    } catch (Laminas\Mail\Header\Exception\InvalidArgumentException $e) {
                         $this->error("Error loading email {$match['match_id']}", $match);
                     }
                 } elseif ($match['index'] === 'phone') {

--- a/src/Event/SystemEvents.php
+++ b/src/Event/SystemEvents.php
@@ -89,7 +89,6 @@ final class SystemEvents
      * Event Fired when MailMessage was created from IMAP Connection.
      *
      * @since 3.4.0
-     * @see ImapMessage::createFromImap
      * @see ImapMessage::createFromImapResource
      */
     public const MAIL_LOADED_IMAP = 'mail.loaded.imap';

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -27,9 +27,9 @@ use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailMessage;
 use Eventum\Model\Repository\ProjectRepository;
 use InvalidArgumentException;
+use Laminas\Mail\Address;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Workflow;
-use Zend\Mail\Address;
 
 /**
  * Extension that adds integration of legacy workflow classes to Extension events

--- a/src/Mail/Exception/InvalidMessageException.php
+++ b/src/Mail/Exception/InvalidMessageException.php
@@ -15,9 +15,9 @@ namespace Eventum\Mail\Exception;
 
 use Eventum\Mail\Helper\MailLoader;
 use Exception;
+use Laminas\Mail;
+use Laminas\Mail\Header\HeaderInterface;
 use RuntimeException;
-use Zend\Mail;
-use Zend\Mail\Header\HeaderInterface;
 
 class InvalidMessageException extends RuntimeException
 {

--- a/src/Mail/Helper/AddressHeader.php
+++ b/src/Mail/Helper/AddressHeader.php
@@ -14,12 +14,12 @@
 namespace Eventum\Mail\Helper;
 
 use InvalidArgumentException;
+use Laminas\Mail\Address;
+use Laminas\Mail\AddressList;
+use Laminas\Mail\Header\AbstractAddressList;
+use Laminas\Mail\Header\HeaderInterface;
+use Laminas\Mail\Header\To;
 use Mime_Helper;
-use Zend\Mail\Address;
-use Zend\Mail\AddressList;
-use Zend\Mail\Header\AbstractAddressList;
-use Zend\Mail\Header\HeaderInterface;
-use Zend\Mail\Header\To;
 
 /**
  * Helper to parse any address list type header (to, from, cc, bcc, reply-to) into Header object
@@ -36,7 +36,7 @@ class AddressHeader
 
     /**
      * @param string $addresses
-     * @throws \Zend\Mail\Header\Exception\InvalidArgumentException
+     * @throws \Laminas\Mail\Header\Exception\InvalidArgumentException
      * @return AddressHeader
      */
     public static function fromString($addresses): self

--- a/src/Mail/Helper/DecodePart.php
+++ b/src/Mail/Helper/DecodePart.php
@@ -13,9 +13,9 @@
 
 namespace Eventum\Mail\Helper;
 
+use Laminas\Mail\Header\ContentTransferEncoding;
+use Laminas\Mail\Storage\Part\PartInterface;
 use LogicException;
-use Zend\Mail\Header\ContentTransferEncoding;
-use Zend\Mail\Storage\Part\PartInterface;
 
 class DecodePart
 {

--- a/src/Mail/Helper/MailLoader.php
+++ b/src/Mail/Helper/MailLoader.php
@@ -13,11 +13,11 @@
 
 namespace Eventum\Mail\Helper;
 
+use Laminas\Mail;
+use Laminas\Mail\Header;
+use Laminas\Mail\Headers;
+use Laminas\Mime;
 use Mime_Helper;
-use Zend\Mail;
-use Zend\Mail\Header;
-use Zend\Mail\Headers;
-use Zend\Mime;
 
 class MailLoader
 {
@@ -25,7 +25,7 @@ class MailLoader
     {
         // do our own header-body splitting.
         //
-        // \Zend\Mail\Storage\Message is unable to process mails that contain \n\n in text body
+        // \Laminas\Mail\Storage\Message is unable to process mails that contain \n\n in text body
         // because it has heuristic which headers separator to use
         // and that gets out of control
         // https://github.com/zendframework/zend-mail/pull/159
@@ -55,7 +55,7 @@ class MailLoader
     public static function encodeHeaders(array &$headers): void
     {
         foreach ($headers as $k => $v) {
-            // Zend\Mail does not like empty headers, "Cc:" for example
+            // Laminas\Mail does not like empty headers, "Cc:" for example
             if ($v === '') {
                 unset($headers[$k]);
             }

--- a/src/Mail/Helper/MimePart.php
+++ b/src/Mail/Helper/MimePart.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Mail\Helper;
 
-use Zend\Mime;
+use Laminas\Mime;
 
 class MimePart extends Mime\Part
 {

--- a/src/Mail/Helper/SanitizeHeaders.php
+++ b/src/Mail/Helper/SanitizeHeaders.php
@@ -15,18 +15,18 @@ namespace Eventum\Mail\Helper;
 
 use DomainException;
 use Eventum\Mail\MailMessage;
+use Laminas\Mail\Header\AbstractAddressList;
+use Laminas\Mail\Header\HeaderInterface;
+use Laminas\Mail\Header\MessageId;
+use Laminas\Mail\Headers;
 use Mail_Helper;
-use Zend\Mail\Header\AbstractAddressList;
-use Zend\Mail\Header\HeaderInterface;
-use Zend\Mail\Header\MessageId;
-use Zend\Mail\Headers;
 
 class SanitizeHeaders
 {
     /**
      * Namespace for Header classes
      */
-    const HEADER_NS = '\\Zend\\Mail\\Header\\';
+    const HEADER_NS = '\\Laminas\\Mail\\Header\\';
 
     /**
      * Sanitize Mail headers:

--- a/src/Mail/Helper/TextMessage.php
+++ b/src/Mail/Helper/TextMessage.php
@@ -14,9 +14,9 @@
 namespace Eventum\Mail\Helper;
 
 use Horde_Text_Flowed;
+use Laminas\Mail\Storage\Part\PartInterface;
 use LogicException;
 use Mime_Helper;
-use Zend\Mail\Storage\Part\PartInterface;
 
 /**
  * Creates textual representation of the message body.

--- a/src/Mail/Helper/WarningMessage.php
+++ b/src/Mail/Helper/WarningMessage.php
@@ -17,10 +17,10 @@ use Closure;
 use Eventum\Mail\MailMessage;
 use Eventum\ServiceContainer;
 use Issue;
+use Laminas\Mail\Exception\InvalidArgumentException;
+use Laminas\Mime;
 use Support;
 use User;
-use Zend\Mail\Exception\InvalidArgumentException;
-use Zend\Mime;
 
 class WarningMessage
 {

--- a/src/Mail/ImapMessage.php
+++ b/src/Mail/ImapMessage.php
@@ -22,7 +22,6 @@ use Eventum\Mail\Imap\ImapResource;
 use InvalidArgumentException;
 use Laminas\Mail\Header\GenericHeader;
 use Laminas\Mail\Storage;
-use RuntimeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -74,14 +73,6 @@ class ImapMessage extends MailMessage
         EventManager::dispatch(SystemEvents::MAIL_LOADED_IMAP, $event);
 
         return $message;
-    }
-
-    /**
-     * @deprecated removed in 3.8.12
-     */
-    public static function createFromImap($mbox, $num, $info): ImapMessage
-    {
-        throw new RuntimeException('This method no longer exists');
     }
 
     /**

--- a/src/Mail/ImapMessage.php
+++ b/src/Mail/ImapMessage.php
@@ -20,10 +20,10 @@ use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\Helper\MailLoader;
 use Eventum\Mail\Imap\ImapResource;
 use InvalidArgumentException;
+use Laminas\Mail\Header\GenericHeader;
+use Laminas\Mail\Storage;
 use RuntimeException;
 use Symfony\Component\EventDispatcher\GenericEvent;
-use Zend\Mail\Header\GenericHeader;
-use Zend\Mail\Storage as ZendMailStorage;
 
 /**
  * Class ImapMessage
@@ -46,12 +46,12 @@ class ImapMessage extends MailMessage
     {
         // fill with "\Seen", "\Deleted", "\Answered", ... etc
         $knownFlags = [
-            'recent' => ZendMailStorage::FLAG_RECENT,
-            'flagged' => ZendMailStorage::FLAG_FLAGGED,
-            'answered' => ZendMailStorage::FLAG_ANSWERED,
-            'deleted' => ZendMailStorage::FLAG_DELETED,
-            'seen' => ZendMailStorage::FLAG_SEEN,
-            'draft' => ZendMailStorage::FLAG_DRAFT,
+            'recent' => Storage::FLAG_RECENT,
+            'flagged' => Storage::FLAG_FLAGGED,
+            'answered' => Storage::FLAG_ANSWERED,
+            'deleted' => Storage::FLAG_DELETED,
+            'seen' => Storage::FLAG_SEEN,
+            'draft' => Storage::FLAG_DRAFT,
         ];
         $flags = [];
         foreach ($knownFlags as $flag => $value) {

--- a/src/Mail/ImapMessage.php
+++ b/src/Mail/ImapMessage.php
@@ -89,7 +89,7 @@ class ImapMessage extends MailMessage
      * @param array $flags
      * @return array
      */
-    public static function createParameters($raw, $flags = [])
+    public static function createParameters($raw, array $flags = []): array
     {
         MailLoader::splitMessage($raw, $headers, $content);
 

--- a/src/Mail/LaminasMailMessage.php
+++ b/src/Mail/LaminasMailMessage.php
@@ -13,15 +13,15 @@
 
 namespace Eventum\Mail;
 
-use Zend\Mail\Headers;
-use Zend\Mail\Message;
+use Laminas\Mail\Headers;
+use Laminas\Mail\Message;
 
 /**
  * See MailMessage::toMessage for long story
  *
  * @internal
  */
-class ZendMailMessage extends Message
+class LaminasMailMessage extends Message
 {
     public function forceHeaders(Headers $headers): void
     {

--- a/src/Mail/MailAttachment.php
+++ b/src/Mail/MailAttachment.php
@@ -14,10 +14,10 @@
 namespace Eventum\Mail;
 
 use Eventum\Mail\Helper\DecodePart;
-use Zend\Mail;
-use Zend\Mail\Header\ContentType;
-use Zend\Mail\Storage;
-use Zend\Mime\Part;
+use Laminas\Mail;
+use Laminas\Mail\Header\ContentType;
+use Laminas\Mail\Storage;
+use Laminas\Mime\Part;
 
 class MailAttachment
 {

--- a/src/Mail/MailAttachment.php
+++ b/src/Mail/MailAttachment.php
@@ -36,10 +36,8 @@ class MailAttachment
      * TODO: handle application/pgp-signature, application/ms-tnef?
      *
      * @see https://github.com/eventum/eventum/blob/v3.2.1/lib/eventum/class.mime_helper.php#L740-L753
-     *
-     * @return  bool
      */
-    public function hasAttachments()
+    public function hasAttachments(): bool
     {
         $have_multipart = $this->message->isMultipart() && $this->message->countParts() > 0;
         if (!$have_multipart) {
@@ -60,7 +58,7 @@ class MailAttachment
      *
      * @return array
      */
-    public function getAttachments()
+    public function getAttachments(): array
     {
         $attachments = [];
 
@@ -132,7 +130,7 @@ class MailAttachment
      * @param MailMessage $part
      * @return bool
      */
-    private function isAttachment(MailMessage $part)
+    private function isAttachment(MailMessage $part): bool
     {
         $is_attachment = false;
         $disposition = $filename = null;

--- a/src/Mail/MailBuilder.php
+++ b/src/Mail/MailBuilder.php
@@ -15,8 +15,8 @@ namespace Eventum\Mail;
 
 use Eventum\Attachment\Attachment;
 use Eventum\Mail\Helper\MimePart;
-use Zend\Mail;
-use Zend\Mime;
+use Laminas\Mail;
+use Laminas\Mime;
 
 /**
  * Helper to combine of Mail\Message, Mime\Message and MailMessage

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -22,24 +22,24 @@ use Eventum\Mail\Helper\MailLoader;
 use Eventum\Mail\Helper\SanitizeHeaders;
 use Eventum\Mail\Helper\TextMessage;
 use InvalidArgumentException;
-use Zend\Mail;
-use Zend\Mail\Address;
-use Zend\Mail\AddressList;
-use Zend\Mail\Header\AbstractAddressList;
-use Zend\Mail\Header\Cc;
-use Zend\Mail\Header\Date;
-use Zend\Mail\Header\From;
-use Zend\Mail\Header\GenericHeader;
-use Zend\Mail\Header\HeaderInterface;
-use Zend\Mail\Header\InReplyTo;
-use Zend\Mail\Header\MessageId;
-use Zend\Mail\Header\MultipleHeadersInterface;
-use Zend\Mail\Header\References;
-use Zend\Mail\Header\Subject;
-use Zend\Mail\Header\To;
-use Zend\Mail\Headers;
-use Zend\Mail\Storage;
-use Zend\Mail\Storage\Message;
+use Laminas\Mail;
+use Laminas\Mail\Address;
+use Laminas\Mail\AddressList;
+use Laminas\Mail\Header\AbstractAddressList;
+use Laminas\Mail\Header\Cc;
+use Laminas\Mail\Header\Date;
+use Laminas\Mail\Header\From;
+use Laminas\Mail\Header\GenericHeader;
+use Laminas\Mail\Header\HeaderInterface;
+use Laminas\Mail\Header\InReplyTo;
+use Laminas\Mail\Header\MessageId;
+use Laminas\Mail\Header\MultipleHeadersInterface;
+use Laminas\Mail\Header\References;
+use Laminas\Mail\Header\Subject;
+use Laminas\Mail\Header\To;
+use Laminas\Mail\Headers;
+use Laminas\Mail\Storage;
+use Laminas\Mail\Storage\Message;
 
 /**
  * Class MailMessage
@@ -141,7 +141,7 @@ class MailMessage extends Message
     }
 
     /**
-     * Create from Zend\Mail\Message object
+     * Create from Mail\Message object
      *
      * @param Mail\Message $message
      * @return MailMessage
@@ -181,7 +181,7 @@ class MailMessage extends Message
          *   Create wrapper for Mail\Message to set Headers without re-encoding them.
          */
 
-        $message = new ZendMailMessage();
+        $message = new LaminasMailMessage();
         $message->forceHeaders($this->getHeaders());
         $message->setBody($this->getContent());
 
@@ -397,7 +397,7 @@ class MailMessage extends Message
      * Access the address list of the To header
      *
      * @return AddressList
-     * @see \Zend\Mail\Message::getTo
+     * @see \Laminas\Mail\Message::getTo
      */
     public function getTo()
     {
@@ -408,7 +408,7 @@ class MailMessage extends Message
      * Retrieve list of CC recipients
      *
      * @return AddressList
-     * @see \Zend\Mail\Message::getCc
+     * @see \Laminas\Mail\Message::getCc
      */
     public function getCc()
     {
@@ -703,7 +703,7 @@ class MailMessage extends Message
      * @param string $headerName
      * @param string $headerClass Header Class name, defaults to GenericHeader
      * @return HeaderInterface|\ArrayIterator header instance or collection of headers
-     * @see \Zend\Mail\Message::getHeaderByName
+     * @see \Laminas\Mail\Message::getHeaderByName
      */
     public function getHeaderByName($headerName, $headerClass = GenericHeader::class)
     {
@@ -761,7 +761,7 @@ class MailMessage extends Message
      * @param  string $headerClass
      * @throws DomainException
      * @return AddressList
-     * @see \Zend\Mail\Message::getAddressListFromHeader
+     * @see \Laminas\Mail\Message::getAddressListFromHeader
      */
     protected function getAddressListFromHeader($headerName, $headerClass)
     {

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -344,7 +344,7 @@ class MailMessage extends Message
      * @param array $headers
      * @return string[]
      */
-    public function getAddresses($headers = ['To', 'Cc'])
+    public function getAddresses($headers = ['To', 'Cc']): array
     {
         if (!$headers) {
             throw new InvalidArgumentException('No header field specified');
@@ -396,10 +396,9 @@ class MailMessage extends Message
     /**
      * Access the address list of the To header
      *
-     * @return AddressList
      * @see \Laminas\Mail\Message::getTo
      */
-    public function getTo()
+    public function getTo(): AddressList
     {
         return $this->getAddressListFromHeader('to', To::class);
     }
@@ -407,30 +406,25 @@ class MailMessage extends Message
     /**
      * Retrieve list of CC recipients
      *
-     * @return AddressList
      * @see \Laminas\Mail\Message::getCc
      */
-    public function getCc()
+    public function getCc(): AddressList
     {
         return $this->getAddressListFromHeader('cc', Cc::class);
     }
 
     /**
      * Get Date as DateTime object
-     *
-     * @return DateTime
      */
-    public function getDate()
+    public function getDate(): DateTime
     {
         return new DateTime($this->date);
     }
 
     /**
      * Get the message Subject header object
-     *
-     * @return Subject
      */
-    protected function getSubject()
+    protected function getSubject(): Subject
     {
         // NOTE: Subject header is always present,
         // so it's safe to call this without checking for header presence
@@ -444,9 +438,8 @@ class MailMessage extends Message
      * Set the message subject header value
      *
      * @param string $subject
-     * @return $this
      */
-    public function setSubject($subject)
+    public function setSubject(string $subject): self
     {
         $this->getSubject()->setSubject($subject);
 
@@ -457,9 +450,8 @@ class MailMessage extends Message
      * Set To: header
      *
      * @param string|AddressList $value
-     * @return $this
      */
-    public function setTo($value)
+    public function setTo($value): self
     {
         $this->setAddressListHeader('To', $value);
 
@@ -470,9 +462,8 @@ class MailMessage extends Message
      * Set From: header
      *
      * @param string|AddressList $value
-     * @return $this
      */
-    public function setFrom($value)
+    public function setFrom($value): self
     {
         $this->setAddressListHeader('From', $value);
 
@@ -483,9 +474,8 @@ class MailMessage extends Message
      * Set Date: header
      *
      * @param string $value
-     * @return $this
      */
-    public function setDate($value = null)
+    public function setDate($value = null): self
     {
         $value = $value ?: Date_Helper::getRFC822Date(time());
 
@@ -506,7 +496,7 @@ class MailMessage extends Message
      * @param string $name
      * @param string|AddressList $value
      */
-    public function setAddressListHeader($name, $value): void
+    public function setAddressListHeader(string $name, $value): void
     {
         /** @var AbstractAddressList $header */
         $header = $this->getHeader($name);
@@ -554,9 +544,8 @@ class MailMessage extends Message
      *
      * @param string $header a header name, like 'To', or 'Cc'
      * @param string $address An email address to remove
-     * @return bool
      */
-    public function removeFromAddressList($header, $address)
+    public function removeFromAddressList(string $header, string $address): bool
     {
         if (!$this->headers->has($header)) {
             return false;
@@ -586,7 +575,7 @@ class MailMessage extends Message
      *
      * @return bool
      */
-    public function isVacationAutoResponder()
+    public function isVacationAutoResponder(): bool
     {
         // has 'auto-submitted' header?
         if ($this->headers->has('auto-submitted')) {
@@ -598,7 +587,7 @@ class MailMessage extends Message
             return false;
         }
 
-        return $this->headers->get('x-vacationmessage') != '';
+        return $this->headers->get('x-vacationmessage') !== '';
     }
 
     /**
@@ -607,7 +596,7 @@ class MailMessage extends Message
      *
      * @return bool
      */
-    public function isBounceMessage()
+    public function isBounceMessage(): bool
     {
         $email = $this->getSender();
 
@@ -644,8 +633,7 @@ class MailMessage extends Message
         // process patterns
         $array = $headers->toArray();
         array_walk(
-            $array,
-            function ($value, $name) use ($headers): void {
+            $array, static function ($value, $name) use ($headers): void {
                 if (preg_match('/^resent.*/i', $name)) {
                     $headers->removeHeader($name);
                 }
@@ -659,9 +647,8 @@ class MailMessage extends Message
      * NOTE: if you have multiparts, you should look into MailBuilder.
      *
      * @param string $content
-     * @return $this
      */
-    public function setContent($content)
+    public function setContent($content): self
     {
         $this->content = $content;
 
@@ -670,10 +657,8 @@ class MailMessage extends Message
 
     /**
      * Returns true if message content has been set
-     *
-     * @return bool
      */
-    public function hasContent()
+    public function hasContent(): bool
     {
         return $this->content !== null;
     }
@@ -757,13 +742,10 @@ class MailMessage extends Message
      * Used with To, From, Cc, Bcc, and ReplyTo headers. If the header does not
      * exist, instantiates it.
      *
-     * @param  string $headerName
-     * @param  string $headerClass
      * @throws DomainException
-     * @return AddressList
      * @see \Laminas\Mail\Message::getAddressListFromHeader
      */
-    protected function getAddressListFromHeader($headerName, $headerClass)
+    private function getAddressListFromHeader(string $headerName, string $headerClass): AddressList
     {
         $header = $this->getHeaderByName($headerName, $headerClass);
         if (!$header instanceof AbstractAddressList) {

--- a/src/Mail/MailMessage.php
+++ b/src/Mail/MailMessage.php
@@ -33,7 +33,6 @@ use Laminas\Mail\Header\GenericHeader;
 use Laminas\Mail\Header\HeaderInterface;
 use Laminas\Mail\Header\InReplyTo;
 use Laminas\Mail\Header\MessageId;
-use Laminas\Mail\Header\MultipleHeadersInterface;
 use Laminas\Mail\Header\References;
 use Laminas\Mail\Header\Subject;
 use Laminas\Mail\Header\To;
@@ -716,24 +715,11 @@ class MailMessage extends Message
      * @return array
      * @see Headers::toArray
      * @see https://github.com/zendframework/zend-mail/pull/61
+     * @deprecated use Headers::toArray(HeaderInterface::FORMAT_ENCODED)
      */
-    public function getHeadersArray($format = HeaderInterface::FORMAT_ENCODED)
+    public function getHeadersArray($format = HeaderInterface::FORMAT_ENCODED): array
     {
-        $headers = [];
-        /* @var $header HeaderInterface */
-        foreach ($this->getHeaders() as $header) {
-            if ($header instanceof MultipleHeadersInterface) {
-                $name = $header->getFieldName();
-                if (!isset($headers[$name])) {
-                    $headers[$name] = [];
-                }
-                $headers[$name][] = $header->getFieldValue($format);
-            } else {
-                $headers[$header->getFieldName()] = $header->getFieldValue($format);
-            }
-        }
-
-        return $headers;
+        return $this->getHeaders()->toArray($format);
     }
 
     /**

--- a/src/Mail/MailStorage.php
+++ b/src/Mail/MailStorage.php
@@ -13,8 +13,8 @@
 
 namespace Eventum\Mail;
 
-use Zend\Mail\Protocol;
-use Zend\Mail\Storage;
+use Laminas\Mail\Protocol;
+use Laminas\Mail\Storage;
 
 /**
  * Class MailStorage
@@ -103,8 +103,8 @@ class MailStorage
         $type = explode('/', $params['ema_type']);
 
         $classname = ucfirst($type[0]);
-        $res['storage_class'] = '\\Zend\\Mail\\Storage\\' . $classname;
-        $res['protocol_class'] = '\\Zend\\Mail\\Protocol\\' . $classname;
+        $res['storage_class'] = '\\Laminas\\Mail\\Storage\\' . $classname;
+        $res['protocol_class'] = '\\Laminas\\Mail\\Protocol\\' . $classname;
         $res['ssl'] = in_array($type[1], ['ssl', 'tls']) ? $type[1] : false;
 
         // NOTE: novalidate and notls are not supported

--- a/src/Mail/MailTransport.php
+++ b/src/Mail/MailTransport.php
@@ -17,8 +17,8 @@ use Eventum\Config\Paths;
 use Eventum\Logger\LoggerTrait;
 use Eventum\ServiceContainer;
 use Exception;
+use Laminas\Mail\Transport;
 use Mail_Helper;
-use Zend\Mail\Transport;
 
 class MailTransport
 {
@@ -112,7 +112,7 @@ class MailTransport
             $ssl = $options['port'] === 587 ? 'tls' : 'ssl';
 
             $options['connection_config'] = [
-                /** @see \Zend\Mail\Protocol\Smtp */
+                /** @see \Laminas\Mail\Protocol\Smtp */
                 // possible values: tls, ssl
                 'ssl' => $setup['ssl'] ?: $ssl,
             ];
@@ -126,7 +126,7 @@ class MailTransport
 
         $spec = [
             /**
-             * @see \Zend\Mail\Transport\Factory::$classMap
+             * @see \Laminas\Mail\Transport\Factory::$classMap
              */
             'type' => $setup['type'] ?: 'smtp',
             'options' => $options,

--- a/tests/Mail/AttachmentTest.php
+++ b/tests/Mail/AttachmentTest.php
@@ -45,7 +45,7 @@ class AttachmentTest extends TestCase
     /**
      * Ensure email with text/plain attachment does not throw InvalidArgumentException
      *
-     * Uncaught Exception Zend\Mail\Storage\Exception\InvalidArgumentException:
+     * Uncaught Exception Laminas\Mail\Storage\Exception\InvalidArgumentException:
      * "Header with Name Content-Disposition or content-disposition not found"
      */
     public function testHasAttachmentPlain(): void

--- a/tests/Mail/MailHelperTest.php
+++ b/tests/Mail/MailHelperTest.php
@@ -16,9 +16,9 @@ namespace Eventum\Test\Mail;
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\MailMessage;
 use Eventum\Test\TestCase;
+use Laminas\Mail\Header\HeaderInterface;
 use Mail_Helper;
 use Setup;
-use Zend\Mail\Header\HeaderInterface;
 
 /**
  * Test class for Mail_Helper.

--- a/tests/Mail/MailMessageTest.php
+++ b/tests/Mail/MailMessageTest.php
@@ -17,14 +17,14 @@ use Date_Helper;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Test\TestCase;
+use Laminas\Mail\AddressList;
+use Laminas\Mail\Headers;
 use Mail_Helper;
 use Mail_Queue;
 use Mime_Helper;
 use Routing;
 use Setup;
 use Zend;
-use Zend\Mail\AddressList;
-use Zend\Mail\Headers;
 
 /**
  * @group mail
@@ -138,7 +138,7 @@ class MailMessageTest extends TestCase
 
         $exp = '<issue-73358@eventum.example.org>';
         $res = array_map(
-            function (\Zend\Mail\Address $a) {
+            function (\Laminas\Mail\Address $a) {
                 return $a->toString();
             }, iterator_to_array($message->getTo())
         );
@@ -150,12 +150,12 @@ class MailMessageTest extends TestCase
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-from.txt');
 
         $to = $message->getTo();
-        $this->assertInstanceOf('Zend\Mail\AddressList', $to);
+        $this->assertInstanceOf('Laminas\Mail\AddressList', $to);
         $this->assertEquals('issue-73358@eventum.example.org', $message->to);
 
         $message = MailMessage::createFromFile(__DIR__ . '/../data/duplicate-msgid.txt');
         $to = $message->getTo();
-        $this->assertInstanceOf('Zend\Mail\AddressList', $to);
+        $this->assertInstanceOf('Laminas\Mail\AddressList', $to);
         $this->assertEquals("support@example.org,\r\n support-2@example.org", $message->to);
     }
 
@@ -291,7 +291,7 @@ class MailMessageTest extends TestCase
         $this->assertEquals('IT <help@localhost>', $from);
 
         $address = $message->getFrom();
-        $this->assertInstanceOf('Zend\Mail\Address', $address);
+        $this->assertInstanceOf('Laminas\Mail\Address', $address);
         $this->assertEquals('IT <help@localhost>', $address->toString());
         $this->assertEquals('help@localhost', $address->getEmail());
         $this->assertEquals('IT', $address->getName());
@@ -586,14 +586,14 @@ class MailMessageTest extends TestCase
         ];
         Mail_Queue::queue($mail, $to, $options);
 
-        $mail = new \Zend\Mail\Message();
+        $mail = new \Laminas\Mail\Message();
         $mail->setBody('This is the text of the email.');
         $mail->setFrom($from);
         $mail->setTo($to);
         $mail->setSubject($subject);
         $mail->setEncoding('UTF-8');
 
-        $transport = new \Zend\Mail\Transport\Sendmail();
+        $transport = new \Laminas\Mail\Transport\Sendmail();
         $transport->setCallable(
             function ($to, $subject, $body, $headers, $params): void {
                 //error_log("to[$to] subject[$subject] body[$body] headers[$headers] params[$params]");
@@ -651,8 +651,8 @@ class MailMessageTest extends TestCase
     public function testParseHeaders(): void
     {
         $header = "Subject: [#77675] New Issue:xxxxxxxxx xxxxxxx xxxxxxxx xxxxxxxxxxxxx xxxxxxxxxx xxxxxxxx=2C =?utf-8?b?dMOkaHRhZWc=?= xx.xx, xxxx\r\n";
-        /** @see \Zend\Mail\Header\HeaderWrap::canBeEncoded */
-        $v0 = \Zend\Mail\Headers::fromString($header);
+        /** @see \Laminas\Mail\Header\HeaderWrap::canBeEncoded */
+        $v0 = \Laminas\Mail\Headers::fromString($header);
         $folding = Headers::FOLDING;
         $eol = Headers::EOL;
 
@@ -669,7 +669,7 @@ class MailMessageTest extends TestCase
         $this->assertEqualsIgnoringCase('x-test: =?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20?=  =?UTF-8?Q?xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx,=20t=C3=A4htaeg=20xx.xx,?=  =?UTF-8?Q?=20xxxx?=', $v);
 
         // this works too
-        $v2 = \Zend\Mail\Header\HeaderWrap::mimeEncodeValue($value, 'UTF-8');
+        $v2 = \Laminas\Mail\Header\HeaderWrap::mimeEncodeValue($value, 'UTF-8');
         $this->assertEquals('=?UTF-8?Q?[#77675]=20New=20Issue:xxxxxxxxx=20xxxxxxx=20xxxxxxxx=20xxxxxxxxxxxxx=20xxxxxxxxxx=20xxxxxxxx=2C=20t=C3=A4htaeg=20xx.xx=2C=20xxxx?=', $v2);
     }
 

--- a/tests/Mail/MailStorageTest.php
+++ b/tests/Mail/MailStorageTest.php
@@ -16,10 +16,10 @@ namespace Eventum\Test\Mail;
 use Eventum\Mail\MailStorage;
 use Eventum\ServiceContainer;
 use Eventum\Test\TestCase;
+use Laminas\Mail;
+use Laminas\Mail\Storage;
 use Setup;
 use Support;
-use Zend;
-use Zend\Mail;
 
 /**
  * @group mail
@@ -56,7 +56,7 @@ class MailStorageTest extends TestCase
     {
         $mbox = new MailStorage($this->account);
         $flags = [
-            Mail\Storage::FLAG_UNSEEN,
+            Storage::FLAG_UNSEEN,
         ];
         $count = $mbox->countMessages($flags);
         $this->assertEquals(0, $count);
@@ -107,7 +107,7 @@ class MailStorageTest extends TestCase
         $storage = new MailStorage($this->account);
         $message2 = $storage->getStorage()->getMessage(1);
 
-        var_dump($message1->hasFlag(Zend\Mail\Storage::FLAG_SEEN));
+        var_dump($message1->hasFlag(Storage::FLAG_SEEN));
 //        $a = ; if (($overview->seen) || ($overview->deleted) || ($overview->answered)) {
 //                        return;
 //                    }
@@ -125,12 +125,12 @@ class MailStorageTest extends TestCase
 
         // fill with "\Seen", "\Deleted", "\Answered", ... etc
         $knownFlags = [
-            'recent' => Zend\Mail\Storage::FLAG_RECENT,
-            'flagged' => Zend\Mail\Storage::FLAG_FLAGGED,
-            'answered' => Zend\Mail\Storage::FLAG_ANSWERED,
-            'deleted' => Zend\Mail\Storage::FLAG_DELETED,
-            'seen' => Zend\Mail\Storage::FLAG_SEEN,
-            'draft' => Zend\Mail\Storage::FLAG_DRAFT,
+            'recent' => Storage::FLAG_RECENT,
+            'flagged' => Storage::FLAG_FLAGGED,
+            'answered' => Storage::FLAG_ANSWERED,
+            'deleted' => Storage::FLAG_DELETED,
+            'seen' => Storage::FLAG_SEEN,
+            'draft' => Storage::FLAG_DRAFT,
         ];
         $flags = [];
         foreach ($knownFlags as $flag => $value) {

--- a/tests/Mail/MailTransportTest.php
+++ b/tests/Mail/MailTransportTest.php
@@ -16,10 +16,10 @@ namespace Eventum\Test\Mail;
 use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
 use Eventum\Test\TestCase;
+use Laminas\Mail\Headers;
+use Laminas\Mail\Protocol;
+use Laminas\Mail\Transport;
 use stdClass;
-use Zend\Mail\Headers;
-use Zend\Mail\Protocol;
-use Zend\Mail\Transport;
 
 /**
  * Class MailTransportTest
@@ -41,7 +41,7 @@ class MailTransportTest extends TestCase
 
         // this logic is from Smtp::send
         // $headers = $this->prepareHeaders($message);
-        /** @see \Zend\Mail\Transport\Smtp::send() */
+        /** @see \Laminas\Mail\Transport\Smtp::send() */
 
         $headers = clone $message->getHeaders();
         $headers->removeHeader('Bcc');

--- a/tests/Mail/MimeMessageTest.php
+++ b/tests/Mail/MimeMessageTest.php
@@ -17,8 +17,8 @@ use Eventum\Attachment\Attachment;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Test\TestCase;
+use Laminas\Mail\Header\MessageId;
 use ReflectionProperty;
-use Zend\Mail\Header\MessageId;
 
 class MimeMessageTest extends TestCase
 {


### PR DESCRIPTION
https://github.com/zendframework/zend-mail repository was abandoned on 2019-12-31

Previously we maintained zend-mail fork, because upstream was unacceptably slow to accept pull requests and make a release:
- https://github.com/eventum/zend-mail: This branch is 11 commits ahead, 14 commits behind zendframework:master.


there's 2.10.1 released for laminas-mail that still does not contain the fixes:
- [#83](https://github.com/laminas/laminas-mail/pull/83) fixes PHPDocs in Transport\InMemory (the last message can be null).
- [#84](https://github.com/laminas/laminas-mail/pull/84) fixes PHP 7.4 compatibility.
- [#82](https://github.com/laminas/laminas-mail/pull/82) fixes numerous issues in Storage\Maildir. This storage adapter was not working before and unit tests were disabled.
- [#75](https://github.com/laminas/laminas-mail/pull/75) fixes how Laminas\Mail\Header\ListParser::parse() parses the string with quotes.
- [#88](https://github.com/laminas/laminas-mail/pull/88) fixes recognizing encoding of Subject and GenericHeader headers.

the version we used was branched of 2.10.0, with following backports:
- [x] https://github.com/zendframework/zend-mail/pull/226 fixed in https://github.com/laminas/laminas-mail/pull/75
- [x] https://github.com/zendframework/zend-mail/pull/230 will be fixed in https://github.com/laminas/laminas-mail/pull/93
