### PR TITLE
Fix sorting links when searching for custom fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details how to upgrade.
 
+- Fix sorting links when searching for custom fields, #947
+
 [3.9.7]: https://github.com/eventum/eventum/compare/v3.9.6...master
 
 ## [3.9.6] - 2020-09-30

--- a/lib/eventum/class.filter.php
+++ b/lib/eventum/class.filter.php
@@ -534,7 +534,7 @@ class Filter
         }
         if (isset($options['custom_field'])) {
             if (is_array($options['custom_field'])) {
-                $options['custom_field'] = serialize($options['custom_field']);
+                $options['custom_field'] = json_encode($options['custom_field']);
             }
             $url .= 'custom_field=' . urlencode($options['custom_field']) . '&';
         }


### PR DESCRIPTION
Commit 5bb5631be changed the serialization of custom field filter
parameters from PHP array syntax to JSON syntax, but missed one
occurrence in the function building the URLs for sorting links. As a
result custom field filters are lost when changing the sort order by
clicking one of the list headings.

x-ref:
- https://github.com/eventum/eventum/pull/393
- https://github.com/eventum/eventum/pull/530