### PR TITLE
Use APP_ENV=prod by default

### DIFF
--- a/bin/console.php
+++ b/bin/console.php
@@ -30,10 +30,6 @@ if ($input->hasParameterOption('--no-debug', true)) {
     putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: Kernel::DEFAULT_ENVIRONMENT;
-$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int)$_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
-
 if ($_SERVER['APP_DEBUG']) {
     umask(0000);
 

--- a/bin/console.php
+++ b/bin/console.php
@@ -30,7 +30,7 @@ if ($input->hasParameterOption('--no-debug', true)) {
     putenv('APP_DEBUG=' . $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = '0');
 }
 
-$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: Kernel::DEFAULT_ENVIRONMENT;
 $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
 $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int)$_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 

--- a/bin/upgrade.php
+++ b/bin/upgrade.php
@@ -12,6 +12,9 @@
  * that were distributed with this source code.
  */
 
+use Eventum\Kernel;
+use Symfony\Bundle\FrameworkBundle\Console\Application;
+
 define('INSTALL_PATH', __DIR__ . '/..');
 define('CONFIG_PATH', INSTALL_PATH . '/config');
 
@@ -27,9 +30,19 @@ if (!file_exists($setup_path) || !filesize($setup_path) || !is_readable($setup_p
 
 require_once INSTALL_PATH . '/init.php';
 
-// run phinx based updater
 chdir(__DIR__ . '/..');
+
+/**
+ * Clear Symfony cache and run phing upgrade
+ */
+
+$kernel = new Kernel($_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG']);
+$app = new Application($kernel);
+$app->setDefaultCommand('cache:clear', true);
+$app->setAutoExit(false);
+$app->run();
 
 $app = new Phinx\Console\PhinxApplication();
 $app->setDefaultCommand('migrate');
+$app->setAutoExit(false);
 $app->run();

--- a/init.php
+++ b/init.php
@@ -13,6 +13,7 @@
 
 use Eventum\Event\SystemEvents;
 use Eventum\Extension\ExtensionManager;
+use Eventum\Kernel;
 use Eventum\ServiceContainer;
 
 require_once __DIR__ . '/autoload.php';
@@ -26,6 +27,10 @@ if (Setup::needsSetup()) {
     header('Location: setup/');
     exit(0);
 }
+
+$_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: Kernel::DEFAULT_ENVIRONMENT;
+$_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
+$_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int)$_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 
 // setup change some PHP settings
 ini_set('memory_limit', '512M');

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -75,10 +75,6 @@ class Kernel extends BaseKernel
             $_SERVER['REQUEST_URI'] = $requestUri . rtrim($_SERVER['REQUEST_URI'], '/');
         }
 
-        $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: self::DEFAULT_ENVIRONMENT;
-        $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
-        $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int)$_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
-
         $kernel = new Kernel($_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG']);
         $request = Request::createFromGlobals();
         $response = $kernel->handle($request);

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -29,6 +29,11 @@ class Kernel extends BaseKernel
 {
     use MicroKernelTrait;
 
+    /**
+     * Value to use if APP_ENV environment variable is not set
+     */
+    public const DEFAULT_ENVIRONMENT = 'prod';
+
     /** @var string */
     private $configDir;
 
@@ -70,7 +75,7 @@ class Kernel extends BaseKernel
             $_SERVER['REQUEST_URI'] = $requestUri . rtrim($_SERVER['REQUEST_URI'], '/');
         }
 
-        $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: 'dev';
+        $_SERVER['APP_ENV'] = $_ENV['APP_ENV'] = ($_SERVER['APP_ENV'] ?? $_ENV['APP_ENV'] ?? null) ?: self::DEFAULT_ENVIRONMENT;
         $_SERVER['APP_DEBUG'] = $_SERVER['APP_DEBUG'] ?? $_ENV['APP_DEBUG'] ?? 'prod' !== $_SERVER['APP_ENV'];
         $_SERVER['APP_DEBUG'] = $_ENV['APP_DEBUG'] = (int)$_SERVER['APP_DEBUG'] || filter_var($_SERVER['APP_DEBUG'], FILTER_VALIDATE_BOOLEAN) ? '1' : '0';
 


### PR DESCRIPTION
This makes default installation to use production mode.

This may need to call cache clear which was not necessary before:

```
$ bin/console.php cache:clear
```