### PR TITLE
Use Symfony\Contracts\EventDispatcher\Event instead of deprecated Symfony\Component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details how to upgrade.
 - Drop loading deprecated `ldap.php`, #899
 - Update `laminas/laminas-mail` (2.11.0 => 2.12.0), #896
 - Use Doctrine PDO connection for legacy PdoAdapter, #901
+- Use `Symfony\Contracts\EventDispatcher\Event` instead of deprecated `Symfony\Component`, #902
 
 [3.9.3]: https://github.com/eventum/eventum/compare/v3.9.2...master
 

--- a/src/Event/ConfigUpdateEvent.php
+++ b/src/Event/ConfigUpdateEvent.php
@@ -17,7 +17,7 @@ use Eventum\Config\Config;
 use Eventum\Crypto\CryptoException;
 use Eventum\Crypto\CryptoManager;
 use Eventum\Crypto\EncryptedValue;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 final class ConfigUpdateEvent extends Event
 {

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -16,9 +16,9 @@ namespace Eventum\EventDispatcher;
 use Eventum\Event\Subscriber;
 use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class EventManager
 {
@@ -51,7 +51,7 @@ class EventManager
      * Helper to dispatch events
      *
      * @param string $eventName
-     * @param Event|\Symfony\Contracts\EventDispatcher\Event $event
+     * @param Event|\Symfony\Component\EventDispatcher\Event $event
      * @return Event|object
      * @see EventDispatcherInterface::dispatch()
      */

--- a/tests/Dispatcher/ExtensionSubscribeTest.php
+++ b/tests/Dispatcher/ExtensionSubscribeTest.php
@@ -15,9 +15,9 @@ namespace Eventum\Test\Dispatcher;
 
 use Eventum\Extension\Provider;
 use Eventum\Test\TestCase;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class ExtensionSubscribeTest extends TestCase
 {


### PR DESCRIPTION
"Symfony\Component\EventDispatcher\Event" is deprecated since Symfony 4.3, use "Symfony\Contracts\EventDispatcher\Event" instead.


refs:
- https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching
- https://www.drupal.org/project/drupal/issues/3055198
- https://www.drupal.org/project/drupal/issues/3153803
- https://github.com/FriendsOfSymfony/FOSUserBundle/issues/2971
- https://jira.ez.no/browse/EZP-30828