### PR TITLE
Update Phinx to 0.12

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details how to upgrade.
 
+- Update Phinx to 0.12, #877
+
 [3.9.1]: https://github.com/eventum/eventum/compare/v3.9.0...master
 
 ## [3.9.0] - 2020-07-01

--- a/composer.json
+++ b/composer.json
@@ -61,7 +61,7 @@
         "portphp/csv": "^1.1",
         "portphp/doctrine": "^1.1",
         "portphp/steps": "^1.2",
-        "robmorgan/phinx": "^0.11.1",
+        "robmorgan/phinx": "^0.12.3",
         "sebastian/diff": "^3.0",
         "smarty-gettext/smarty-gettext": "~1.0",
         "smarty/smarty": "~3.1.12",

--- a/composer.lock
+++ b/composer.lock
@@ -4,68 +4,24 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "d4ef7ebc3e362220b626c9dd1ec9ff2f",
+    "content-hash": "Auto-merged! Run `composer update --lock` to regenerate",
     "packages": [
         {
-            "name": "cakephp/cache",
-            "version": "3.8.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cakephp/cache.git",
-                "reference": "09b2a1c4929e134456d30c61d9dbf6e10ace8436"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/cache/zipball/09b2a1c4929e134456d30c61d9dbf6e10ace8436",
-                "reference": "09b2a1c4929e134456d30c61d9dbf6e10ace8436",
-                "shasum": ""
-            },
-            "require": {
-                "cakephp/core": "^3.6.0",
-                "php": ">=5.6.0",
-                "psr/simple-cache": "^1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cake\\Cache\\": "."
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "CakePHP Community",
-                    "homepage": "https://github.com/cakephp/cache/graphs/contributors"
-                }
-            ],
-            "description": "Easy to use Caching library with support for multiple caching backends",
-            "homepage": "https://cakephp.org",
-            "keywords": [
-                "cache",
-                "caching",
-                "cakephp"
-            ],
-            "time": "2020-04-19T21:38:42+00:00"
-        },
-        {
             "name": "cakephp/collection",
-            "version": "3.8.13",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/collection.git",
-                "reference": "013e9d02552c56d737a6bff91e59544c735efed7"
+                "reference": "96bfd16c815fb8cbdaf736d5dc5dc9236af76567"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/collection/zipball/013e9d02552c56d737a6bff91e59544c735efed7",
-                "reference": "013e9d02552c56d737a6bff91e59544c735efed7",
+                "url": "https://api.github.com/repos/cakephp/collection/zipball/96bfd16c815fb8cbdaf736d5dc5dc9236af76567",
+                "reference": "96bfd16c815fb8cbdaf736d5dc5dc9236af76567",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.6.0"
+                "php": ">=7.2.0"
             },
             "type": "library",
             "autoload": {
@@ -94,25 +50,25 @@
                 "collections",
                 "iterators"
             ],
-            "time": "2020-01-10T15:24:40+00:00"
+            "time": "2020-05-20T14:35:50+00:00"
         },
         {
             "name": "cakephp/core",
-            "version": "3.8.12",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/core.git",
-                "reference": "16249fa6771663e6649cbdb832f7ff25bf568b84"
+                "reference": "47634837aedcef333e8d8cf235467e645181c226"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/core/zipball/16249fa6771663e6649cbdb832f7ff25bf568b84",
-                "reference": "16249fa6771663e6649cbdb832f7ff25bf568b84",
+                "url": "https://api.github.com/repos/cakephp/core/zipball/47634837aedcef333e8d8cf235467e645181c226",
+                "reference": "47634837aedcef333e8d8cf235467e645181c226",
                 "shasum": ""
             },
             "require": {
-                "cakephp/utility": "^3.6.0",
-                "php": ">=5.6.0"
+                "cakephp/utility": "^4.0",
+                "php": ">=7.2.0"
             },
             "suggest": {
                 "cakephp/cache": "To use Configure::store() and restore().",
@@ -144,28 +100,29 @@
                 "core",
                 "framework"
             ],
-            "time": "2020-01-10T15:24:40+00:00"
+            "time": "2020-05-21T21:18:40+00:00"
         },
         {
             "name": "cakephp/database",
-            "version": "3.8.13",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/database.git",
-                "reference": "9c6026f4a11f8cc8a0a7297fa516bd96573a2ce7"
+                "reference": "7f5b42ce86b59d1f8137a4633134540aaf236404"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/database/zipball/9c6026f4a11f8cc8a0a7297fa516bd96573a2ce7",
-                "reference": "9c6026f4a11f8cc8a0a7297fa516bd96573a2ce7",
+                "url": "https://api.github.com/repos/cakephp/database/zipball/7f5b42ce86b59d1f8137a4633134540aaf236404",
+                "reference": "7f5b42ce86b59d1f8137a4633134540aaf236404",
                 "shasum": ""
             },
             "require": {
-                "cakephp/cache": "^3.6.0",
-                "cakephp/core": "^3.6.0",
-                "cakephp/datasource": "^3.6.0",
-                "cakephp/log": "^3.6.0",
-                "php": ">=5.6.0"
+                "cakephp/core": "^4.0",
+                "cakephp/datasource": "^4.0",
+                "php": ">=7.2.0"
+            },
+            "suggest": {
+                "cakephp/i18n": "If you are using locale-aware datetime formats or Chronos types."
             },
             "type": "library",
             "autoload": {
@@ -192,25 +149,27 @@
                 "database abstraction",
                 "pdo"
             ],
-            "time": "2020-05-21T21:19:48+00:00"
+            "time": "2020-05-21T05:06:55+00:00"
         },
         {
             "name": "cakephp/datasource",
-            "version": "3.8.12",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/datasource.git",
-                "reference": "adc983f7c4d99c4361e3a8e4c0db7cdde26ee180"
+                "reference": "8667778e8e1ff3c75dc67e35c3d1279a427aaa72"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/datasource/zipball/adc983f7c4d99c4361e3a8e4c0db7cdde26ee180",
-                "reference": "adc983f7c4d99c4361e3a8e4c0db7cdde26ee180",
+                "url": "https://api.github.com/repos/cakephp/datasource/zipball/8667778e8e1ff3c75dc67e35c3d1279a427aaa72",
+                "reference": "8667778e8e1ff3c75dc67e35c3d1279a427aaa72",
                 "shasum": ""
             },
             "require": {
-                "cakephp/core": "^3.6.0",
-                "php": ">=5.6.0"
+                "cakephp/core": "^4.0",
+                "php": ">=7.2.0",
+                "psr/log": "^1.1",
+                "psr/simple-cache": "^1.0"
             },
             "suggest": {
                 "cakephp/cache": "If you decide to use Query caching.",
@@ -242,70 +201,25 @@
                 "entity",
                 "query"
             ],
-            "time": "2020-04-14T14:22:40+00:00"
-        },
-        {
-            "name": "cakephp/log",
-            "version": "3.8.12",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/cakephp/log.git",
-                "reference": "2dae5b32430ca89d66c73bd9d568fcf68736eae5"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/log/zipball/2dae5b32430ca89d66c73bd9d568fcf68736eae5",
-                "reference": "2dae5b32430ca89d66c73bd9d568fcf68736eae5",
-                "shasum": ""
-            },
-            "require": {
-                "cakephp/core": "^3.6.0",
-                "php": ">=5.6.0",
-                "psr/log": "^1.0.0"
-            },
-            "type": "library",
-            "autoload": {
-                "psr-4": {
-                    "Cake\\Log\\": "."
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "CakePHP Community",
-                    "homepage": "https://github.com/cakephp/log/graphs/contributors"
-                }
-            ],
-            "description": "CakePHP logging library with support for multiple different streams",
-            "homepage": "https://cakephp.org",
-            "keywords": [
-                "Streams",
-                "cakephp",
-                "log",
-                "logging"
-            ],
-            "time": "2020-01-10T15:24:40+00:00"
+            "time": "2020-05-19T14:52:54+00:00"
         },
         {
             "name": "cakephp/utility",
-            "version": "3.8.12",
+            "version": "4.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/utility.git",
-                "reference": "9f121defbff4b5f3691b33de8cb203b8923fc2a4"
+                "reference": "f4f151efcd2b952a619c9a62acd8b068c264fcde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/utility/zipball/9f121defbff4b5f3691b33de8cb203b8923fc2a4",
-                "reference": "9f121defbff4b5f3691b33de8cb203b8923fc2a4",
+                "url": "https://api.github.com/repos/cakephp/utility/zipball/f4f151efcd2b952a619c9a62acd8b068c264fcde",
+                "reference": "f4f151efcd2b952a619c9a62acd8b068c264fcde",
                 "shasum": ""
             },
             "require": {
-                "cakephp/core": "^3.6.0",
-                "php": ">=5.6.0"
+                "cakephp/core": "^4.0",
+                "php": ">=7.2.0"
             },
             "suggest": {
                 "ext-intl": "To use Text::transliterate() or Text::slug()",
@@ -340,7 +254,7 @@
                 "string",
                 "utility"
             ],
-            "time": "2020-02-18T01:57:35+00:00"
+            "time": "2020-05-21T05:06:55+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -3270,34 +3184,37 @@
         },
         {
             "name": "robmorgan/phinx",
-            "version": "0.11.7",
+            "version": "0.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/cakephp/phinx.git",
-                "reference": "3cdde73e0c33c410e076108b3e1603fabb5b330d"
+                "reference": "c63dcecbad83ae5723498e8b78163a4988d118f6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/cakephp/phinx/zipball/3cdde73e0c33c410e076108b3e1603fabb5b330d",
-                "reference": "3cdde73e0c33c410e076108b3e1603fabb5b330d",
+                "url": "https://api.github.com/repos/cakephp/phinx/zipball/c63dcecbad83ae5723498e8b78163a4988d118f6",
+                "reference": "c63dcecbad83ae5723498e8b78163a4988d118f6",
                 "shasum": ""
             },
             "require": {
-                "cakephp/collection": "^3.7",
-                "cakephp/database": "^3.7",
-                "php": ">=5.6",
+                "cakephp/collection": "^4.0",
+                "cakephp/database": "^4.0",
+                "php": ">=7.2",
+                "psr/container": "^1.0",
                 "symfony/config": "^3.4|^4.0|^5.0",
-                "symfony/console": "^3.4|^4.0|^5.0",
-                "symfony/yaml": "^3.4|^4.0|^5.0"
+                "symfony/console": "^3.4|^4.0|^5.0"
             },
             "require-dev": {
                 "cakephp/cakephp-codesniffer": "^3.0",
                 "ext-json": "*",
-                "phpunit/phpunit": ">=5.7,<8.0",
-                "sebastian/comparator": ">=1.2.3"
+                "ext-pdo": "*",
+                "phpunit/phpunit": "^8.5",
+                "sebastian/comparator": ">=1.2.3",
+                "symfony/yaml": "^3.4|^4.0|^5.0"
             },
             "suggest": {
                 "ext-json": "Install if using JSON configuration format",
+                "ext-pdo": "PDO extension is needed",
                 "symfony/yaml": "Install if using YAML configuration format"
             },
             "bin": [
@@ -3346,7 +3263,7 @@
                 "migrations",
                 "phinx"
             ],
-            "time": "2020-05-09T13:59:05+00:00"
+            "time": "2020-06-25T23:01:19+00:00"
         },
         {
             "name": "sebastian/diff",

--- a/phinx.php
+++ b/phinx.php
@@ -48,7 +48,7 @@ $phinx = [
 
     'environments' => [
         'default_migration_table' => 'phinxlog',
-        'default_database' => 'production',
+        'default_environment' => 'production',
         'production' => [
             'adapter' => 'mysql',
             'host' => $config['hostname'],


### PR DESCRIPTION
- https://github.com/cakephp/phinx/releases/tag/0.12.0
- https://github.com/cakephp/phinx/releases/tag/0.12.1
- https://github.com/cakephp/phinx/releases/tag/0.12.2
- https://github.com/cakephp/phinx/releases/tag/0.12.3

# Breaking Changes

- [x] Minimum of PHP 7.2 required now.
- [ ] `cakephp/database>=4.0` now required. This could impact migrations/seeds that use the query APIs.
- [x] In environment configuration `default_database` is now `default_environment`.