### PR TITLE
Update PHP requirement to 7.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,6 @@ jobs:
     strategy:
       matrix:
         php:
-          - "7.2"
           - "7.3"
           - "7.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
       language:
         - node_js
         - php
-      php: "7.2"
+      php: "7.3"
       node_js: "10"
       script:
         - docker --version

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,10 @@
-language: php
+language: minimal
 sudo: required
 dist: xenial
 
 # disable the default submodule logic
 git:
   submodules: false
-
-services:
-  - mysql
-
-env:
-  - PHPUNIT_EXCLUDE_GROUP=ldap,imap,logger,mail,api,locale,date,crypto,flaky
 
 # https://docs.travis-ci.com/user/languages/php/#choosing-php-versions-to-test-against
 jobs:
@@ -19,11 +13,6 @@ jobs:
     # TODO: would be nice to have two separate stages, one for build, and other for actually publishing
     - stage: release
       name: GitHub Release
-      language:
-        - node_js
-        - php
-      php: "7.3"
-      node_js: "10"
       script:
         - docker --version
         - docker build . -f bin/releng/Dockerfile -t releng --target=releng
@@ -57,17 +46,6 @@ cache:
     - $HOME/.composer/vendor
     - cache
     - vendor
-
-before_install:
-  - bin/releng/configure.sh
-
-install:
-  - composer install --no-interaction --prefer-dist --no-suggest
-  - bin/releng/seed.sh
-
-script:
-  - PATH=vendor/bin:$HOME/.composer/vendor/bin:$PATH
-  - composer test
 
 notifications:
   irc:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Update PHP requirement to 7.3, #1012
+
 [3.10.0]: https://github.com/eventum/eventum/compare/v3.9.12...master
 
 ## [3.9.12] - 2021-03-10

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -39,11 +39,12 @@ RUN set -x \
 
 FROM deps AS releng
 WORKDIR /app
-COPY Makefile .
-COPY bin/releng ./bin/releng
-
-RUN bin/releng/tools.sh
+COPY bin/releng/locales.sh ./bin/releng/locales.sh
 RUN bin/releng/locales.sh
+
+COPY Makefile .
+COPY bin/releng/tools.sh ./bin/releng/tools.sh
+RUN bin/releng/tools.sh
 
 # docker build . -f bin/releng/Dockerfile -t app --target=stage-release
 FROM releng AS stage-release

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         }
     ],
     "require": {
-        "php": "^7.2.0 || ^8.0",
+        "php": "^7.3.0 || ^8.0",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",
@@ -128,7 +128,7 @@
     "config": {
         "autoloader-suffix": "EventumCore",
         "platform": {
-            "php": "7.2.5"
+            "php": "7.3.0"
         },
         "sort-packages": true
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "54909bd2602876793a655c613bdc681e",
+    "content-hash": "5d284b63eed447bd4ec44fd59dd9066d",
     "packages": [
         {
             "name": "cakephp/core",
@@ -8457,7 +8457,7 @@
     "prefer-stable": true,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.2.0 || ^8.0",
+        "php": "^7.3.0 || ^8.0",
         "ext-ctype": "*",
         "ext-dom": "*",
         "ext-fileinfo": "*",
@@ -8476,7 +8476,7 @@
     },
     "platform-dev": [],
     "platform-overrides": {
-        "php": "7.2.5"
+        "php": "7.3.0"
     },
     "plugin-api-version": "1.1.0"
 }

--- a/docs/wiki/Prerequisites.md
+++ b/docs/wiki/Prerequisites.md
@@ -3,7 +3,7 @@
 You will need:
 
 -   A Webserver that is capable of handling PHP scripts (i.e [Apache HTTPD Server](https://httpd.apache.org/))
--   [PHP](https://php.net) 7.2.x with the following extensions
+-   [PHP](https://php.net) 7.3.x with the following extensions
     -   ctype
     -   date (builtin)
     -   pcre (builtin)

--- a/docs/wiki/Upgrading.md
+++ b/docs/wiki/Upgrading.md
@@ -26,6 +26,7 @@ shows PHP version required for the update.
 | 3.6.x | 3.7.0 | 7.1 |
 | 3.7.x | 3.8.0 | 7.1 |
 | 3.8.x | 3.9.0 | 7.2 |
+| 3.9.x | 3.10.0 | 7.3 |
 
 ## UTF-8 is required
 

--- a/symfony.lock
+++ b/symfony.lock
@@ -171,7 +171,7 @@
         "version": "1.1.0"
     },
     "php": {
-        "version": "7.2.5"
+        "version": "7.3.0"
     },
     "php-di/invoker": {
         "version": "2.0.0"


### PR DESCRIPTION
Update required php version to 7.3 to be able to update laminas-mail 2.14:
- https://github.com/laminas/laminas-mail/pull/140

Tasks
- [x] Update composer.json/composer.lock with php 7.3
- [x] Update documentation with php 7.3
- [x] Update Travis to use 7.3+ for release tarball generation: https://github.com/eventum/eventum/pull/1014
- [x] Make snapshot release to test release process is okay
- [x] Remove PHP 7.2 from required checks:  https://github.com/eventum/eventum/settings/branch_protection_rules/825256