### PR TITLE
Move SCM setup to Extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Upgrading] for details on how to upgrade.
 - Add extension support to be able to configure container, #1025, #1026
 - Add Extension to report errors to Slack channel, #1024
 - Avoid using deprecated Setup::get(), #1030
+- Move SCM setup to Extension, #890
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/db/migrations/20200710050147_eventum_register_scm_extension.php
+++ b/db/migrations/20200710050147_eventum_register_scm_extension.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+use Eventum\Extension\RegisterExtension;
+use Eventum\Extension\ScmExtension;
+use Eventum\ServiceContainer;
+
+class EventumRegisterScmExtension extends AbstractMigration
+{
+    private const EXTENSIONS = [
+        ScmExtension::class,
+    ];
+
+    public function up(): void
+    {
+        $this->registerExtensions();
+    }
+
+    public function down(): void
+    {
+        $this->unregisterExtensions();
+    }
+
+    private function registerExtensions(): void
+    {
+        if ($this->isEnabled()) {
+            $register = new RegisterExtension();
+            $register->register(...self::EXTENSIONS);
+        }
+    }
+
+    private function unregisterExtensions(): void
+    {
+        if ($this->isEnabled()) {
+            $register = new RegisterExtension();
+            $register->unregister(...self::EXTENSIONS);
+        }
+    }
+
+    private function isEnabled(): bool
+    {
+        return ServiceContainer::getConfig()['scm_integration'] === 'enabled';
+    }
+}

--- a/res/routes.yml
+++ b/res/routes.yml
@@ -169,11 +169,6 @@ rss:
   path: /rss.php
   controller: Eventum\Controller\RssController::indexAction
 
-scm_ping:
-  path: /scm_ping.php
-  methods: POST
-  controller: Eventum\Controller\ScmPingController::defaultAction
-
 searchbar:
   path: /searchbar.php
   methods: GET

--- a/src/Controller/Manage/ScmController.php
+++ b/src/Controller/Manage/ScmController.php
@@ -14,6 +14,8 @@
 namespace Eventum\Controller\Manage;
 
 use Eventum\Controller\Helper\MessagesHelper;
+use Eventum\Extension\RegisterExtension;
+use Eventum\Extension\ScmExtension;
 use Eventum\ServiceContainer;
 use Setup;
 use User;
@@ -55,6 +57,10 @@ class ScmController extends ManageBaseController
 
         $setup = ['scm_integration' => $post->get('scm_integration')];
         $res = Setup::save($setup);
+
+        $register = new RegisterExtension();
+        $register->enable(ScmExtension::class, $setup['scm_integration'] === 'enabled');
+
         $this->tpl->assign('result', $res);
 
         $setupFile = Setup::getSetupFile();

--- a/src/Controller/Manage/ScmController.php
+++ b/src/Controller/Manage/ScmController.php
@@ -80,6 +80,7 @@ class ScmController extends ManageBaseController
             ), MessagesHelper::MSG_NOTE_BOX],
         ];
         $this->messages->mapMessages($res, $map);
+        $this->redirect('scm.php');
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -19,12 +19,14 @@ use Eventum\ServiceContainer;
 use Generator;
 use InvalidArgumentException;
 use LazyProperty\LazyPropertiesTrait;
+use ReflectionClass;
 use RuntimeException;
 use Symfony\Component\Config\Loader\LoaderInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Throwable;
+use UnexpectedValueException;
 
 final class ExtensionManager implements
     Provider\ContainerConfiguratorProvider,
@@ -258,6 +260,24 @@ final class ExtensionManager implements
         }
 
         return new $className();
+    }
+
+    /**
+     * @since 3.10.2
+     */
+    public function add(string $className): void
+    {
+        $extension = new $className();
+        if (!$extension instanceof Provider\ExtensionProvider) {
+            $error = sprintf('Extension must be a string or instance of %s', Provider\ExtensionProvider::class);
+            throw new InvalidArgumentException($error);
+        }
+
+        $class = new ReflectionClass($extension);
+        if (isset($this->extensions[$class->getName()])) {
+            throw new UnexpectedValueException(sprintf('Extension %s already added', $class->getName()));
+        }
+        $this->extensions[$class->getName()] = $extension;
     }
 
     /**

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -26,7 +26,6 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigurator;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Throwable;
-use UnexpectedValueException;
 
 final class ExtensionManager implements
     Provider\ContainerConfiguratorProvider,
@@ -275,7 +274,7 @@ final class ExtensionManager implements
 
         $class = new ReflectionClass($extension);
         if (isset($this->extensions[$class->getName()])) {
-            throw new UnexpectedValueException(sprintf('Extension %s already added', $class->getName()));
+            return;
         }
         $this->extensions[$class->getName()] = $extension;
     }

--- a/src/Extension/ScmExtension.php
+++ b/src/Extension/ScmExtension.php
@@ -13,11 +13,16 @@
 
 namespace Eventum\Extension;
 
+use Eventum\Controller\ScmPingController;
 use Eventum\Extension\Provider\ExtensionProvider;
+use Eventum\Extension\Provider\RouteProvider;
 use Eventum\Logger\LoggerTrait;
 use Eventum\ServiceContainer;
+use Symfony\Component\Routing\RouteCollectionBuilder;
 
-class ScmExtension implements ExtensionProvider
+class ScmExtension implements
+    ExtensionProvider,
+    RouteProvider
 {
     use LoggerTrait;
 
@@ -28,5 +33,12 @@ class ScmExtension implements ExtensionProvider
     {
         $config = ServiceContainer::getConfig();
         $this->enabled = $config['scm_integration'] === 'enabled';
+    }
+
+    public function configureRoutes(RouteCollectionBuilder $routes): void
+    {
+        $routes
+            ->add('/scm_ping.php', ScmPingController::class . '::defaultAction', 'scm_ping')
+            ->setMethods('POST');
     }
 }

--- a/src/Extension/ScmExtension.php
+++ b/src/Extension/ScmExtension.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use Eventum\Extension\Provider\ExtensionProvider;
+use Eventum\Logger\LoggerTrait;
+use Eventum\ServiceContainer;
+
+class ScmExtension implements ExtensionProvider
+{
+    use LoggerTrait;
+
+    /** @var bool */
+    private $enabled;
+
+    public function __construct()
+    {
+        $config = ServiceContainer::getConfig();
+        $this->enabled = $config['scm_integration'] === 'enabled';
+    }
+}

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -16,12 +16,11 @@ namespace Eventum\Test\Scm;
 use Date_Helper;
 use Eventum\Event\SystemEvents;
 use Eventum\EventDispatcher\EventManager;
-use Eventum\Extension\ExtensionManager;
+use Eventum\Extension\ScmExtension;
 use Eventum\Model\Entity;
 use Eventum\Model\Repository\StatusRepository;
 use Eventum\ServiceContainer;
 use Eventum\Test\Traits\DoctrineTrait;
-
 use ProjectSeeder;
 use Setup;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
@@ -35,10 +34,9 @@ abstract class TestCase extends WebTestCase
     public static function setUpBeforeClass(): void
     {
         self::setUpConfig();
-
-        // Boot ExtensionManager
-        // current test touches parts that would require workflow to be called
-        ServiceContainer::getExtensionManager()->boot();
+        $em = ServiceContainer::getExtensionManager();
+        $em->add(ScmExtension::class);
+        $em->boot();
     }
 
     /**


### PR DESCRIPTION
If the extension is not enabled, the `/scm_ping` route will be missing.