### PR TITLE
Resolve Doctrine ORM 3.0 EntityManager::detach deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Resolve Doctrine ORM 3.0 EntityManager::detach deprecation, #1035
+
 [3.10.6]: https://github.com/eventum/eventum/compare/v3.10.5...master
 
 ## [3.10.5] - 2021-04-27

--- a/tests/Scm/TestCase.php
+++ b/tests/Scm/TestCase.php
@@ -88,10 +88,10 @@ abstract class TestCase extends WebTestCase
 
         // flush cache to ensure doctrine has to fetch from db
         foreach ($commit->getFiles() as $file) {
-            $em->detach($file);
+            $em->clear(get_class($file));
         }
-        $em->detach($commit);
-        $em->detach($commit->getIssue());
+        $em->clear(get_class($commit));
+        $em->clear(get_class($commit->getIssue()));
 
         return $commit;
     }


### PR DESCRIPTION
```
  6x: Method Doctrine\ORM\EntityManager::detach() is deprecated and will be removed in Doctrine ORM 3.0.
    6x in CommitTest::setUp from Eventum\Test\Scm
```

refs:
- https://github.com/eventum/eventum/runs/2231927632?check_suite_focus=true