### PR TITLE
Fix assignment field and quick search dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Upgrading] for details how to upgrade.
 
 - Move inline documentation to docs/help and convert to markdown, #921
 - Move imap related methods to ImapConnection class, #937
+- Fix assignment field and quick search dropdowns, #943, #916, #942
 
 [3.9.6]: https://github.com/eventum/eventum/compare/v3.9.5...master
 

--- a/res/assets/sass/main.scss
+++ b/res/assets/sass/main.scss
@@ -408,8 +408,6 @@ table.grid {
 
     td {
         padding: .3em;
-        max-width: 95vw;
-        overflow-y: auto;
     }
 
     tr {

--- a/res/assets/sass/main.scss
+++ b/res/assets/sass/main.scss
@@ -427,6 +427,14 @@ table.grid {
     }
 }
 
+// fix over overly long note text
+div.issue_section {
+    table.grid td {
+        max-width: 95vw;
+        overflow-y: auto;
+    }
+}
+
 /* if issue description is too wide */
 #issue_description {
     display: inline-block;


### PR DESCRIPTION
Revert fab53a1 and apply better.

The selector was too loose and applied unwanted selectors:
- https://github.com/eventum/eventum/pull/794#issuecomment-677665278



Fixes https://github.com/eventum/eventum/issues/916, https://github.com/eventum/eventum/issues/942