### PR TITLE
Enable PHP version check in vendor/autoload.php

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 /.travis.yml export-ignore
 /phpcompatinfo.json export-ignore
 /build.xml export-ignore
+/symfony.lock export-ignore
 /bin/releng/ export-ignore
 
 /config/phpxref.cfg export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details how to upgrade.
 - Switch to use `laminas/laminas-mail` instead of `zendframework/zend-mail`, #876
 - Fix event context passing of click handlers, #891
 - Include xhgui profiler in release package, #892
+- Enable PHP version check in `vendor/autoload.php`, #893
 
 [3.9.2]: https://github.com/eventum/eventum/compare/v3.9.1...master
 

--- a/composer.json
+++ b/composer.json
@@ -104,6 +104,7 @@
         "maximebf/debugbar": "1.*",
         "sentry/sentry": "^1.7",
         "symfony/browser-kit": "^4.2",
+        "symfony/flex": "^1.9",
         "symfony/phpunit-bridge": "^5.0",
         "symfony/thanks": "^1.0"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c8b240fadb7418ec4cc30c004f9a62c0",
+    "content-hash": "e486528b5813562d642f45e0e9e3ee4b",
     "packages": [
         {
             "name": "cakephp/collection",
@@ -8039,6 +8039,69 @@
                 }
             ],
             "time": "2020-05-23T00:03:06+00:00"
+        },
+        {
+            "name": "symfony/flex",
+            "version": "v1.9.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/flex.git",
+                "reference": "0e752e47d8382361ca2d7ef016f549828185ddb6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/flex/zipball/0e752e47d8382361ca2d7ef016f549828185ddb6",
+                "reference": "0e752e47d8382361ca2d7ef016f549828185ddb6",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0|^2.0",
+                "php": ">=7.1"
+            },
+            "require-dev": {
+                "composer/composer": "^1.0.2|^2.0",
+                "symfony/dotenv": "^4.4|^5.0",
+                "symfony/phpunit-bridge": "^4.4|^5.0",
+                "symfony/process": "^3.4|^4.4|^5.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.8-dev"
+                },
+                "class": "Symfony\\Flex\\Flex"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Flex\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien.potencier@gmail.com"
+                }
+            ],
+            "description": "Composer plugin for Symfony",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2020-07-14T15:18:33+00:00"
         },
         {
             "name": "symfony/phpunit-bridge",

--- a/symfony.lock
+++ b/symfony.lock
@@ -1,0 +1,17 @@
+{
+    "php": {
+        "version": "7.2.5"
+    },
+    "symfony/flex": {
+        "version": "1.0",
+        "recipe": {
+            "repo": "github.com/symfony/recipes",
+            "branch": "master",
+            "version": "1.0",
+            "ref": "c0eeb50665f0f77226616b6038a9b06c03752d8e"
+        },
+        "files": [
+            ".env"
+        ]
+    }
+}


### PR DESCRIPTION
Setup `symfony/flex` (dev only), but it has side effect:
- the generated vendor/autoload.php has PHP version check:

```
➔ head vendor/autoload.php
<?php

if (\PHP_VERSION_ID < 70200) {
    echo sprintf("Fatal Error: composer.lock was created for PHP version 7.2.5 or higher but the current PHP version is %d.%d.%d.\n", PHP_MAJOR_VERSION, PHP_MINOR_VERSION, PHP_RELEASE_VERSION);
    exit(1);
}
```

I've tried to accomplish that check with composer 2.0 initially:
- https://github.com/eventum/eventum/pull/873

but it proved to be more difficult to achieve.