### PR TITLE
Deprecate EventManager class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ See [Upgrading] for details on how to upgrade.
 - Avoid using deprecated Setup::get(), #1030
 - Move SCM setup to Extension, #890
 - Deprecate bin scripts over excuting via bin/console.php, #1031
+- Deprecate EventManager class, #1033
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/init.php
+++ b/init.php
@@ -49,4 +49,4 @@ if (Setup::isMaintenance()) {
 
 Eventum\DebugBarManager::getDebugBarManager();
 ServiceContainer::getExtensionManager()->boot();
-Eventum\EventDispatcher\EventManager::dispatch(SystemEvents::BOOT);
+ServiceContainer::dispatch(SystemEvents::BOOT);

--- a/lib/eventum/class.history.php
+++ b/lib/eventum/class.history.php
@@ -14,7 +14,7 @@
 use Eventum\Db\DatabaseException;
 use Eventum\Db\Doctrine;
 use Eventum\Event;
-use Eventum\EventDispatcher\EventManager;
+use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -81,7 +81,7 @@ class History
         $params['prj_id'] = (int)Auth::getCurrentProject();
 
         $event = new GenericEvent(null, $params);
-        EventManager::dispatch(Event\SystemEvents::HISTORY_ADD, $event);
+        ServiceContainer::dispatch(Event\SystemEvents::HISTORY_ADD, $event);
     }
 
     /**

--- a/lib/eventum/class.issue.php
+++ b/lib/eventum/class.issue.php
@@ -15,8 +15,8 @@ use Eventum\Attachment\AttachmentManager;
 use Eventum\Db\DatabaseException;
 use Eventum\Db\Doctrine;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailMessage;
+use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -909,7 +909,7 @@ class Issue
             'duplicate_iss_id' => (int)$dup_iss_id,
         ];
         $event = new GenericEvent($arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_MARK_DUPLICATE, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_MARK_DUPLICATE, $event);
 
         // record the change
         History::add($issue_id, $usr_id, 'duplicate_added', 'Issue marked as a duplicate of issue #{issue_id} by {user}', [

--- a/lib/eventum/class.mail_queue.php
+++ b/lib/eventum/class.mail_queue.php
@@ -12,10 +12,10 @@
  */
 
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailBuilder;
 use Eventum\Mail\MailMessage;
 use Eventum\Mail\MailTransport;
+use Eventum\ServiceContainer;
 use Laminas\Mail\Address;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -151,15 +151,15 @@ class Mail_Queue
 
                 unset($entry['headers'], $entry['body']);
                 $event = new GenericEvent($mail, $entry);
-                EventManager::dispatch(SystemEvents::MAIL_QUEUE_SEND, $event);
+                ServiceContainer::dispatch(SystemEvents::MAIL_QUEUE_SEND, $event);
 
                 $transport = new MailTransport();
                 $transport->send($entry['recipient'], $mail);
 
-                EventManager::dispatch(SystemEvents::MAIL_QUEUE_SENT, $event);
+                ServiceContainer::dispatch(SystemEvents::MAIL_QUEUE_SENT, $event);
             } catch (Exception $e) {
                 $event = new GenericEvent($e, $entry);
-                EventManager::dispatch(SystemEvents::MAIL_QUEUE_ERROR, $event);
+                ServiceContainer::dispatch(SystemEvents::MAIL_QUEUE_ERROR, $event);
             }
         }
     }

--- a/lib/eventum/class.notification.php
+++ b/lib/eventum/class.notification.php
@@ -16,7 +16,6 @@ use Eventum\Db\DatabaseException;
 use Eventum\Db\Doctrine;
 use Eventum\Diff\Differ;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\Helper\WarningMessage;
 use Eventum\Mail\MailBuilder;
@@ -1220,7 +1219,7 @@ class Notification
         ];
 
         $event = new GenericEvent(null, $arguments);
-        EventManager::dispatch(SystemEvents::NOTIFY_ISSUE_CREATED, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTIFY_ISSUE_CREATED, $event);
 
         self::notifySubscribers($issue_id, $emails, 'new_issue', $data, $subject, false, false, $headers);
     }

--- a/lib/eventum/class.reminder_action.php
+++ b/lib/eventum/class.reminder_action.php
@@ -13,7 +13,6 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
@@ -666,7 +665,7 @@ class Reminder_Action
             'to' => $to,
         ];
         $event = new GenericEvent(null, $arguments);
-        EventManager::dispatch(SystemEvents::REMINDER_ACTION_PERFORM, $event);
+        ServiceContainer::dispatch(SystemEvents::REMINDER_ACTION_PERFORM, $event);
 
         $setup = ServiceContainer::getConfig();
         // if there are no recipients, then just skip to the next action

--- a/lib/eventum/class.routing.php
+++ b/lib/eventum/class.routing.php
@@ -12,7 +12,6 @@
  */
 
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\Exception\RoutingException;
 use Eventum\Mail\Helper\AddressHeader;
 use Eventum\Mail\Helper\WarningMessage;
@@ -90,7 +89,7 @@ class Routing
      */
     protected static function route_emails(MailMessage $mail): bool
     {
-        EventManager::dispatch(SystemEvents::MAIL_ROUTE_EMAIL, $mail);
+        ServiceContainer::dispatch(SystemEvents::MAIL_ROUTE_EMAIL, $mail);
 
         // check if the email routing interface is even supposed to be enabled
         $setup = ServiceContainer::getConfig();
@@ -243,7 +242,7 @@ class Routing
      */
     protected static function route_notes(MailMessage $mail): bool
     {
-        EventManager::dispatch(SystemEvents::MAIL_ROUTE_NOTE, $mail);
+        ServiceContainer::dispatch(SystemEvents::MAIL_ROUTE_NOTE, $mail);
 
         $headers = $mail->getHeaders();
 
@@ -371,7 +370,7 @@ class Routing
      */
     protected static function route_drafts(MailMessage $mail): bool
     {
-        EventManager::dispatch(SystemEvents::MAIL_ROUTE_DRAFT, $mail);
+        ServiceContainer::dispatch(SystemEvents::MAIL_ROUTE_DRAFT, $mail);
 
         $headers = $mail->getHeaders();
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -16,7 +16,6 @@ use Eventum\Config\ConfigPersistence;
 use Eventum\Config\Paths;
 use Eventum\Event\ConfigUpdateEvent;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\ServiceContainer;
 use Symfony\Component\Filesystem\Exception\IOException;
 
@@ -259,7 +258,7 @@ class Setup
         $config = self::set($options);
 
         $event = new ConfigUpdateEvent($config);
-        EventManager::dispatch(SystemEvents::CONFIG_SAVE, $event);
+        ServiceContainer::dispatch(SystemEvents::CONFIG_SAVE, $event);
 
         try {
             self::saveConfig(self::getSetupFile(), $config);

--- a/lib/eventum/class.template_helper.php
+++ b/lib/eventum/class.template_helper.php
@@ -15,7 +15,6 @@ use Eventum\AppInfo;
 use Eventum\Config\Paths;
 use Eventum\DebugBarManager;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\ServiceContainer;
 use Eventum\Templating;
 
@@ -211,7 +210,7 @@ class Template_Helper
         }
         $this->assign('core', $core);
 
-        EventManager::dispatch(SystemEvents::SMARTY_PROCESS, $this);
+        ServiceContainer::dispatch(SystemEvents::SMARTY_PROCESS, $this);
 
         $this->assign('header_templates', $this->headerTemplates);
 

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -13,7 +13,6 @@
 
 use Eventum\Db\DatabaseException;
 use Eventum\Event;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\MailBuilder;
 use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
@@ -1073,7 +1072,7 @@ class User
         unset($user['password']);
 
         $event = new GenericEvent(null, $user);
-        EventManager::dispatch(Event\SystemEvents::USER_UPDATE, $event);
+        ServiceContainer::dispatch(Event\SystemEvents::USER_UPDATE, $event);
 
         return true;
     }
@@ -1141,7 +1140,7 @@ class User
         unset($user['password']);
 
         $event = new GenericEvent(null, $user);
-        EventManager::dispatch(Event\SystemEvents::USER_CREATE, $event);
+        ServiceContainer::dispatch(Event\SystemEvents::USER_CREATE, $event);
 
         return $usr_id;
     }

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -17,7 +17,6 @@ use Eventum\Db\Doctrine;
 use Eventum\Event\EventContext;
 use Eventum\Event\ResultableEvent;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionLoader;
 use Eventum\LinkFilter\LinkFilter;
 use Eventum\Mail\Helper\AddressHeader;
@@ -56,7 +55,7 @@ class Workflow
             'raw_post' => $raw_post,
         ];
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_UPDATED, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_UPDATED, $event);
     }
 
     /**
@@ -83,7 +82,7 @@ class Workflow
         ];
 
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_UPDATED_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_UPDATED_BEFORE, $event);
 
         if ($event['bubble'] !== true) {
             return $event['bubble'];
@@ -109,7 +108,7 @@ class Workflow
     public static function handleAttachment(int $prj_id, int $issue_id, int $usr_id, AttachmentGroup $attachment_group): void
     {
         $event = new EventContext($prj_id, $issue_id, $usr_id, [], $attachment_group);
-        EventManager::dispatch(SystemEvents::ATTACHMENT_ATTACHMENT_GROUP, $event);
+        ServiceContainer::dispatch(SystemEvents::ATTACHMENT_ATTACHMENT_GROUP, $event);
     }
 
     /**
@@ -127,7 +126,7 @@ class Workflow
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id, [], $attachment);
         $event->setResult(true);
-        EventManager::dispatch(SystemEvents::ATTACHMENT_ATTACH_FILE, $event);
+        ServiceContainer::dispatch(SystemEvents::ATTACHMENT_ATTACH_FILE, $event);
 
         return $event->getResult();
     }
@@ -150,7 +149,7 @@ class Workflow
             'changes' => $changes,
         ];
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_UPDATED_PRIORITY, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_UPDATED_PRIORITY, $event);
     }
 
     /**
@@ -171,7 +170,7 @@ class Workflow
             'changes' => $changes,
         ];
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_UPDATED_SEVERITY, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_UPDATED_SEVERITY, $event);
     }
 
     /**
@@ -195,7 +194,7 @@ class Workflow
             'mail' => $mail,
         ];
         $event = new EventContext($prj_id, $issue_id, null, $arguments, $mail);
-        EventManager::dispatch(SystemEvents::EMAIL_BLOCKED, $event);
+        ServiceContainer::dispatch(SystemEvents::EMAIL_BLOCKED, $event);
     }
 
     /**
@@ -220,7 +219,7 @@ class Workflow
         ];
 
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_ASSIGNMENT_CHANGE, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_ASSIGNMENT_CHANGE, $event);
     }
 
     /**
@@ -244,7 +243,7 @@ class Workflow
         ];
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
 
-        EventManager::dispatch(SystemEvents::ISSUE_CREATED, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_CREATED, $event);
     }
 
     /**
@@ -280,11 +279,11 @@ class Workflow
 
         if (empty($row['issue_id'])) {
             $event = new EventContext($prj_id, $issue_id, null, $arguments, $mail);
-            EventManager::dispatch(SystemEvents::MAIL_PENDING, $event);
+            ServiceContainer::dispatch(SystemEvents::MAIL_PENDING, $event);
         }
 
         $event = new EventContext($prj_id, $issue_id, null, $arguments, $mail);
-        EventManager::dispatch(SystemEvents::MAIL_CREATED, $event);
+        ServiceContainer::dispatch(SystemEvents::MAIL_CREATED, $event);
     }
 
     /**
@@ -303,7 +302,7 @@ class Workflow
             'sup_ids' => $sup_ids,
         ];
         $event = new EventContext($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::MAIL_ASSOCIATED_MANUAL, $event);
+        ServiceContainer::dispatch(SystemEvents::MAIL_ASSOCIATED_MANUAL, $event);
     }
 
     /**
@@ -329,7 +328,7 @@ class Workflow
             'closing' => $closing,
         ];
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::NOTE_CREATED, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTE_CREATED, $event);
     }
 
     /**
@@ -346,7 +345,7 @@ class Workflow
     {
         $statusList = Status::getAssocStatusList($prj_id, false);
         $event = new ResultableEvent($prj_id, $issue_id, null, [], $statusList);
-        EventManager::dispatch(SystemEvents::ISSUE_ALLOWED_STATUSES, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_ALLOWED_STATUSES, $event);
         if ($event->hasResult()) {
             return $event->getResult();
         }
@@ -381,7 +380,7 @@ class Workflow
         ];
 
         $event = new EventContext($prj_id, $issue_id, $usr_id, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_CLOSED, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_CLOSED, $event);
     }
 
     /**
@@ -403,7 +402,7 @@ class Workflow
             'changed' => $changed,
         ];
         $event = new EventContext($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::CUSTOM_FIELDS_UPDATED, $event);
+        ServiceContainer::dispatch(SystemEvents::CUSTOM_FIELDS_UPDATED, $event);
     }
 
     /**
@@ -430,7 +429,7 @@ class Workflow
         ];
 
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::NOTIFICATION_HANDLE_SUBSCRIPTION, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTIFICATION_HANDLE_SUBSCRIPTION, $event);
 
         // assign back, in case these were changed
         $subscriber_usr_id = $event['subscriber_usr_id'];
@@ -466,7 +465,7 @@ class Workflow
         ];
 
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments, $address);
-        EventManager::dispatch(SystemEvents::NOTIFICATION_NOTIFY_ADDRESS, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTIFICATION_NOTIFY_ADDRESS, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -494,7 +493,7 @@ class Workflow
         ];
 
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::NOTIFICATION_NOTIFY_ADDRESSES_EXTRA, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTIFICATION_NOTIFY_ADDRESSES_EXTRA, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -519,7 +518,7 @@ class Workflow
     {
         $address = AddressHeader::fromString($email)->getAddress();
         $event = new ResultableEvent($prj_id, $issue_id, null, [], $address);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_EMAIL, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_EMAIL, $event);
         if ($event->hasResult()) {
             return $event->getResult();
         }
@@ -545,7 +544,7 @@ class Workflow
             'mail' => $mail,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments, $address);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_NOTE, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_NOTE, $event);
         if ($event->hasResult()) {
             return $event->getResult();
         }
@@ -566,7 +565,7 @@ class Workflow
     public static function canCloneIssue(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CLONE, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_CLONE, $event);
         if ($event->hasResult()) {
             return $event->getResult();
         }
@@ -587,7 +586,7 @@ class Workflow
     public static function canChangeAccessLevel(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ACCESS, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ACCESS, $event);
         if ($event->hasResult()) {
             return $event->getResult();
         }
@@ -609,7 +608,7 @@ class Workflow
     {
         $address = AddressHeader::fromString($email)->getAddress();
         $event = new ResultableEvent($prj_id, $issue_id, null, [], $address);
-        EventManager::dispatch(SystemEvents::AUTHORIZED_REPLIER_ADD, $event);
+        ServiceContainer::dispatch(SystemEvents::AUTHORIZED_REPLIER_ADD, $event);
 
         // assign back, in case it was modified by event
         if (isset($event['email'])) {
@@ -636,7 +635,7 @@ class Workflow
     public static function preEmailDownload(int $prj_id, ImapMessage $mail): bool
     {
         $event = new EventContext($prj_id, null, null, [], $mail);
-        EventManager::dispatch(SystemEvents::MAIL_PROCESS_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::MAIL_PROCESS_BEFORE, $event);
         if ($event->isPropagationStopped()) {
             return false;
         }
@@ -661,7 +660,7 @@ class Workflow
             'data' => $data,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::NOTE_INSERT_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTE_INSERT_BEFORE, $event);
 
         // assign back, in case it was changed
         $data = $event['data'];
@@ -688,7 +687,7 @@ class Workflow
     {
         $event = new ResultableEvent($prj_id, null, null);
         $event->setResult(true);
-        EventManager::dispatch(SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD, $event);
+        ServiceContainer::dispatch(SystemEvents::PROJECT_NOTIFICATION_AUTO_ADD, $event);
 
         return $event->getResult();
     }
@@ -714,7 +713,7 @@ class Workflow
             'account' => $account,
         ];
         $event = new ResultableEvent($prj_id, null, null, $arguments, $mail);
-        EventManager::dispatch(SystemEvents::ISSUE_EMAIL_CREATE_OPTIONS, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_EMAIL_CREATE_OPTIONS, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -742,7 +741,7 @@ class Workflow
             'address' => $address,
         ];
         $event = new EventContext($prj_id, null, null, $arguments, $mail);
-        EventManager::dispatch(SystemEvents::MAIL_QUEUE_MODIFY, $event);
+        ServiceContainer::dispatch(SystemEvents::MAIL_QUEUE_MODIFY, $event);
     }
 
     /**
@@ -763,7 +762,7 @@ class Workflow
             'notify' => $notify,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_STATUS_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_STATUS_BEFORE, $event);
 
         // assign back, in case they were modified
         $issue_id = $event['issue_id'];
@@ -789,7 +788,7 @@ class Workflow
     public static function prePage(int $prj_id, string $page_name): void
     {
         $event = new EventContext($prj_id, null, null, [], $page_name);
-        EventManager::dispatch(SystemEvents::PAGE_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::PAGE_BEFORE, $event);
     }
 
     /**
@@ -812,7 +811,7 @@ class Workflow
             'source' => $source,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::NOTIFICATION_ACTIONS, $event);
+        ServiceContainer::dispatch(SystemEvents::NOTIFICATION_ACTIONS, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -835,7 +834,7 @@ class Workflow
     public static function getIssueFieldsToDisplay(int $prj_id, int $issue_id, string $location): array
     {
         $event = new ResultableEvent($prj_id, $issue_id, null, [], $location);
-        EventManager::dispatch(SystemEvents::ISSUE_FIELDS_DISPLAY, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_FIELDS_DISPLAY, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -854,7 +853,7 @@ class Workflow
     public static function addLinkFilters(LinkFilter $linkFilter, int $prj_id): void
     {
         $event = new EventContext($prj_id, null, null, [], $linkFilter);
-        EventManager::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_LINK_FILTERS, $event);
     }
 
     /**
@@ -866,7 +865,7 @@ class Workflow
     public static function canUpdateIssue(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_UPDATE, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_UPDATE, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -884,7 +883,7 @@ class Workflow
     public static function canChangeAssignee(int $prj_id, int $issue_id, int $usr_id): ?bool
     {
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE_CHANGE_ASSIGNEE, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -902,7 +901,7 @@ class Workflow
     public static function getActiveGroup(int $prj_id): ?int
     {
         $event = new ResultableEvent($prj_id, null, null);
-        EventManager::dispatch(SystemEvents::GROUP_ACTIVE, $event);
+        ServiceContainer::dispatch(SystemEvents::GROUP_ACTIVE, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -920,7 +919,7 @@ class Workflow
     public static function getAccessLevels(?int $prj_id): ?array
     {
         $event = new ResultableEvent($prj_id, null, null);
-        EventManager::dispatch(SystemEvents::ACCESS_LEVELS, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_LEVELS, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -943,7 +942,7 @@ class Workflow
         ];
         $event = new ResultableEvent($prj_id, $issue_id, $usr_id, $arguments);
         $event->setResult($return);
-        EventManager::dispatch(SystemEvents::ACCESS_ISSUE, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_ISSUE, $event);
 
         return $event->getResult();
     }
@@ -958,7 +957,7 @@ class Workflow
     public static function getAdditionalAccessSQL(int $prj_id, int $usr_id): ?string
     {
         $event = new ResultableEvent($prj_id, null, $usr_id);
-        EventManager::dispatch(SystemEvents::ACCESS_LISTING_SQL, $event);
+        ServiceContainer::dispatch(SystemEvents::ACCESS_LISTING_SQL, $event);
 
         if ($event->hasResult()) {
             return $event->getResult();
@@ -980,7 +979,7 @@ class Workflow
             'new_prj_id' => $new_prj_id,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_MOVE_FROM_PROJECT, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_MOVE_FROM_PROJECT, $event);
     }
 
     /**
@@ -996,7 +995,7 @@ class Workflow
             'old_prj_id' => $old_prj_id,
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
-        EventManager::dispatch(SystemEvents::ISSUE_MOVE_TO_PROJECT, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_MOVE_TO_PROJECT, $event);
     }
 
     /**
@@ -1018,7 +1017,7 @@ class Workflow
         ];
         $event = new ResultableEvent($prj_id, $issue_id, null, $arguments);
         $event->setResult($mapping);
-        EventManager::dispatch(SystemEvents::ISSUE_MOVE_MAPPING, $event);
+        ServiceContainer::dispatch(SystemEvents::ISSUE_MOVE_MAPPING, $event);
 
         return $event->getResult();
     }

--- a/phinx.php
+++ b/phinx.php
@@ -13,7 +13,7 @@
 
 use Eventum\Db\AbstractMigration;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
+use Eventum\ServiceContainer;
 use Symfony\Component\EventDispatcher\GenericEvent;
 
 /**
@@ -79,6 +79,6 @@ $phinx['environments']['test'] = $phinx['environments']['production'];
 $phinx['environments']['test']['name'] = getenv('MYSQL_DATABASE') ?: 'e_test';
 
 $event = new GenericEvent(null, $phinx);
-EventManager::dispatch(SystemEvents::PHINX_CONFIG, $event);
+ServiceContainer::dispatch(SystemEvents::PHINX_CONFIG, $event);
 
 return $event->getArguments();

--- a/src/Console/Application.php
+++ b/src/Console/Application.php
@@ -13,7 +13,6 @@
 
 namespace Eventum\Console;
 
-use Eventum\EventDispatcher\EventManager;
 use Eventum\ServiceContainer;
 use Silly\Application as BaseApplication;
 use Symfony\Component\Console\Input\ArgvInput;
@@ -24,7 +23,7 @@ class Application extends BaseApplication
     public function __construct($name = 'UNKNOWN', $version = 'UNKNOWN')
     {
         parent::__construct($name, $version);
-        $this->setDispatcher(EventManager::getEventDispatcher());
+        $this->setDispatcher(ServiceContainer::getEventDispatcher());
         $this->useContainer(ServiceContainer::getContainer());
     }
 

--- a/src/Crypto/CryptoUpgradeManager.php
+++ b/src/Crypto/CryptoUpgradeManager.php
@@ -16,7 +16,6 @@ namespace Eventum\Crypto;
 use Eventum\Config\Config;
 use Eventum\Event\ConfigUpdateEvent;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\ServiceContainer;
 use Setup;
 
@@ -72,7 +71,7 @@ class CryptoUpgradeManager
         }
 
         $event = new ConfigUpdateEvent($this->config);
-        EventManager::dispatch(SystemEvents::CONFIG_CRYPTO_UPGRADE, $event);
+        ServiceContainer::dispatch(SystemEvents::CONFIG_CRYPTO_UPGRADE, $event);
 
         Setup::save();
     }
@@ -85,7 +84,7 @@ class CryptoUpgradeManager
         $this->canPerform(false);
 
         $event = new ConfigUpdateEvent($this->config);
-        EventManager::dispatch(SystemEvents::CONFIG_CRYPTO_DOWNGRADE, $event);
+        ServiceContainer::dispatch(SystemEvents::CONFIG_CRYPTO_DOWNGRADE, $event);
 
         $this->config['encryption'] = 'disabled';
         if (CryptoManager::encryptionEnabled()) {

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -53,9 +53,12 @@ class EventManager
      * @param Event|\Symfony\Component\EventDispatcher\Event $event
      * @return Event|object
      * @see EventDispatcherInterface::dispatch()
+     * @deprecated since 3.10.2, use ServiceContainer::dispatch();
      */
     public static function dispatch($eventName, $event = null)
     {
+        trigger_deprecation('eventum/eventum', '3.10.2', 'Method "%s::%s" is deprecated, use ServiceContainer::dispatch', __CLASS__, __METHOD__);
+
         return self::getEventDispatcher()->dispatch($event ?? new Event(), $eventName);
     }
 }

--- a/src/EventDispatcher/EventManager.php
+++ b/src/EventDispatcher/EventManager.php
@@ -23,8 +23,9 @@ class EventManager
 {
     /**
      * Singleton for Event Dispatcher
+     * @deprecated since 3.10.2, use ServiceContainer::getEventDispatcher();
      */
-    public static function getEventDispatcher(): EventDispatcherInterface
+    public static function getEventDispatcher($notifyDeprecated = true): EventDispatcherInterface
     {
         static $dispatcher;
         if (!$dispatcher) {
@@ -41,6 +42,9 @@ class EventManager
             // load builtin event subscribers
             $dispatcher->addSubscriber(new Subscriber\MailQueueListener());
             $dispatcher->addSubscriber(new Subscriber\CryptoSubscriber());
+            if ($notifyDeprecated) {
+                trigger_deprecation('eventum/eventum', '3.10.2', 'Method "%s::%s" is deprecated', __CLASS__, __METHOD__);
+            }
         }
 
         return $dispatcher;
@@ -59,6 +63,6 @@ class EventManager
     {
         trigger_deprecation('eventum/eventum', '3.10.2', 'Method "%s::%s" is deprecated, use ServiceContainer::dispatch', __CLASS__, __METHOD__);
 
-        return self::getEventDispatcher()->dispatch($event ?? new Event(), $eventName);
+        return self::getEventDispatcher(false)->dispatch($event ?? new Event(), $eventName);
     }
 }

--- a/src/Mail/ImapMessage.php
+++ b/src/Mail/ImapMessage.php
@@ -16,9 +16,9 @@ namespace Eventum\Mail;
 use Date_Helper;
 use DateTime;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Mail\Helper\MailLoader;
 use Eventum\Mail\Imap\ImapResource;
+use Eventum\ServiceContainer;
 use InvalidArgumentException;
 use Laminas\Mail\Header\GenericHeader;
 use Laminas\Mail\Storage;
@@ -70,7 +70,7 @@ class ImapMessage extends MailMessage
         $message->num = $resource->num;
 
         $event = new GenericEvent($message, $parameters);
-        EventManager::dispatch(SystemEvents::MAIL_LOADED_IMAP, $event);
+        ServiceContainer::dispatch(SystemEvents::MAIL_LOADED_IMAP, $event);
 
         return $message;
     }

--- a/src/Model/Repository/CommitRepository.php
+++ b/src/Model/Repository/CommitRepository.php
@@ -15,9 +15,9 @@ namespace Eventum\Model\Repository;
 
 use Eventum\Db\Doctrine;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Model\Entity;
 use Eventum\Scm\Payload;
+use Eventum\ServiceContainer;
 use History;
 use InvalidArgumentException;
 use Issue;
@@ -56,7 +56,7 @@ class CommitRepository extends BaseRepository
     public function preCommit(Entity\Commit $ci, Payload\PayloadInterface $payload): void
     {
         $event = new GenericEvent($ci, ['payload' => $payload]);
-        EventManager::dispatch(SystemEvents::SCM_COMMIT_BEFORE, $event);
+        ServiceContainer::dispatch(SystemEvents::SCM_COMMIT_BEFORE, $event);
     }
 
     /**
@@ -165,7 +165,7 @@ class CommitRepository extends BaseRepository
             ];
             $event = new GenericEvent($ci, $arguments);
 
-            EventManager::dispatch(SystemEvents::SCM_COMMIT_ASSOCIATED, $event);
+            ServiceContainer::dispatch(SystemEvents::SCM_COMMIT_ASSOCIATED, $event);
 
             // print report to stdout of commits so hook could report status back to committer
             echo "#$issue_id - {$issue->getSummary()} ({$issue->getStatusTitle()})\n";

--- a/src/Scm/Adapter/Gitlab.php
+++ b/src/Scm/Adapter/Gitlab.php
@@ -15,7 +15,6 @@ namespace Eventum\Scm\Adapter;
 
 use Eventum\Db\Doctrine;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Scm\Payload\GitlabPayload;
 use Eventum\Scm\ScmRepository;
 use Eventum\ServiceContainer;
@@ -134,7 +133,7 @@ class Gitlab extends AbstractAdapter
 
         // dispatch matches as event
         $event = new GenericEvent($payload, $data);
-        EventManager::dispatch(SystemEvents::RPC_GITLAB_MATCH_ISSUE, $event);
+        ServiceContainer::dispatch(SystemEvents::RPC_GITLAB_MATCH_ISSUE, $event);
     }
 
     /**

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -15,6 +15,7 @@ namespace Eventum;
 
 use Doctrine\ORM\EntityManagerInterface;
 use Eventum\Config\Config;
+use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ExtensionManager;
 use LogicException;
 use Pimple\Container;
@@ -22,8 +23,10 @@ use Pimple\Psr11\Container as PsrContainer;
 use Psr\Container\ContainerInterface;
 use Psr\Log\LoggerInterface;
 use Symfony\Bundle\FrameworkBundle\Console\Application;
+use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelInterface;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class ServiceContainer
 {
@@ -114,6 +117,28 @@ class ServiceContainer
         }
 
         return static::get(EntityManagerInterface::class);
+    }
+
+    /**
+     * @since 3.10.2
+     */
+    public static function getEventDispatcher(): EventDispatcherInterface
+    {
+        return EventManager::getEventDispatcher();
+    }
+
+    /**
+     * Helper to dispatch events
+     *
+     * @param string $eventName
+     * @param Event|\Symfony\Component\EventDispatcher\Event $event
+     * @return Event|object
+     * @see EventDispatcherInterface::dispatch()
+     * @since 3.10.2
+     */
+    public static function dispatch(string $eventName, $event = null)
+    {
+        return static::getEventDispatcher()->dispatch($event ?? new Event(), $eventName);
     }
 
     /**

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -124,7 +124,7 @@ class ServiceContainer
      */
     public static function getEventDispatcher(): EventDispatcherInterface
     {
-        return EventManager::getEventDispatcher();
+        return EventManager::getEventDispatcher(false);
     }
 
     /**

--- a/src/ServiceProvider/MarkdownServiceProvider.php
+++ b/src/ServiceProvider/MarkdownServiceProvider.php
@@ -15,9 +15,9 @@ namespace Eventum\ServiceProvider;
 
 use Eventum\Config\Paths;
 use Eventum\Event;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Markdown;
 use Eventum\Markdown\CommonMark\UserMentionGenerator;
+use Eventum\ServiceContainer;
 use Giberti\EmojiExtension\EmojiExtension;
 use HTMLPurifier;
 use HTMLPurifier_HTML5Config;
@@ -131,7 +131,7 @@ class MarkdownServiceProvider implements ServiceProviderInterface
 
         // allow extensions to apply behaviour
         $event = new GenericEvent($environment);
-        EventManager::dispatch(Event\SystemEvents::MARKDOWN_ENVIRONMENT_CONFIGURE, $event);
+        ServiceContainer::dispatch(Event\SystemEvents::MARKDOWN_ENVIRONMENT_CONFIGURE, $event);
     }
 
     private static function createPurifier(): HTMLPurifier

--- a/src/ServiceProvider/ServiceProvider.php
+++ b/src/ServiceProvider/ServiceProvider.php
@@ -102,7 +102,7 @@ class ServiceProvider implements ServiceProviderInterface
         };
 
         $app[EventDispatcherInterface::class] = static function () {
-            return EventManager::getEventDispatcher();
+            return EventManager::getEventDispatcher(false);
         };
 
         $app[ExtensionManager::class] = static function ($app) {

--- a/tests/CustomField/CustomFieldTest.php
+++ b/tests/CustomField/CustomFieldTest.php
@@ -15,8 +15,8 @@ namespace Eventum\Test\CustomField;
 
 use CustomFieldSeeder;
 use Eventum\CustomField\Converter;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Model\Entity\CustomField;
+use Eventum\ServiceContainer;
 use IssueSeeder;
 use ProjectSeeder;
 use User;
@@ -47,7 +47,7 @@ class CustomFieldTest extends TestCase
         $this->assertCount(0, $customFields);
 
         // trigger setup of extensions
-        EventManager::getEventDispatcher();
+        ServiceContainer::getEventDispatcher();
 
         $converter = new Converter();
         $fields = $converter->convertIssueCustomFields($customFields, $iss_id, $formType);

--- a/tests/Scm/ScmControllerTest.php
+++ b/tests/Scm/ScmControllerTest.php
@@ -14,7 +14,7 @@
 namespace Eventum\Test\Scm;
 
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
+use Eventum\ServiceContainer;
 use Eventum\Test\Traits\DataFileTrait;
 
 class ScmControllerTest extends TestCase
@@ -54,7 +54,7 @@ class ScmControllerTest extends TestCase
             $invoked = true;
         };
 
-        $dispatcher = EventManager::getEventDispatcher();
+        $dispatcher = ServiceContainer::getEventDispatcher();
         $dispatcher->addListener(SystemEvents::RPC_GITLAB_MATCH_ISSUE, $listener);
 
         $json = $this->makeRequest($payload, ['HTTP_X-Gitlab-Event' => 'Note Hook']);

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -15,7 +15,6 @@ namespace Eventum\Test\Scm;
 
 use Date_Helper;
 use Eventum\Event\SystemEvents;
-use Eventum\EventDispatcher\EventManager;
 use Eventum\Extension\ScmExtension;
 use Eventum\Model\Entity;
 use Eventum\Model\Repository\StatusRepository;
@@ -107,7 +106,7 @@ abstract class TestCase extends WebTestCase
             }
         };
 
-        $dispatcher = EventManager::getEventDispatcher();
+        $dispatcher = ServiceContainer::getEventDispatcher();
         $dispatcher->addListener(SystemEvents::SCM_COMMIT_ASSOCIATED, $listener);
     }
 


### PR DESCRIPTION
Extracted from https://github.com/eventum/eventum/pull/966.

This picks change from https://github.com/eventum/eventum/pull/966 other than the ones creating dependency loop. Proxy EventManager methods into ServiceContainer for future changes.