### PR TITLE
Allow timeago to have future timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Upgrading] for details on how to upgrade.
 - Avoid calling imap methods on null, #968
 - Wrap large code blocks in note and email view, #969
 - Add Request context to LinkFilter callbacks, #970
+- Allow timeago to have future timestamps, #971
 
 [3.9.8]: https://github.com/eventum/eventum/compare/v3.9.7...master
 

--- a/res/assets/scripts/app.js
+++ b/res/assets/scripts/app.js
@@ -104,6 +104,8 @@ $(document).ready(function () {
     mermaid.initialize({startOnLoad:true});
 
     // jquery timeago
+    jQuery.timeago.settings.allowFuture = true;
+
     const $timeago = $("time.timeago");
     // on click toggle between views
     const timeago_toggle = function () {


### PR DESCRIPTION
To support timestamps in the future, use the `allowFuture` setting:
```js
jQuery.timeago.settings.allowFuture = true;
```