### PR TITLE
Fix markdown heading_permalink deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ See [Upgrading] for details on how to upgrade.
 - Fix catching Defuse CryptoException, #1034
 - Use logger via Symfony container, #1029
 - Fix twig deprecation, #1038
+- Fix markdown `heading_permalink` deprecation, #1037
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/src/ServiceProvider/MarkdownServiceProvider.php
+++ b/src/ServiceProvider/MarkdownServiceProvider.php
@@ -77,7 +77,7 @@ class MarkdownServiceProvider implements ServiceProviderInterface
             'allow_unsafe_links' => false,
             'max_nesting_level' => self::MAX_NESTING_LEVEL,
             'heading_permalink' => [
-                'inner_contents' => '¶',
+                'symbol' => '¶',
                 'insert' => 'after',
             ],
 


### PR DESCRIPTION
The `inner_contents` config option is deprecated; use `symbol` instead:
- https://github.com/thephpleague/commonmark/pull/506