### PR TITLE
Fix catching Defuse CryptoException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ See [Upgrading] for details on how to upgrade.
 - Move SCM setup to Extension, #890
 - Deprecate bin scripts over excuting via bin/console.php, #1031
 - Deprecate EventManager class, #1033
+- Fix catching Defuse CryptoException, #1034
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/src/Crypto/CryptoKeyManager.php
+++ b/src/Crypto/CryptoKeyManager.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Crypto;
 
+use Defuse\Crypto\Exception\CryptoException as DefuseCryptoException;
 use Defuse\Crypto\Key;
 use Eventum\Opcache;
 use Setup;
@@ -43,8 +44,8 @@ final class CryptoKeyManager
         try {
             $this->key = Key::createNewRandomKey();
             $this->storePrivateKey();
-        } catch (CryptoException $e) {
-            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        } catch (DefuseCryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 
@@ -120,8 +121,8 @@ final class CryptoKeyManager
 
         try {
             $this->key = Key::loadFromAsciiSafeString($key);
-        } catch (CryptoException $e) {
-            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        } catch (DefuseCryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage(), $e->getCode(), $e);
         }
 
         return true;

--- a/src/Crypto/CryptoManager.php
+++ b/src/Crypto/CryptoManager.php
@@ -14,6 +14,7 @@
 namespace Eventum\Crypto;
 
 use Defuse\Crypto\Crypto;
+use Defuse\Crypto\Exception\CryptoException as DefuseCryptoException;
 use Defuse\Crypto\Key;
 use Defuse\Crypto\RuntimeTests;
 use Eventum\ServiceContainer;
@@ -51,7 +52,7 @@ final class CryptoManager
         }
         try {
             RuntimeTests::runtimeTest();
-        } catch (CryptoException $e) {
+        } catch (DefuseCryptoException $e) {
             throw new CryptoException($e->getMessage(), $e->getCode(), $e);
         }
 
@@ -79,8 +80,8 @@ final class CryptoManager
 
         try {
             $ciphertext = Crypto::encrypt($plaintext, self::getKey(), true);
-        } catch (CryptoException $e) {
-            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        } catch (DefuseCryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage(), $e->getCode(), $e);
         }
 
         return rtrim(base64_encode($ciphertext), '=');
@@ -114,8 +115,8 @@ final class CryptoManager
 
             // support legacy decrypt
             return Crypto::legacyDecrypt($ciphertext, $key);
-        } catch (CryptoException $e) {
-            throw new CryptoException('Cannot perform operation: ' . $e->getMessage());
+        } catch (DefuseCryptoException $e) {
+            throw new CryptoException('Cannot perform operation: ' . $e->getMessage(), $e->getCode(), $e);
         }
     }
 

--- a/src/Crypto/EncryptedValue.php
+++ b/src/Crypto/EncryptedValue.php
@@ -13,6 +13,7 @@
 
 namespace Eventum\Crypto;
 
+use Defuse\Crypto\Exception\CryptoException as DefuseCryptoException;
 use Throwable;
 
 /**
@@ -65,7 +66,11 @@ final class EncryptedValue
             throw new CryptoException('Value not initialized yet');
         }
 
-        return CryptoManager::decrypt($this->ciphertext);
+        try {
+            return CryptoManager::decrypt($this->ciphertext);
+        } catch (DefuseCryptoException $e) {
+            throw new CryptoException($e->getMessage(), $e->getCode(), $e);
+        }
     }
 
     /**

--- a/tests/Crypto/CryptoTest.php
+++ b/tests/Crypto/CryptoTest.php
@@ -163,14 +163,4 @@ class CryptoTest extends TestCase
         $trace = $f($value);
         $this->assertNotContains($plaintext, $trace);
     }
-
-    public function testZendCrypt(): void
-    {
-        $key = 'secretkeyvalue';
-        $method = 'aes-128-cbc';
-        $keysize = 16;
-        $hash_function = 'sha256';
-        $ENCRYPTION_INFO = 'DefusePHP|KeyForEncryption';
-//        $ekey = self::HKDF($hash_function, $key, $keysize, $ENCRYPTION_INFO);
-    }
 }

--- a/tests/Crypto/CryptoTest.php
+++ b/tests/Crypto/CryptoTest.php
@@ -18,7 +18,6 @@ use Eventum\Crypto\CryptoManager;
 use Eventum\Crypto\EncryptedValue;
 use Eventum\Test\TestCase;
 use Exception;
-use InvalidArgumentException;
 
 /**
  * @group crypto
@@ -101,26 +100,6 @@ class CryptoTest extends TestCase
     {
         $encrypted = CryptoManager::encrypt('');
         $this->assertNotEmpty($encrypted);
-    }
-
-    /**
-     * should not encrypt null
-     *
-     * @expectedException InvalidArgumentException
-     */
-    public function testEncryptNull(): void
-    {
-        CryptoManager::encrypt(null);
-    }
-
-    /**
-     * should not encrypt false
-     *
-     * @expectedException InvalidArgumentException
-     */
-    public function testEncryptFalse(): void
-    {
-        CryptoManager::encrypt(false);
     }
 
     /**

--- a/tests/Crypto/CryptoTest.php
+++ b/tests/Crypto/CryptoTest.php
@@ -99,7 +99,8 @@ class CryptoTest extends TestCase
      */
     public function testEncryptEmptyString(): void
     {
-        CryptoManager::encrypt('');
+        $encrypted = CryptoManager::encrypt('');
+        $this->assertNotEmpty($encrypted);
     }
 
     /**
@@ -123,19 +124,21 @@ class CryptoTest extends TestCase
     }
 
     /**
-     * encrypt "0" is ok
+     * encrypt "0" (string) is ok
      */
     public function testEncryptZeroString(): void
     {
-        CryptoManager::encrypt('0');
+        $encrypted = CryptoManager::encrypt('0');
+        $this->assertNotEmpty($encrypted);
     }
 
     /**
-     * encrypt 0 is ok
+     * encrypt 0 (number) is ok
      */
-    public function testEncryptZero(): void
+    public function testEncryptZeroNumber(): void
     {
-        CryptoManager::encrypt(0);
+        $encrypted = CryptoManager::encrypt(0);
+        $this->assertNotEmpty($encrypted);
     }
 
     /**


### PR DESCRIPTION
We want that exceptions thrown from crypto subsystem throw `Eventum\Crypto\CryptoException`

This worked if `Defuse\Crypto\Exception\CryptoException` was thrown, but not its subclasses.