### PR TITLE
Use GitHub Actions for CI integration

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,6 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
+          tools: composer:v1
           extensions: pdo, pdo_mysql, gd, ldap
 
       - name: Validate composer.json and composer.lock

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,9 @@ jobs:
     strategy:
       matrix:
         php:
+          - "7.2"
           - "7.3"
+          - "7.4"
 
     env:
       MYSQL_USER: "eventum"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -40,8 +40,21 @@ jobs:
           php-version: ${{ matrix.php }}
           extensions: pdo, pdo_mysql, gd, ldap
 
+      - name: Validate composer.json and composer.lock
+        run: composer validate
+
+      - name: Cache Composer packages
+        id: composer-cache
+        uses: actions/cache@v2
+        with:
+          path: vendor
+          key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-
+
       - name: Install dependencies
-        run: composer install
+        if: steps.composer-cache.outputs.cache-hit != 'true'
+        run: composer install --prefer-dist --no-progress --no-suggest
 
       - name: Seed database
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
-          extensions: pdo, pdo_mysql
+          extensions: pdo, pdo_mysql, gd, ldap
 
       - name: Install dependencies
         run: composer install

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,63 @@
+name: "Tests"
+
+on:
+  - pull_request
+
+jobs:
+  test:
+    name: PHP ${{ matrix.php }}
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        php:
+          - "7.3"
+
+    env:
+      MYSQL_USER: "eventum"
+      MYSQL_PASSWORD: "password"
+      MYSQL_DATABASE: "eventum"
+      MYSQL_HOST: "127.0.0.1"
+
+    services:
+      mysql:
+        image: percona/percona-server:5.7
+        ports:
+          - 3306:3306
+        env:
+          MYSQL_USER: "eventum"
+          MYSQL_PASSWORD: "password"
+          MYSQL_DATABASE: "eventum"
+          MYSQL_ALLOW_EMPTY_PASSWORD: "1"
+        options: --health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=2s --health-retries=3
+
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+
+      - name: Setup PHP ${{ matrix.php }}
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: pdo, pdo_mysql
+
+      - name: Install dependencies
+        run: composer install
+
+      - name: Seed database
+        run: |
+          cp -p tests/travis/*.php config
+          vendor/bin/phinx migrate -e test
+          cat config/setup.php
+          vendor/bin/phinx seed:run -e test
+
+      - name: Run PHPUnit tests
+        run: composer test
+        env:
+          # comma separated @group names to exclude
+          PHPUNIT_EXCLUDE_GROUP: "ldap,imap,logger,mail,api,locale,date,crypto,flaky"
+
+      - name: MySQL Service logs
+        run: docker logs ${{ job.services.mysql.id }}
+        if: always()
+
+# vim:ft=yaml:et:ts=2:sw=2

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
           tools: composer:v1
-          extensions: pdo, pdo_mysql, gd, ldap
+          extensions: pdo, pdo_mysql, gd, ldap, tidy
 
       - name: Validate composer.json and composer.lock
         run: composer validate

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,9 @@ git:
 services:
   - mysql
 
+env:
+  - PHPUNIT_EXCLUDE_GROUP=ldap,imap,logger,mail,api,locale,date,crypto
+
 # https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against
 jobs:
   allow_failures:
@@ -71,7 +74,7 @@ install:
 
 script:
   - PATH=vendor/bin:$HOME/.composer/vendor/bin:$PATH
-  - simple-phpunit --verbose --exclude-group ldap,imap,logger,mail,api,locale,date,crypto
+  - composer test
 
 notifications:
   irc:

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
   - mysql
 
 env:
-  - PHPUNIT_EXCLUDE_GROUP=ldap,imap,logger,mail,api,locale,date,crypto
+  - PHPUNIT_EXCLUDE_GROUP=ldap,imap,logger,mail,api,locale,date,crypto,flaky
 
 # https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,16 +14,8 @@ env:
 
 # https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against
 jobs:
-  allow_failures:
-    - php: "7.4"
-    - php: "nightly"
   # NOTE: when adding/removing jobs, update bin/releng/snapshot.sh travis_log job_id
   include:
-    - php: "7.2"
-    - php: "7.3"
-    - php: "7.4"
-    - php: "nightly"
-
     # TODO: would be nice to have two separate stages, one for build, and other for actually publishing
     - stage: release
       name: GitHub Release

--- a/composer.json
+++ b/composer.json
@@ -159,7 +159,7 @@
             "yarn",
             "yarn run assets:development"
         ],
-        "test": "simple-phpunit"
+        "test": "simple-phpunit --exclude-group=$PHPUNIT_EXCLUDE_GROUP"
     },
     "extra": {
         "config-dir": "res",

--- a/phinx.php
+++ b/phinx.php
@@ -81,7 +81,7 @@ $phinx = [
 
 // create "test" environment
 $phinx['environments']['test'] = $phinx['environments']['production'];
-$phinx['environments']['test']['name'] = 'e_test';
+$phinx['environments']['test']['name'] = getenv('MYSQL_DATABASE') ?: 'e_test';
 
 $event = new GenericEvent(null, $phinx);
 EventManager::dispatch(SystemEvents::PHINX_CONFIG, $event);

--- a/tests/Generic/MarkdownTest.php
+++ b/tests/Generic/MarkdownTest.php
@@ -34,6 +34,7 @@ class MarkdownTest extends TestCase
 
     /**
      * @dataProvider dataProvider
+     * @group flaky
      */
     public function testMarkdown(string $input, string $expected): void
     {

--- a/tests/Generic/MarkdownTest.php
+++ b/tests/Generic/MarkdownTest.php
@@ -39,14 +39,6 @@ class MarkdownTest extends TestCase
     public function testMarkdown(string $input, string $expected): void
     {
         $rendered = $this->renderer->render($input);
-
-        // XXX: strip newlines, somewhy tests on travis produce different newline placements
-        // https://travis-ci.org/glensc/eventum/jobs/521628232
-        if (getenv('TRAVIS')) {
-            $expected = str_replace("\n", '', $expected);
-            $rendered = str_replace("\n", '', $rendered);
-        }
-
         $this->assertEquals($expected, $rendered);
     }
 

--- a/tests/travis/setup.php
+++ b/tests/travis/setup.php
@@ -14,11 +14,11 @@
 return [
     'database' => [
         'driver' => 'mysql',
-        'hostname' => 'localhost',
-        'database' => 'e_test',
-        'username' => 'root',
-        'password' => '',
+        'hostname' => getenv('MYSQL_HOST') ?: 'localhost',
+        'database' => getenv('MYSQL_DATABASE') ?: 'e_test',
+        'username' => getenv('MYSQL_USER') ?: 'root',
+        'password' => getenv('MYSQL_PASSWORD') ?: '',
+        'port' => getenv('MYSQL_PORT') ?: 3306,
         'charset' => 'utf8',
-        'port' => 3306,
     ],
 ];


### PR DESCRIPTION
Travis integration has become totally unbearable recently:
- jobs wait queue is very long, some hours or even days
- status updates are no longer updated in PRs
- inconsistent and old composer versions, making it very difficult to have a consistent environment for different PHP versions. for example, unwanted upgrade to v2 and force to use v1 requires hack as `--1` flag not supported on composer 1.8

🙇 Thank you Travis-CI for being out there for that long, but it is time to switch...

This migrates CI jobs for pull requests to GitHub Actions, the release step is still run in Travis CI.

Inspired by my previous work:
- https://github.com/perftools/xhgui/pull/366

refs:
- https://github.com/actions/toolkit/blob/main/docs/commands.md#environment-files

