### PR TITLE
Fix twig deprecation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ See [Upgrading] for details on how to upgrade.
 - Deprecate EventManager class, #1033
 - Fix catching Defuse CryptoException, #1034
 - Use logger via Symfony container, #1029
+- Fix twig deprecation, #1038
 
 [3.10.2]: https://github.com/eventum/eventum/compare/v3.10.1...master
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -24,7 +24,7 @@
 		<env name="KERNEL_CLASS" value="Eventum\Kernel"/>
 		<server name="SYMFONY_PHPUNIT_VERSION" value="7.5" />
 		<!-- https://symfony.com/doc/4.4/components/phpunit_bridge.html#configuration -->
-		<server name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=34&amp;max[self]=2&amp;max[direct]=27&amp;max[indirect]=4&amp;verbose=1" />
+		<server name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=32&amp;max[self]=2&amp;max[direct]=27&amp;max[indirect]=2&amp;verbose=1" />
 	<!--
 		<ini name="date.timezone" value="UTC" />
 		<server name="KERNEL_DIR" value="/path/to/your/app/" />

--- a/res/packages/test/twig.yml
+++ b/res/packages/test/twig.yml
@@ -1,4 +1,5 @@
 twig:
   strict_variables: true
+  exception_controller: null
 
 # vim:ts=2:sw=2:et


### PR DESCRIPTION
The "twig.exception_controller" configuration key has been deprecated in
Symfony 4.4, set it to "null" and use "framework.error_controller"
configuration key instead.

- https://github.com/symfony/symfony/blob/4.4/UPGRADE-4.4.md#twigbundle
- https://github.com/symfony/symfony/issues/34493