### PR TITLE
Use pre-built docker image

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,10 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Build release tarball
+        env:
+          BUILD_IMAGE: ghcr.io/eventum/eventum:release-image
         run: |
-          docker build . -f bin/releng/Dockerfile -t releng --target=releng
-          docker run -v $(pwd):/app releng bin/releng/dist.sh
+          docker run -v $(pwd):/app $BUILD_IMAGE bin/releng/dist.sh
 
       # https://github.com/actions/upload-artifact
       - uses: actions/upload-artifact@v2

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -44,7 +44,7 @@ RUN bin/releng/locales.sh
 
 COPY Makefile .
 COPY bin/releng/tools.sh ./bin/releng/tools.sh
-RUN bin/releng/tools.sh
+RUN bin/releng/tools.sh /usr/bin
 
 # docker build . -f bin/releng/Dockerfile -t app --target=stage-release
 FROM releng AS stage-release

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -265,9 +265,6 @@ prepare_source() {
 	phplint
 }
 
-# download tools
-make phpcompatinfo.phar phing.phar
-
 composer=$(find_prog composer)
 phpcompatinfo=$(find_prog phpcompatinfo)
 phing=$(find_prog phing)

--- a/bin/releng/dist.sh
+++ b/bin/releng/dist.sh
@@ -7,9 +7,6 @@ if [ -f "$DOCKER_ENV_LOAD" ]; then
 	. "$DOCKER_ENV_LOAD"
 fi
 
-bin/releng/tools.sh
-bin/releng/locales.sh
-
 # need to fetch tags first for release process
 git fetch origin --unshallow "+refs/tags/v*:refs/tags/v*"
 

--- a/bin/releng/tools.sh
+++ b/bin/releng/tools.sh
@@ -3,20 +3,15 @@
 # install tools necessary for CI
 #
 
-cachedir=$(pwd)/cache
-install -d $cachedir
+destdir="$1"
 
 # copy tool from cache
 # or download and put it to cache
 get() {
-	local tool=$1
-	local cachefile=$cachedir/$tool
-	if [ -e $cachefile ]; then
-		cp -p $cachefile .
-	else
-		make $tool
-		cp -p $tool $cachedir
-	fi
+	local tool="$1"
+
+	make $tool
+	cp -p $tool $destdir
 }
 
 get php-cs-fixer.phar

--- a/bin/releng/tools.sh
+++ b/bin/releng/tools.sh
@@ -14,7 +14,5 @@ get() {
 	cp -p $tool $destdir
 }
 
-get php-cs-fixer.phar
 get phpcompatinfo.phar
-get box.phar
 get phing.phar


### PR DESCRIPTION
This should speed up the build by using a pre-built docker image for the release process.

Before: 8m: https://github.com/eventum/eventum/runs/2252437914
After: 3m: https://github.com/eventum/eventum/pull/1043/checks?check_run_id=2261951583