### PR TITLE
Refactor ExtensionManager to take extensions list from constructor

### DIFF
--- a/init.php
+++ b/init.php
@@ -12,7 +12,6 @@
  */
 
 use Eventum\Event\SystemEvents;
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 
 require_once __DIR__ . '/autoload.php';
@@ -49,5 +48,5 @@ if (Setup::isMaintenance()) {
 }
 
 Eventum\DebugBarManager::getDebugBarManager();
-ServiceContainer::get(ExtensionManager::class);
+ServiceContainer::getExtensionManager();
 Eventum\EventDispatcher\EventManager::dispatch(SystemEvents::BOOT);

--- a/init.php
+++ b/init.php
@@ -48,5 +48,5 @@ if (Setup::isMaintenance()) {
 }
 
 Eventum\DebugBarManager::getDebugBarManager();
-ServiceContainer::getExtensionManager();
+ServiceContainer::getExtensionManager()->boot();
 Eventum\EventDispatcher\EventManager::dispatch(SystemEvents::BOOT);

--- a/res/services.php
+++ b/res/services.php
@@ -13,14 +13,12 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 
 /**
  * https://symfony.com/doc/4.4/components/dependency_injection.html
  */
 return static function (ContainerConfigurator $configurator) {
-    /** @var ExtensionManager $em */
-    $em = ServiceContainer::get(ExtensionManager::class);
+    $em = ServiceContainer::getExtensionManager();
     $em->containerConfigurator($configurator);
 };

--- a/src/Auth/Adapter/Factory.php
+++ b/src/Auth/Adapter/Factory.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Auth\Adapter;
 
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 use ReflectionClass;
 
@@ -56,8 +55,7 @@ abstract class Factory
             ],
         ];
 
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         foreach ($em->getAvailableAuthAdapters() as $className => $options) {
             if (is_numeric($className)) {
                 $className = $options;

--- a/src/Controller/Manage/CustomFieldsController.php
+++ b/src/Controller/Manage/CustomFieldsController.php
@@ -17,7 +17,6 @@ use Auth;
 use CRM;
 use Custom_Field;
 use Eventum\Db\Doctrine;
-use Eventum\Extension\ExtensionManager;
 use Eventum\Model\Entity\CustomField;
 use Eventum\Model\Repository\CustomFieldRepository;
 use Eventum\ServiceContainer;
@@ -208,8 +207,7 @@ class CustomFieldsController extends ManageBaseController
     private function getBackends(): array
     {
         // load classes from extension manager
-        /** @var ExtensionManager $manager */
-        $manager = ServiceContainer::get(ExtensionManager::class);
+        $manager = ServiceContainer::getExtensionManager();
         $backends = $manager->getCustomFieldClasses();
 
         return $this->filterValues($backends);

--- a/src/Controller/Manage/PartnersController.php
+++ b/src/Controller/Manage/PartnersController.php
@@ -15,7 +15,6 @@ namespace Eventum\Controller\Manage;
 
 use Eventum\Db\DatabaseException;
 use Eventum\Db\Doctrine;
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 use Partner;
 use Project;
@@ -111,8 +110,7 @@ class PartnersController extends ManageBaseController
     private function getPartnersList(): array
     {
         $partners = [];
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $backends = $em->getPartnerClasses();
         foreach ($backends as $par_code => $backend) {
             $partners[] = [

--- a/src/Controller/Manage/ProjectsController.php
+++ b/src/Controller/Manage/ProjectsController.php
@@ -18,7 +18,6 @@ use DateTime;
 use Display_Column;
 use Eventum\Db\DatabaseException;
 use Eventum\Db\Doctrine;
-use Eventum\Extension\ExtensionManager;
 use Eventum\Extension\Legacy\WorkflowLegacyExtension;
 use Eventum\Extension\RegisterExtension;
 use Eventum\Model\Entity;
@@ -194,8 +193,7 @@ class ProjectsController extends ManageBaseController
     private function getWorkflowBackends(): array
     {
         // load classes from extension manager
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $backends = $em->getWorkflowClasses();
 
         return $this->filterValues($backends);
@@ -204,8 +202,7 @@ class ProjectsController extends ManageBaseController
     private function getCustomerBackends(): array
     {
         // load classes from extension manager
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $backends = $em->getCustomerClasses();
 
         return $this->filterValues($backends);

--- a/src/Controller/Manage/UsersController.php
+++ b/src/Controller/Manage/UsersController.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Controller\Manage;
 
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 use Exception;
 use Group;
@@ -272,8 +271,7 @@ class UsersController extends ManageBaseController
     private function getPartnersList(): array
     {
         $partners = [];
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $backends = $em->getPartnerClasses();
         foreach ($backends as $par_code => $backend) {
             $partners[$par_code] = $backend->getName();

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -14,7 +14,6 @@
 namespace Eventum\EventDispatcher;
 
 use Eventum\Event\Subscriber;
-use Eventum\Extension\ExtensionManager;
 use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
@@ -32,8 +31,7 @@ class EventManager
             $dispatcher = new EventDispatcher();
 
             // register subscribers from extensions
-            /** @var ExtensionManager $em */
-            $em = ServiceContainer::get(ExtensionManager::class);
+            $em = ServiceContainer::getExtensionManager();
             $subscribers = $em->getSubscribers();
             foreach ($subscribers as $subscriber) {
                 $dispatcher->addSubscriber($subscriber);

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -48,8 +48,7 @@ final class ExtensionManager implements
     {
         static $manager;
         if (!$manager) {
-            $manager = new self();
-            $manager->boot();
+            $manager = ServiceContainer::get(ExtensionManager::class);
         }
 
         return $manager;

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -43,13 +43,13 @@ final class ExtensionManager implements
      * Singleton Extension Manager
      *
      * @return ExtensionManager
-     * @deprecated since 3.8.11, use ServiceContainer::get(ExtensionManager::class) instead
+     * @deprecated since 3.8.11, use ServiceContainer::getExtensionManager() instead
      */
     public static function getManager(): self
     {
         static $manager;
         if (!$manager) {
-            $manager = ServiceContainer::get(ExtensionManager::class);
+            $manager = ServiceContainer::getExtensionManager();
         }
 
         return $manager;

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -38,6 +38,8 @@ final class ExtensionManager implements
     private $extensions;
     /** @var array */
     private $extensionFiles;
+    /** @var bool */
+    private $booted = false;
 
     /**
      * Singleton Extension Manager
@@ -65,6 +67,10 @@ final class ExtensionManager implements
 
     public function boot(): void
     {
+        if ($this->booted) {
+            return;
+        }
+
         $loader = $this->getAutoloader();
         $container = ServiceContainer::getInstance();
 
@@ -78,6 +84,7 @@ final class ExtensionManager implements
                 $extension->register($container);
             }
         }
+        $this->booted = true;
     }
 
     /**
@@ -185,7 +192,7 @@ final class ExtensionManager implements
 
     private function filterExtensions(callable $filter): Generator
     {
-        foreach ($this->extensions as $extension) {
+        foreach ($this->extensions ?? [] as $extension) {
             if (!$filter($extension)) {
                 continue;
             }
@@ -254,7 +261,7 @@ final class ExtensionManager implements
     }
 
     /**
-     * Create all extensions, initialize autoloader on them.
+     * Load all extensions. This does not initialize them.
      *
      * @return Provider\ExtensionProvider[]
      */

--- a/src/Extension/Legacy/WorkflowLegacyExtension.php
+++ b/src/Extension/Legacy/WorkflowLegacyExtension.php
@@ -28,6 +28,7 @@ use Eventum\Mail\MailMessage;
 use Eventum\Model\Repository\ProjectRepository;
 use InvalidArgumentException;
 use Laminas\Mail\Address;
+use LazyProperty\LazyPropertiesTrait;
 use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 use Workflow;
 
@@ -37,6 +38,7 @@ use Workflow;
 class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubscriberInterface
 {
     use LoggerTrait;
+    use LazyPropertiesTrait;
 
     /** @var ExtensionLoader */
     private $extensionLoader;
@@ -45,7 +47,9 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
 
     public function __construct()
     {
-        $this->projectRepository = Doctrine::getProjectRepository();
+        $this->initLazyProperties([
+            'projectRepository',
+        ]);
         $this->extensionLoader = Workflow::getExtensionLoader();
     }
 
@@ -854,5 +858,13 @@ class WorkflowLegacyExtension implements Provider\SubscriberProvider, EventSubsc
         }
 
         return $backend;
+    }
+
+    /**
+     * @return ProjectRepository
+     */
+    protected function getProjectRepository(): ProjectRepository
+    {
+        return Doctrine::getProjectRepository();
     }
 }

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -17,7 +17,6 @@ use Auth;
 use Doctrine\ORM\EntityManagerInterface;
 use Eventum\Config\Paths;
 use Eventum\Db\Doctrine;
-use Eventum\Extension\ExtensionManager;
 use Psr\Log\LoggerInterface;
 use Setup;
 use Symfony\Bundle\FrameworkBundle\Kernel\MicroKernelTrait;
@@ -158,8 +157,7 @@ class Kernel extends BaseKernel implements CompilerPassInterface
             $container->setParameter('env(DATABASE_URL)', $dsn);
         }
 
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $em->configureContainer($container, $loader);
     }
 
@@ -179,8 +177,7 @@ class Kernel extends BaseKernel implements CompilerPassInterface
             $routes->import("{$this->configDir}/routes.yml");
         }
 
-        /** @var ExtensionManager $em */
-        $em = ServiceContainer::get(ExtensionManager::class);
+        $em = ServiceContainer::getExtensionManager();
         $em->configureRoutes($routes);
     }
 

--- a/src/Kernel.php
+++ b/src/Kernel.php
@@ -62,6 +62,11 @@ class Kernel extends BaseKernel implements CompilerPassInterface
         return $this;
     }
 
+    public function isBooting(): bool
+    {
+        return !$this->booted;
+    }
+
     private static function isRewrite(): bool
     {
         if (isset($_SERVER['PATH_INFO'])) {

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -15,6 +15,7 @@ namespace Eventum;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eventum\Config\Config;
+use Eventum\Extension\ExtensionManager;
 use Pimple\Container;
 use Pimple\Psr11\Container as PsrContainer;
 use Psr\Container\ContainerInterface;
@@ -108,5 +109,13 @@ class ServiceContainer
     public static function getEntityManager(): EntityManagerInterface
     {
         return static::get(EntityManagerInterface::class);
+    }
+
+    /**
+     * @since 3.10.2
+     */
+    public static function getExtensionManager(): ExtensionManager
+    {
+        return static::get(ExtensionManager::class);
     }
 }

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -16,6 +16,7 @@ namespace Eventum;
 use Doctrine\ORM\EntityManagerInterface;
 use Eventum\Config\Config;
 use Eventum\Extension\ExtensionManager;
+use LogicException;
 use Pimple\Container;
 use Pimple\Psr11\Container as PsrContainer;
 use Psr\Container\ContainerInterface;
@@ -108,6 +109,10 @@ class ServiceContainer
      */
     public static function getEntityManager(): EntityManagerInterface
     {
+        if (static::isBooting()) {
+            throw new LogicException('Access to EntityManagerInterface forbidden when Kernel is booting');
+        }
+
         return static::get(EntityManagerInterface::class);
     }
 
@@ -117,5 +122,13 @@ class ServiceContainer
     public static function getExtensionManager(): ExtensionManager
     {
         return static::get(ExtensionManager::class);
+    }
+
+    /**
+     * @since 3.10.2
+     */
+    private static function isBooting(): bool
+    {
+        return static::getKernel()->isBooting();
     }
 }

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -106,7 +106,10 @@ class ServiceProvider implements ServiceProviderInterface
         };
 
         $app[ExtensionManager::class] = static function () {
-            return ExtensionManager::getManager();
+            $manager = new ExtensionManager();
+            $manager->boot();
+
+            return $manager;
         };
 
         $app[MessageIdGenerator::class] = static function () {

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -108,10 +108,7 @@ class ServiceProvider implements ServiceProviderInterface
         $app[ExtensionManager::class] = static function ($app) {
             $extensions = $app['config']['extensions'] ?: [];
 
-            $manager = new ExtensionManager($extensions);
-            $manager->boot();
-
-            return $manager;
+            return new ExtensionManager($extensions);
         };
 
         $app[MessageIdGenerator::class] = static function () {

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -105,8 +105,10 @@ class ServiceProvider implements ServiceProviderInterface
             return EventManager::getEventDispatcher();
         };
 
-        $app[ExtensionManager::class] = static function () {
-            $manager = new ExtensionManager();
+        $app[ExtensionManager::class] = static function ($app) {
+            $extensions = $app['config']['extensions'] ?: [];
+
+            $manager = new ExtensionManager($extensions);
             $manager->boot();
 
             return $manager;

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -38,7 +38,7 @@ abstract class TestCase extends WebTestCase
 
         // Boot ExtensionManager
         // current test touches parts that would require workflow to be called
-        ServiceContainer::getExtensionManager();
+        ServiceContainer::getExtensionManager()->boot();
     }
 
     /**

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -38,7 +38,7 @@ abstract class TestCase extends WebTestCase
 
         // Boot ExtensionManager
         // current test touches parts that would require workflow to be called
-        ServiceContainer::get(ExtensionManager::class);
+        ServiceContainer::getExtensionManager();
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -27,19 +27,9 @@ class TestCase extends \PHPUnit\Framework\TestCase
      */
     protected function getExtensionManager(array $config): ExtensionManager
     {
-        /** @var ExtensionManager $stub */
-        $stub = $this->getMockBuilder(ExtensionManager::class)
-            ->disableOriginalConstructor()
-            ->setMethods(['getExtensionFiles'])
-            ->getMock();
+        $em = new ExtensionManager($config);
+        $em->boot();
 
-        $stub->method('getExtensionFiles')
-            ->willReturn($config);
-
-        // as ->getMock() calls original constructor before method mocks is setup
-        // we disabled original constructor and call it out now.
-        $stub->__construct();
-
-        return $stub;
+        return $em;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -41,3 +41,5 @@ if (!file_exists($privateKeyFile = Setup::getPrivateKeyPath()) || !filesize($pri
 // this setups ev_gettext wrappers
 Language::setup();
 Logger::initialize();
+ServiceContainer::getKernel()->boot();
+ServiceContainer::getExtensionManager()->boot();


### PR DESCRIPTION
Addendum to https://github.com/eventum/eventum/pull/1025.

This ensures `ExtensionManager` is final and testable. Somehow #1025 CI passed and merged prematurely event tests were broken.

This attempts to really fix the cyclic loop that #1025 introduced with a small tradeoff of backward-incompatible change.

# Backward incompatible change

Extensions should not access things from container in their constructor. Such access must be delayed, for example use `LazyPropertiesTrait`: fcb1fbd6ae9210312c7e9e1c71f03ecae9c7415c