### PR TITLE
Use underscore_number_aware naming_strategy for Doctrine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Use `underscore_number_aware` naming_strategy for Doctrine, #965
+
 [3.9.9]: https://github.com/eventum/eventum/compare/v3.9.8...master
 
 ## [3.9.8] - 2020-11-30

--- a/res/packages/doctrine.yml
+++ b/res/packages/doctrine.yml
@@ -23,7 +23,7 @@ doctrine:
 
   orm:
     auto_generate_proxy_classes: true
-    naming_strategy: doctrine.orm.naming_strategy.underscore
+    naming_strategy: doctrine.orm.naming_strategy.underscore_number_aware
     auto_mapping: true
     mappings:
       Eventum\Model:


### PR DESCRIPTION
User Deprecated: Creating Doctrine\ORM\Mapping\UnderscoreNamingStrategy
without making it number aware is deprecated and will be removed in
Doctrine ORM 3.0.

Creating Doctrine\ORM\Mapping\UnderscoreNamingStrategy without making it
number aware is deprecated and will be removed in Doctrine ORM 3.0.

- https://stackoverflow.com/questions/58975182/deprecation-doctrine-orm-mapping-underscorenamingstrategy-without-making-it-num
- https://github.com/doctrine/orm/blob/2.8.x/UPGRADE.md#deprecated-number-unaware-doctrineormmappingunderscorenamingstrategy
- https://github.com/symfony/recipes/blob/af59c6fed6ae2d8929f9ac3a1b9d280a3ebfbfbc/doctrine/doctrine-bundle/2.0/config/packages/doctrine.yaml