### PR TITLE
Fix creating mail message on null note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details how to upgrade.
 - Replace symfony/polyfill-php72, #911
 - Add support for GitLab noteable type `Commit`, #912
 - Detect rewrite module (nginx), #910
+- Fix creating mail message on null note, #914
 
 [3.9.4]: https://github.com/eventum/eventum/compare/v3.9.3...master
 

--- a/db/migrations/20200818114141_eventum_fix_null_notes.php
+++ b/db/migrations/20200818114141_eventum_fix_null_notes.php
@@ -1,0 +1,32 @@
+<?php
+declare(strict_types=1);
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+use Eventum\Db\AbstractMigration;
+
+final class EventumFixNullNotes extends AbstractMigration
+{
+    public function up(): void
+    {
+        $builder = $this->getQueryBuilder();
+        $builder
+            ->update('note')
+            ->set($builder->newExpr('not_has_attachment = 0'))
+            ->where('not_has_attachment > 0 and not_full_message is null')
+            ->execute();
+    }
+
+    public function down(): void
+    {
+    }
+}

--- a/lib/eventum/class.note.php
+++ b/lib/eventum/class.note.php
@@ -93,7 +93,7 @@ class Note
         } else {
             $res['not_from'] = User::getFullName($res['not_usr_id']);
         }
-        if ($res['not_has_attachment']) {
+        if ($res['not_has_attachment'] && $res['not_full_message'] !== null) {
             $mail = MailMessage::createFromString($res['not_full_message']);
             $res['attachments'] = $mail->getAttachment()->getAttachments();
         }


### PR DESCRIPTION

Uncaught Exception TypeError: "Argument 1 passed to Eventum\Mail\MailMessage::createFromString() must be of the type string, null given,

called in lib/eventum/class.note.php on line 97 at src/Mail/MailMessage.php line 103

    [stacktrace]
    #0 lib/eventum/class.note.php(97): Eventum\\Mail\\MailMessage::createFromString(NULL)
    #1 lib/eventum/search/class.sphinx_fulltext_search.php(150): Note::getDetails(175541)
    #2 lib/eventum/class.search.php(788): Sphinx_Fulltext_Search->getExcerpts()
    #3 lib/eventum/class.search.php(424): Search::getFullTextExcerpts(Array)
    #4 src/Controller/ListController.php(163): Search::getListing(1, Array, 0, 15)
    #5 src/Controller/BaseController.php(84): Eventum\\Controller\\ListController->prepareTemplate()
    #6 htdocs/list.php(17): Eventum\\Controller\\BaseController->run()
    #7 {main}
