### PR TITLE
Add Symfony Deprecation contracts to mark deprecations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ See [Upgrading] for details how to upgrade.
 - Switch to use `laminas/laminas-config` instead of `zendframework/zend-config`, #875
 - Define all controllers in Symfony routes, #878
 - Fix getPassword to return EncryptedValue object, #883
+- Add Symfony Deprecation contracts to mark deprecations, #881
 
 [3.9.0]: https://github.com/eventum/eventum/compare/v3.9.0...master
 

--- a/composer.json
+++ b/composer.json
@@ -68,6 +68,7 @@
         "sphinx/php-sphinxapi": "2.0.*",
         "symfony/asset": "^4.4",
         "symfony/console": "^3.2.0 || ^4.0",
+        "symfony/deprecation-contracts": "^2.1",
         "symfony/event-dispatcher": "^2.7 || ^3.0 || ^4.0",
         "symfony/expression-language": "^4.3",
         "symfony/filesystem": "^2.7 || ^3.0 || ^4.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "effb1ba512e516a954a75a17aa8921b6",
+    "content-hash": "d4ef7ebc3e362220b626c9dd1ec9ff2f",
     "packages": [
         {
             "name": "cakephp/cache",
@@ -4129,6 +4129,66 @@
                 }
             ],
             "time": "2020-06-12T07:37:04+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v2.1.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
+                "reference": "dd99cb3a0aff6cadd2a8d7d7ed72c2161e218337",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.1-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-05-27T08:34:37+00:00"
         },
         {
             "name": "symfony/doctrine-bridge",

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -289,8 +289,11 @@ class Issue
      * @param   bool $notify if a notification should be sent about this change
      * @return  int 1 if the update worked, -2 if no change is made, -1 on error
      */
-    public static function setStatus(int $issue_id, int $status_id, bool $notify = false)
+    public static function setStatus(int $issue_id, ?int $status_id, bool $notify = false)
     {
+        trigger_deprecation('eventum/eventum', '3.9.0', 'Passing $status_id as non-integer is deprecated. Got "%s"', $status_id);
+        $status_id = (int)$status_id;
+
         $prj_id = self::getProjectID($issue_id);
         $workflow = Workflow::preStatusChange($prj_id, $issue_id, $status_id, $notify);
         if ($workflow !== true) {


### PR DESCRIPTION
Use [symfony/deprecation-contracts][1] to note down deprecations.

- [x] Deprecate non-integer Issue::setStatus $status_id parameter

[1]: https://packagist.org/packages/symfony/deprecation-contracts