### PR TITLE
Fix DynamicCustomFieldController accessing repository too soon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix `DynamicCustomFieldController` accessing repository too soon, #1041
+
 [3.10.3]: https://github.com/eventum/eventum/compare/v3.10.2...master
 
 ## [3.10.2] - 2021-04-01


### PR DESCRIPTION
`/ajax/dynamic_custom_field.js.php?form_type=report_form`:

> Uncaught LogicException: Access to EntityManagerInterface forbidden when Kernel is booting

refs: #1026