### PR TITLE
Configure Symfony logger: Processors, MailHandler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Upgrading] for details how to upgrade.
 - Update `laminas/laminas-mail` (2.11.0 => 2.12.0), #896
 - Use Doctrine PDO connection for legacy PdoAdapter, #901
 - Use `Symfony\Contracts\EventDispatcher\Event` instead of deprecated `Symfony\Component`, #902
+- Configure Symfony logger: Processors, MailHandler, #904
 
 [3.9.3]: https://github.com/eventum/eventum/compare/v3.9.2...master
 

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -467,7 +467,7 @@ class Auth
                 $adapter = Eventum\Auth\Adapter\Factory::create($spec ? $spec->toArray() : []);
             } catch (Throwable $e) {
                 $message = 'Unable to instantiate auth adapter';
-                Logger::app()->critical($message, ['exception' => $e]);
+                ServiceContainer::getLogger()->critical($message, ['exception' => $e]);
 
                 $tpl = new Template_Helper();
                 $tpl->setTemplate('authentication_error.tpl.html');

--- a/lib/eventum/class.custom_field.php
+++ b/lib/eventum/class.custom_field.php
@@ -18,7 +18,6 @@ use Eventum\Db\Doctrine;
 use Eventum\Diff;
 use Eventum\Extension\ExtensionLoader;
 use Eventum\Model\Entity\CustomField;
-use Eventum\Monolog\Logger;
 use Eventum\ServiceContainer;
 
 /**
@@ -406,7 +405,7 @@ class Custom_Field
         try {
             self::updateCustomFieldValues($issue_id, $role_id, $custom_fields);
         } catch (Throwable $e) {
-            Logger::app()->error($e->getMessage(), ['exception' => $e]);
+            ServiceContainer::getLogger()->error($e->getMessage(), ['exception' => $e]);
 
             return false;
         }

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -17,7 +17,6 @@ use Eventum\Config\Paths;
 use Eventum\Event\ConfigUpdateEvent;
 use Eventum\Event\SystemEvents;
 use Eventum\EventDispatcher\EventManager;
-use Eventum\Monolog\Logger;
 use Eventum\ServiceContainer;
 use Symfony\Component\Filesystem\Exception\IOException;
 
@@ -261,7 +260,7 @@ class Setup
             self::saveConfig(self::getSetupFile(), $config);
         } catch (Exception $e) {
             $code = $e->getCode();
-            Logger::app()->error($e);
+            ServiceContainer::getLogger()->error($e);
 
             return $code ?: -1;
         }

--- a/lib/eventum/class.support.php
+++ b/lib/eventum/class.support.php
@@ -22,7 +22,6 @@ use Eventum\Mail\Helper\WarningMessage;
 use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
-use Eventum\Monolog\Logger;
 use Eventum\ServiceContainer;
 
 /**
@@ -336,7 +335,7 @@ class Support
         $mbox = @imap_open(self::getServerURI($info), $info['ema_username'], $info['ema_password']);
         if ($mbox === false) {
             $error = @imap_last_error();
-            Logger::app()->error("Error while connecting to the email server - {$error}");
+            ServiceContainer::getLogger()->error("Error while connecting to the email server - {$error}");
         }
 
         return $mbox;
@@ -1622,7 +1621,7 @@ class Support
     {
         if ($to === null) {
             // BTW, $to = '' is ok
-            Logger::app()->error('"To:" can not be NULL');
+            ServiceContainer::getLogger()->error('"To:" can not be NULL');
 
             return -1;
         }

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -15,7 +15,6 @@ use Eventum\Db\DatabaseException;
 use Eventum\Event;
 use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailBuilder;
-use Eventum\Monolog\Logger;
 use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -325,7 +324,7 @@ class User
         try {
             self::updatePassword($usr_id, $passwd);
         } catch (Exception $e) {
-            Logger::app()->error($e);
+            ServiceContainer::getLogger()->error($e);
 
             return -1;
         }
@@ -433,7 +432,7 @@ class User
         static $returns;
 
         if (!is_string($email)) {
-            Logger::app()->error('$email parameter is not a string', ['type' => gettype($email), 'value' => $email]);
+            ServiceContainer::getLogger()->error('$email parameter is not a string', ['type' => gettype($email), 'value' => $email]);
 
             return null;
         }

--- a/res/monolog.yml
+++ b/res/monolog.yml
@@ -1,0 +1,21 @@
+services:
+  Eventum\Monolog\AppInfoProcessor:
+    tags:
+      - { name: monolog.processor }
+  Monolog\Processor\WebProcessor:
+    tags:
+      - { name: monolog.processor }
+  Monolog\Processor\MemoryUsageProcessor:
+    tags:
+      - { name: monolog.processor }
+  Monolog\Processor\MemoryPeakUsageProcessor:
+    tags:
+      - { name: monolog.processor }
+  Monolog\Processor\PsrLogMessageProcessor:
+    tags:
+      - { name: monolog.processor }
+  Monolog\Processor\IntrospectionProcessor:
+    tags:
+      - { name: monolog.processor }
+
+# vim:ts=2:sw=2:et

--- a/res/packages/dev/monolog.yml
+++ b/res/packages/dev/monolog.yml
@@ -21,8 +21,6 @@ monolog:
       # optionally configure the mapping between verbosity levels and log levels
       # verbosity_levels:
       #     VERBOSITY_NORMAL: NOTICE
-
-    # Uncomment to log deprecations
     deprecation:
       type: stream
       path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"

--- a/res/packages/dev/monolog.yml
+++ b/res/packages/dev/monolog.yml
@@ -29,5 +29,8 @@ monolog:
       handler: deprecation
       max_level: info
       channels: ["php"]
+    error_mailer:
+      type: service
+      id: Eventum\Monolog\MailHandler
 
 # vim:ts=2:sw=2:et

--- a/res/packages/prod/monolog.yml
+++ b/res/packages/prod/monolog.yml
@@ -14,6 +14,9 @@ monolog:
       type: console
       process_psr_3_messages: false
       channels: ["!event", "!doctrine"]
+    error_mailer:
+      type: service
+      id: Eventum\Monolog\MailHandler
     deprecation:
       type: stream
       path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"

--- a/res/packages/prod/monolog.yml
+++ b/res/packages/prod/monolog.yml
@@ -14,15 +14,13 @@ monolog:
       type: console
       process_psr_3_messages: false
       channels: ["!event", "!doctrine"]
-
-    # Uncomment to log deprecations
-    #deprecation:
-    #    type: stream
-    #    path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
-    #deprecation_filter:
-    #    type: filter
-    #    handler: deprecation
-    #    max_level: info
-    #    channels: ["php"]
+    deprecation:
+      type: stream
+      path: "%kernel.logs_dir%/%kernel.environment%.deprecations.log"
+    deprecation_filter:
+      type: filter
+      handler: deprecation
+      max_level: info
+      channels: ["php"]
 
 # vim:ts=2:sw=2:et

--- a/src/Logger/LoggerTrait.php
+++ b/src/Logger/LoggerTrait.php
@@ -13,7 +13,7 @@
 
 namespace Eventum\Logger;
 
-use Eventum\Monolog\Logger;
+use Eventum\ServiceContainer;
 use Psr\Log\LoggerInterface;
 use Psr\Log\LoggerTrait as PsrLoggerTrait;
 
@@ -32,7 +32,7 @@ trait LoggerTrait
     protected function getLogger(): LoggerInterface
     {
         if ($this->logger === null) {
-            $this->logger = Logger::app();
+            $this->logger = ServiceContainer::getLogger();
         }
 
         return $this->logger;

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -17,6 +17,7 @@ use Eventum\Config\Config;
 use Pimple\Container;
 use Pimple\Psr11\Container as PsrContainer;
 use Psr\Container\ContainerInterface;
+use Psr\Log\LoggerInterface;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ServiceContainer
@@ -55,6 +56,11 @@ class ServiceContainer
     public static function getConfig(): Config
     {
         return static::get('config');
+    }
+
+    public static function getLogger(): LoggerInterface
+    {
+        return static::get(LoggerInterface::class);
     }
 
     public static function getKernel(): KernelInterface


### PR DESCRIPTION
Configure Symfony same way as monolog-cascade logger:
- add processors
- add error mail handler

Extracted from https://github.com/eventum/eventum/pull/898 to be able to merge sooner.