### PR TITLE
Add emoji parsing to markdown areas

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 See [Upgrading] for details on how to upgrade.
 
 - Fix: Remove post note debug, #1009
+- Add emoji parsing to markdown areas, #1008
 
 [3.9.12]: https://github.com/eventum/eventum/compare/v3.9.11...master
 

--- a/composer.json
+++ b/composer.json
@@ -40,6 +40,7 @@
         "enrise/urihelper": "^1.0",
         "ezyang/htmlpurifier": "^4.10",
         "fonts/liberation": "*",
+        "giberti/commonmark-emoji-extension": "^0.2.0",
         "glen/filename-normalizer": "^2.0",
         "horde/text-flowed": "dev-patch-1 as 2.0.3",
         "horde/util": "dev-patch-1 as 2.5.8",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "19ec563d1c719b2fc7f0dbf1a6b267a1",
+    "content-hash": "54909bd2602876793a655c613bdc681e",
     "packages": [
         {
             "name": "cakephp/core",
@@ -1605,6 +1605,66 @@
             "license": [
                 "OFL-1.1"
             ]
+        },
+        {
+            "name": "giberti/commonmark-emoji-extension",
+            "version": "0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giberti/commonmark-emoji-extension.git",
+                "reference": "5be21de92f78227df3c65409b20b530feaf14397"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giberti/commonmark-emoji-extension/zipball/5be21de92f78227df3c65409b20b530feaf14397",
+                "reference": "5be21de92f78227df3c65409b20b530feaf14397",
+                "shasum": ""
+            },
+            "require": {
+                "giberti/emoji-data": "^0.1",
+                "php": "^7.2"
+            },
+            "require-dev": {
+                "league/commonmark": "^1.5",
+                "phpunit/phpunit": "^8.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giberti\\EmojiExtension\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2020-10-27T11:09:10+00:00"
+        },
+        {
+            "name": "giberti/emoji-data",
+            "version": "v0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/giberti/emoji-data.git",
+                "reference": "f07a1d0dee6453d076bbc8ce89c68856d8cabdde"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/giberti/emoji-data/zipball/f07a1d0dee6453d076bbc8ce89c68856d8cabdde",
+                "reference": "f07a1d0dee6453d076bbc8ce89c68856d8cabdde",
+                "shasum": ""
+            },
+            "require-dev": {
+                "nicmart/tree": "^0.3.0",
+                "php": "^7.3",
+                "phpunit/phpunit": "^9.3",
+                "twig/twig": "^3.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Giberti\\EmojiData\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "time": "2020-09-26T21:23:18+00:00"
         },
         {
             "name": "glen/filename-normalizer",

--- a/src/ServiceProvider/MarkdownServiceProvider.php
+++ b/src/ServiceProvider/MarkdownServiceProvider.php
@@ -18,6 +18,7 @@ use Eventum\Event;
 use Eventum\EventDispatcher\EventManager;
 use Eventum\Markdown;
 use Eventum\Markdown\CommonMark\UserMentionGenerator;
+use Giberti\EmojiExtension\EmojiExtension;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
 use League\CommonMark\Block\Element\FencedCode;
@@ -126,6 +127,7 @@ class MarkdownServiceProvider implements ServiceProviderInterface
         $environment->addExtension(new AttributesExtension());
         $environment->addExtension(new FootnoteExtension());
         $environment->addExtension(new MentionExtension());
+        $environment->addExtension(new EmojiExtension());
 
         // allow extensions to apply behaviour
         $event = new GenericEvent($environment);

--- a/symfony.lock
+++ b/symfony.lock
@@ -95,6 +95,12 @@
     "fonts/liberation": {
         "version": "2.00.1"
     },
+    "giberti/commonmark-emoji-extension": {
+        "version": "0.2"
+    },
+    "giberti/emoji-data": {
+        "version": "v0.1"
+    },
     "glen/filename-normalizer": {
         "version": "2.0.1"
     },


### PR DESCRIPTION
Uses https://github.com/giberti/commonmark-emoji-extension until https://github.com/thephpleague/commonmark/pull/546 is ready.

Did not feel necessary to make this configurable, so this is always enabled.
Can do that later if people request or complain.