### PR TITLE
Add Extension to report errors to Slack channel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details on how to upgrade.
 - Add prosemirror rendered markdown for textareas (disabled), #991
 - Use logger from Symfony Framework, #898
 - Add extension support to be able to configure container, #1025
+- Add Extension to report errors to Slack channel, #1024
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -389,6 +389,13 @@ class Setup
                 'status' => 'disabled',
             ],
 
+            // https://github.com/eventum/eventum/pull/1024
+            'slack' => [
+                'status' => 'disabled',
+                'bot_name' => 'Eventum Bot',
+                'icon_emoji' => 'boom',
+            ],
+
             'sentry' => [
                 'status' => 'disabled',
                 // dsn consists of: 'https://<key>@<domain>/<project>'

--- a/src/Controller/Manage/GeneralController.php
+++ b/src/Controller/Manage/GeneralController.php
@@ -93,6 +93,7 @@ class GeneralController extends ManageBaseController
         $register->enable(Extension\AuditTrailExtension::class, $setup['audit_trail'] === 'enabled');
         $register->enable(Extension\IrcNotifyExtension::class, $setup['irc_notification'] === 'enabled');
         $register->enable(Extension\SentryExtension::class, $setup['sentry']['status'] === 'enabled');
+        $register->enable(Extension\SlackExtension::class, $setup['slack']['status'] === 'enabled');
         $register->enable(Extension\XhguiProfilerExtension::class, $setup['xhgui']['status'] === 'enabled');
 
         $this->tpl->assign('result', $res);

--- a/src/Controller/Manage/GeneralController.php
+++ b/src/Controller/Manage/GeneralController.php
@@ -83,6 +83,7 @@ class GeneralController extends ManageBaseController
             'markdown' => $post->get('markdown'),
             'audit_trail' => $post->get('audit_trail'),
             'sentry' => $post->get('sentry'),
+            'slack' => $post->get('slack'),
             'xhgui' => $post->get('xhgui'),
         ];
         $res = Setup::save($setup);

--- a/src/Extension/SlackExtension.php
+++ b/src/Extension/SlackExtension.php
@@ -1,0 +1,77 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Extension;
+
+use Eventum\Config\Config;
+use Eventum\Event\ConfigUpdateEvent;
+use Eventum\Event\SystemEvents;
+use Eventum\Extension\Provider\SubscriberProvider;
+use Eventum\Logger\LoggerTrait;
+use Eventum\ServiceContainer;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+class SlackExtension implements SubscriberProvider, EventSubscriberInterface
+{
+    use LoggerTrait;
+
+    /** @var Config */
+    private $config;
+
+    public function __construct()
+    {
+        $this->config = ServiceContainer::getConfig()['slack'];
+    }
+
+    public function getSubscribers(): array
+    {
+        return [
+            self::class,
+        ];
+    }
+
+    public static function getSubscribedEvents(): array
+    {
+        return [
+            /** @see configUpgrade */
+            SystemEvents::CONFIG_CRYPTO_UPGRADE => 'configUpgrade',
+            /** @see configDowngrade */
+            SystemEvents::CONFIG_CRYPTO_DOWNGRADE => 'configDowngrade',
+            /** @see configSave */
+            SystemEvents::CONFIG_SAVE => 'configSave',
+        ];
+    }
+
+    public function configUpgrade(ConfigUpdateEvent $event): void
+    {
+        $config = $event->getConfig();
+
+        $event->encrypt($config['slack']['webhook_url']);
+    }
+
+    public function configDowngrade(ConfigUpdateEvent $event): void
+    {
+        $config = $event->getConfig();
+
+        $event->decrypt($config['slack']['webhook_url']);
+    }
+
+    public function configSave(ConfigUpdateEvent $event): void
+    {
+        if ($event->hasEncryption()) {
+            $this->configUpgrade($event);
+        } else {
+            $this->configDowngrade($event);
+        }
+    }
+}

--- a/templates/manage/general.tpl.html
+++ b/templates/manage/general.tpl.html
@@ -167,6 +167,21 @@
       Eventum.getField('sentry[domain]').attr('disabled', bool).css('backgroundColor', bgcolor);
   }
 
+  function toggleSlackFields()
+  {
+      var bgcolor;
+      var bool = !Eventum.getField('slack[status]').first().is(':checked');
+      if (bool) {
+          bgcolor = '#CCCCCC';
+      } else {
+          bgcolor = "#FFFFFF";
+      }
+      Eventum.getField('slack[webhook_url]').attr('disabled', bool).css('backgroundColor', bgcolor);
+      Eventum.getField('slack[channel]').attr('disabled', bool).css('backgroundColor', bgcolor);
+      Eventum.getField('slack[bot_name]').attr('disabled', bool).css('backgroundColor', bgcolor);
+      Eventum.getField('slack[icon_emoji]').attr('disabled', bool).css('backgroundColor', bgcolor);
+  }
+
   function toggleXHGuiFields()
   {
       var bool = !Eventum.getField('xhgui[status]').first().is(':checked');
@@ -233,6 +248,7 @@ $().ready(function() {
     Eventum.getField('email_error[status]').change(toggleErrorEmailFields);
     Eventum.getField('smtp[save_outgoing_email]').change(checkDebugField);
     Eventum.getField('sentry[status]').change(toggleSentryFields);
+    Eventum.getField('slack[status]').change(toggleSlackFields);
     Eventum.getField('xhgui[status]').change(toggleXHGuiFields);
 
     toggleAuthFields();
@@ -245,6 +261,7 @@ $().ready(function() {
     toggleReminderEmailFields();
     toggleErrorEmailFields();
     toggleSentryFields();
+    toggleSlackFields();
     toggleXHGuiFields();
 });
   //-->
@@ -773,6 +790,7 @@ $().ready(function() {
           </tr>
 
           {include file="manage/general/sentry.tpl.html"}
+          {include file="manage/general/slack.tpl.html"}
           {include file="manage/general/xhgui.tpl.html"}
 
           <tr>

--- a/templates/manage/general/slack.tpl.html
+++ b/templates/manage/general/slack.tpl.html
@@ -1,0 +1,61 @@
+<tr>
+  <th width="120">
+    {t}Slack Reporting{/t}
+  </th>
+  <td>
+    <table>
+      <tr>
+        <td colspan="2">
+          <label>
+            <input type="radio" name="slack[status]" value="enabled" {if $setup.slack.status == 'enabled'}checked{/if}>
+            {t}Enabled{/t}
+          </label>
+          <label>
+            <input type="radio" name="slack[status]" value="disabled" {if $setup.slack.status != 'enabled'}checked{/if}>
+            {t}Disabled{/t}
+          </label>
+        </td>
+      </tr>
+
+      <tr>
+        <td width="10%" align="right" nowrap>
+          {t}Slack Webhook URL{/t}
+        </td>
+        <td width="90%">
+          <input type="text" name="slack[webhook_url]" value="{$setup.slack.webhook_url}" size="40">
+          <span>
+            {t 1="https://hooks.slack.com/services/xxx/xxx/xxx"}e.g. %1{/t}
+          </span>
+        </td>
+      </tr>
+      <tr>
+        <td width="10%" align="right" nowrap>
+          {t}Slack channel (encoded ID or name){/t}
+        </td>
+        <td width="90%">
+          <input type="text" name="slack[channel]" value="{$setup.slack.channel}" size="40">
+          <span>{t 1="#general"}e.g. %1{/t}</span>
+        </td>
+      </tr>
+      <tr>
+        <td width="10%" align="right" nowrap>
+          {t}Name of a bot{/t}
+        </td>
+        <td width="90%">
+          <input type="text" name="slack[bot_name]" value="{$setup.slack.bot_name}" size="40">
+          <span>{t 1="Eventum Bot"}e.g. %1. Leave empty to use webhook default username{/t}</span>
+        </td>
+      </tr>
+      <tr>
+        <td width="10%" align="right" nowrap>
+          {t}Icon moji{/t}
+        </td>
+        <td width="90%">
+          <input type="text" name="slack[icon_emoji]" value="{$setup.slack.icon_emoji}" size="40">
+          <span>{t 1="boom"}e.g. %1. Leave empty to use webhook default icon{/t}</span>
+        </td>
+      </tr>
+
+    </table>
+  </td>
+</tr>


### PR DESCRIPTION
Can be enabled in Settings -> General:

![image](https://user-images.githubusercontent.com/199095/112430580-04f08c80-8d47-11eb-98fc-bc7021f08bb5.png)


Requires:
- https://github.com/eventum/eventum/pull/898
- https://github.com/eventum/eventum/pull/1025