### PR TITLE
Fix: Remove post note debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix: Remove post note debug, #1009
+
 [3.9.12]: https://github.com/eventum/eventum/compare/v3.9.11...master
 
 ## [3.9.11] - 2021-03-07

--- a/templates/post_note.tpl.html
+++ b/templates/post_note.tpl.html
@@ -130,9 +130,9 @@
         </tr>
         <tr>
             <td colspan="2">
-              {capture assign=note}{$note.not_body|default:"asd"}{if not $core.current_user_prefs.auto_append_note_sig}[
+              {capture assign=note}{$note.not_body|default:""}{if not $core.current_user_prefs.auto_append_note_sig}
 
-{$core.current_user_prefs.email_signature}]{/if}{/capture}
+{$core.current_user_prefs.email_signature}{/if}{/capture}
 
               {include file="include/md_textarea.tpl.html"
                 content="$note"


### PR DESCRIPTION
Debug slipped in from 96cb66163fa7bd3b8aba084761e7692c226bca41 via #989

The debug resulted weird snippets appearing at the end of notes:

for replies:
```
[

]
```

for new notes:

```
asd[

]
```