### PR TITLE
Add Request context to LinkFilter callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details on how to upgrade.
 - Switch to symfony/lock implementation, #815
 - Avoid calling imap methods on null, #968
 - Wrap large code blocks in note and email view, #969
+- Add Request context to LinkFilter callbacks, #970
 
 [3.9.8]: https://github.com/eventum/eventum/compare/v3.9.7...master
 

--- a/lib/eventum/class.link_filter.php
+++ b/lib/eventum/class.link_filter.php
@@ -345,7 +345,7 @@ class Link_Filter
         static $cache;
 
         $initialize = static function (?int $prj_id) {
-            $linkFilter = new LinkFilter();
+            $linkFilter = new LinkFilter(ServiceContainer::getRequest());
             $linkFilter->addFilter(new IssueLinkFilter(Setup::getBaseUrl()));
 
             if ($prj_id) {

--- a/res/assets/scripts/Eventum.js
+++ b/res/assets/scripts/Eventum.js
@@ -380,12 +380,12 @@ export class Eventum {
         }
     }
 
-    showPreview(input_id, preview_id) {
+    showPreview(input_id, preview_id, params) {
         const $input = $(input_id);
         $input.hide();
 
         const $preview = $(preview_id);
-        $preview.load(this.rel_url + 'get_remote_data.php?action=preview', { source: $input.val() }, function () {
+        $preview.load(this.rel_url + 'get_remote_data.php?action=preview', { ...params, source: $input.val() }, function () {
             $(document).trigger("md_preview.eventum", [$preview, preview_id]);
         });
         $preview.show();

--- a/src/Controller/BaseController.php
+++ b/src/Controller/BaseController.php
@@ -15,6 +15,7 @@ namespace Eventum\Controller;
 
 use Auth;
 use Enrise\Uri;
+use Eventum\ServiceContainer;
 use InvalidArgumentException;
 use ReflectionClass;
 use Symfony\Component\HttpFoundation\Request;
@@ -105,7 +106,7 @@ abstract class BaseController
     {
         static $request;
         if (!$request) {
-            $request = Request::createFromGlobals();
+            $request = ServiceContainer::getRequest();
         }
 
         return $request;

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -106,7 +106,7 @@ class Kernel extends BaseKernel implements CompilerPassInterface
         }
 
         $kernel = ServiceContainer::getKernel();
-        $request = Request::createFromGlobals();
+        $request = ServiceContainer::getRequest();
         $response = $kernel->handle($request);
         $response->send();
         $kernel->terminate($request, $response);

--- a/src/LinkFilter/LinkFilter.php
+++ b/src/LinkFilter/LinkFilter.php
@@ -14,15 +14,19 @@
 namespace Eventum\LinkFilter;
 
 use Ds\Set;
+use Symfony\Component\HttpFoundation\Request;
 
 class LinkFilter
 {
     /** @var Set */
     private $rules;
+    /** @var Request */
+    private $request;
 
-    public function __construct()
+    public function __construct(Request $request)
     {
         $this->rules = new Set();
+        $this->request = $request;
     }
 
     public function addFilter(LinkFilterInterface $handler): self
@@ -56,7 +60,9 @@ class LinkFilter
         foreach ($this->rules as $rule) {
             [$pattern, $handler] = $rule;
             if (is_callable($handler)) {
-                $text = preg_replace_callback($pattern, $handler, $text);
+                $text = (string)preg_replace_callback($pattern, function ($text) use ($handler) {
+                    return $handler($text, $this->request);
+                }, $text);
             } else {
                 $text = preg_replace($pattern, $handler, $text);
             }

--- a/src/LinkFilter/LinkFilterInterface.php
+++ b/src/LinkFilter/LinkFilterInterface.php
@@ -13,6 +13,8 @@
 
 namespace Eventum\LinkFilter;
 
+use Symfony\Component\HttpFoundation\Request;
+
 interface LinkFilterInterface
 {
     public function getPatterns(): array;
@@ -22,7 +24,10 @@ interface LinkFilterInterface
      * text and creates links to other issues.
      *
      * @param   array $matches Regular expression matches
+     * @param Request $request
      * @return  string The link to the appropriate issue
+     * @since 3.9.8 Adds $request parameter
+     * @since 3.10.0 The $request parameter will be mandatory
      */
-    public function __invoke(array $matches): string;
+    public function __invoke(array $matches/*, Request $request*/): string;
 }

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -20,6 +20,7 @@ use Pimple\Psr11\Container as PsrContainer;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ServiceContainer
@@ -63,6 +64,14 @@ class ServiceContainer
     public static function getLogger(): LoggerInterface
     {
         return static::get(LoggerInterface::class);
+    }
+
+    /**
+     * @since 3.9.8
+     */
+    public static function getRequest(): Request
+    {
+        return static::get(Request::class);
     }
 
     public static function getKernel(): KernelInterface

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -29,6 +29,7 @@ use Setup;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
 
 class ServiceProvider implements ServiceProviderInterface
@@ -63,6 +64,10 @@ class ServiceProvider implements ServiceProviderInterface
 
         $app[KernelInterface::class] = static function () {
             return new Kernel($_SERVER['APP_ENV'], (bool)$_SERVER['APP_DEBUG']);
+        };
+
+        $app[Request::class] = static function () {
+            return Request::createFromGlobals();
         };
 
         $app[Application::class] = static function ($app) {

--- a/templates/add_phone_entry.tpl.html
+++ b/templates/add_phone_entry.tpl.html
@@ -140,7 +140,7 @@ $().ready(function() {
                 <th width="190" nowrap>{t}Description{/t}</th>
                 <td>
                   <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}</a>
-                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}</a>
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview', { issue_id: {$issue_id|intval} })">{t}[Preview]{/t}</a>
                   <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                   <textarea id="description" name="description" rows="8" style="width: 97%"></textarea>
                   {include file="error_icon.tpl.html" field="description"}

--- a/templates/bulk_update.tpl.html
+++ b/templates/bulk_update.tpl.html
@@ -83,7 +83,7 @@
               <div id="close_message_popup" style="display: none">
                   <label for="closed_message">{t}Closed Message{/t}</label><br />
                   <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#closed_message_popup', '#preview')">{t}[Write]{/t}</a>
-                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#closed_message_popup', '#preview')">{t}[Preview]{/t}</a>
+                  <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#closed_message_popup', '#preview', { issue_id: {$issue_id|intval} })">{t}[Preview]{/t}</a>
                   <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                   <textarea id="closed_message_popup" name="closed_message_popup" rows="8" cols="80">Issue Bulk closed</textarea>
                   <div id="preview"></div>

--- a/templates/include/new_form.tpl.html
+++ b/templates/include/new_form.tpl.html
@@ -186,7 +186,7 @@
       </th>
       <td>
         <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}<a>
-        <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}<a>
+        <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview', { issue_id: {$issue_id|intval} })">{t}[Preview]{/t}<a>
         <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
         {if $new_issue_id != ''}
             {assign var='issue_description' value=''}

--- a/templates/post_note.tpl.html
+++ b/templates/post_note.tpl.html
@@ -131,7 +131,7 @@
         <tr>
             <td colspan="2">
                 <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#note', '#preview')">{t}[Write]{/t}</a>
-                <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#note', '#preview')">{t}[Preview]{/t}</a>
+                <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#note', '#preview', { issue_id: {$issue_id|intval} })">{t}[Preview]{/t}</a>
                 <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                 <textarea id="note" name="note" rows="16" style="width: 97%">{$note.not_body|default:""|escape:"html"}{if $core.current_user_prefs.auto_append_note_sig}
 

--- a/templates/update_form.tpl.html
+++ b/templates/update_form.tpl.html
@@ -226,7 +226,7 @@
                     </span>
                     {else}
                     <a class="white_link" href="javascript:void(null);" onClick="Eventum.hidePreview('#description', '#preview')">{t}[Write]{/t}</a>
-                    <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview')">{t}[Preview]{/t}</a>
+                    <a class="white_link" href="javascript:void(null);" onClick="Eventum.showPreview('#description', '#preview', { issue_id: {$issue_id|intval} })">{t}[Preview]{/t}</a>
                     <a class="white_link" href="https://commonmark.org/help/" target="_blank">{t}[Markdown Help]{/t}</a>
                     <textarea id="description" name="description" rows="20" style="width: 97%">{$issue.iss_original_description|escape:"html"}</textarea>
                     <div id="preview" style="width: 97%"></div>


### PR DESCRIPTION
This allows LinkFilters that rendered view in `view.php` relying on `issue_id` POST value now be able to render same in preview mode.