### PR TITLE
Wrap large code blocks in note and email view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Upgrading] for details on how to upgrade.
 
 - Switch to symfony/lock implementation, #815
 - Avoid calling imap methods on null, #968
+- Wrap large code blocks in note and email view, #969
 
 [3.9.8]: https://github.com/eventum/eventum/compare/v3.9.7...master
 

--- a/res/assets/sass/page.scss
+++ b/res/assets/sass/page.scss
@@ -551,6 +551,10 @@ option.select_icon_priority {
     }
 }
 
+td#email_message code {
+    white-space: break-spaces;
+}
+
 /* Font Awesome override */
 .expandable_buttons .fa {
     font-size: 1.1em;


### PR DESCRIPTION
If email/note is added long `<code>` block, it will mess up whole layout.

cc @slay123 