### PR TITLE
Avoid calling imap methods on null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 See [Upgrading] for details on how to upgrade.
 
 - Switch to symfony/lock implementation, #815
+- Avoid calling imap methods on null, #968
 
 [3.9.8]: https://github.com/eventum/eventum/compare/v3.9.7...master
 

--- a/src/Mail/Imap/ImapConnection.php
+++ b/src/Mail/Imap/ImapConnection.php
@@ -43,7 +43,13 @@ class ImapConnection
 
     public function __destruct()
     {
-        $this->closeConnection();
+        if ($this->connection) {
+            imap_expunge($this->connection);
+            imap_close($this->connection);
+            unset($this->connection);
+        }
+
+        imap_errors();
     }
 
     public function isConnected(): bool
@@ -167,32 +173,5 @@ class ImapConnection
         }
 
         return '{' . $uri . '}' . $folder;
-    }
-
-    private function closeConnection(): void
-    {
-        $this->closeEmailServer();
-        $this->clearErrors();
-    }
-
-    /**
-     * Method used to close the existing connection to the email
-     * server.
-     */
-    private function closeEmailServer(): void
-    {
-        if ($this->connection) {
-            imap_expunge($this->connection);
-            imap_close($this->connection);
-            unset($this->connection);
-        }
-    }
-
-    /**
-     * Method used to clear the error stack as required by the IMAP PHP extension.
-     */
-    private function clearErrors(): void
-    {
-        imap_errors();
     }
 }

--- a/src/Mail/Imap/ImapConnection.php
+++ b/src/Mail/Imap/ImapConnection.php
@@ -181,9 +181,11 @@ class ImapConnection
      */
     private function closeEmailServer(): void
     {
-        imap_expunge($this->connection);
-        imap_close($this->connection);
-        unset($this->connection);
+        if ($this->connection) {
+            imap_expunge($this->connection);
+            imap_close($this->connection);
+            unset($this->connection);
+        }
     }
 
     /**


### PR DESCRIPTION
Fixes notices like E_WARNING: imap_expunge() expects parameter 1 to be resource, null given.