### PR TITLE
Add workaround for Manage users dataTable error

### DIFF
--- a/templates/base.tpl.html
+++ b/templates/base.tpl.html
@@ -56,6 +56,8 @@
   {* allow pages to inject to <head> block *}
   {block "javascripts"}
   {/block}
+  {block "javascripts2"}
+  {/block}
   {$debugbar_head|default:''}
   {* local directory can add overrides *}
   {$userscript}

--- a/templates/sentry.tpl.html
+++ b/templates/sentry.tpl.html
@@ -1,4 +1,4 @@
-{block "javascripts" append}
+{block "javascripts2" append}
 <script type="text/javascript" src="{asset path='js/raven.js'}"></script>
 <script type="text/javascript">
   Raven.config('{$sentry.dsn}', {


### PR DESCRIPTION
Workaround for mis-use of {block}, {extends} and {include}: https://github.com/smarty-php/smarty/issues/303 which results of certain block on the page ({javascripts} from users_list.tpl) being repeated twice.