### PR TITLE
Use random_bytes() rather RandomLib library

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ See [Upgrading] for details on how to upgrade.
 - Use logger via Symfony container, #1029
 - Fix twig deprecation, #1038
 - Fix markdown `heading_permalink` deprecation, #1037
+- Use `random_bytes()` rather RandomLib library, #1036
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -51,7 +51,7 @@ class Auth
     public static function generatePrivateKey(): void
     {
         $path = Setup::getPrivateKeyPath();
-        $private_key = md5(Misc::generateRandom(32));
+        $private_key = md5(random_bytes(32));
 
         $contents = '<' . "?php\n\$private_key = " . var_export($private_key, 1) . ";\n";
 

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -541,10 +541,7 @@ class Misc
      */
     public static function generateRandom($size = 32)
     {
-        $factory = new RandomLib\Factory();
-        $generator = @$factory->getMediumStrengthGenerator();
-
-        return $generator->generate($size);
+        return random_bytes($size);
     }
 
     /**

--- a/src/Mail/MessageIdGenerator.php
+++ b/src/Mail/MessageIdGenerator.php
@@ -13,8 +13,6 @@
 
 namespace Eventum\Mail;
 
-use Misc;
-
 class MessageIdGenerator
 {
     /** @var string */
@@ -36,7 +34,7 @@ class MessageIdGenerator
         $first = microtime(true);
 
         // second part is random string
-        $second = bin2hex(Misc::generateRandom(16));
+        $second = bin2hex(random_bytes(16));
 
         return $this->format($first, $second);
     }


### PR DESCRIPTION
Deprecate use of `ircmaxell/random-lib`, use [random_bytes](https://www.php.net/random_bytes) from php 7.0