### PR TITLE
Cleanup ext-mcrypt, no longer used with defuse/php-encryption 2.x

### DIFF
--- a/bin/releng/configure.sh
+++ b/bin/releng/configure.sh
@@ -15,9 +15,5 @@ composer config platform.ext-gd '0'
 # disable xdebug
 phpenv config-rm xdebug.ini || :
 
-# PHP 7.2 does not have mcrypt
-# Installation request for defuse/php-encryption ~1.2.1 -> satisfiable by defuse/php-encryption[v1.2.1].
-composer config platform.ext-mcrypt '0'
-
 # disable secure-http because sourceforge redirects to http:// urls
 composer config secure-http false


### PR DESCRIPTION
No longer used as of #358 (3.4.0)