### PR TITLE
Time tracking - Eventum still says "Please select a valid date of work"

### DIFF
--- a/res/assets/scripts/Validation.js
+++ b/res/assets/scripts/Validation.js
@@ -152,7 +152,7 @@ export class Validation {
         selected_date.setDate(Eventum.getField(field_prefix + '[Day]').val());
         selected_date.setYear(Eventum.getField(field_prefix + '[Year]').val());
 
-        return selected_date.getDate() === Eventum.getField(field_prefix + '[Day]').val();
+        return selected_date.getDate() === Number(Eventum.getField(field_prefix + '[Day]').val());
     };
 
     checkFormSubmission(form, callback_func) {


### PR DESCRIPTION
#963 
- https://github.com/eventum/eventum/blob/master/res/assets/scripts/Validation.js#L146-L156
```js
    isValidDate(field_prefix) {
        const selected_date = new Date();

        selected_date.setMonth(Eventum.getField(field_prefix + '[Month]').val() - 1);
        selected_date.setDate(Eventum.getField(field_prefix + '[Day]').val());
        selected_date.setYear(Eventum.getField(field_prefix + '[Year]').val());

        return selected_date.getDate() === Eventum.getField(field_prefix + '[Day]').val();
    };
```
typeof(selected_date.getDate() ) is number
typeof(Eventum.getField(field_prefix + '[Day]').val()) is string

Function isValidDate is never true in strict comparing. Solution may be retype getField().val() to number and rebuild app.js, I think.