### PR TITLE
Drop loading deprecated ldap.php

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details how to upgrade.
 
+- Drop loading deprecated `ldap.php`, #899
+
 [3.9.3]: https://github.com/eventum/eventum/compare/v3.9.2...master
 
 ## [3.9.2] - 2020-07-26

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -306,28 +306,6 @@ class Setup
         $config = new Config(self::getDefaults(), true);
         $config->merge(new Config($loader->load(self::getSetupFile())));
 
-        // some subtrees are saved to different files
-        $extra_configs = [
-            // @deprecated
-            'ldap' => self::getConfigPath() . '/ldap.php',
-        ];
-
-        foreach ($extra_configs as $section => $filename) {
-            // skip if already present in main config
-            if (isset($config[$section]) && $config[$section]->toArray()) {
-                continue;
-            }
-
-            if (!file_exists($filename)) {
-                continue;
-            }
-
-            $subConfig = $loader->load($filename);
-            if ($subConfig) {
-                $config->merge(new Config([$section => $subConfig]));
-            }
-        }
-
         return $config;
     }
 


### PR DESCRIPTION
This was removed in #686 (Eventum 3.8.3) and is no longer needed.
