### PR TITLE
Travis: Use pre-built image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
       script:
         - docker --version
         - BUILD_IMAGE=ghcr.io/eventum/eventum:release-image
+        - unset LANG LANGUAGE LC_ALL
         - export -p > env.sh
         - docker run -v $(pwd):/app -e DOCKER_ENV_LOAD=./env.sh $BUILD_IMAGE bin/releng/dist.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,9 @@ jobs:
       name: GitHub Release
       script:
         - docker --version
-        - docker build . -f bin/releng/Dockerfile -t releng --target=releng
+        - BUILD_IMAGE=ghcr.io/eventum/eventum:release-image
         - export -p > env.sh
-        - docker run -v $(pwd):/app -e DOCKER_ENV_LOAD=./env.sh releng bin/releng/dist.sh
+        - docker run -v $(pwd):/app -e DOCKER_ENV_LOAD=./env.sh $BUILD_IMAGE bin/releng/dist.sh
 
       # https://docs.travis-ci.com/user/deployment/releases
       # https://docs.travis-ci.com/user/build-stages/deploy-github-releases/

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "47c751c5adf718e08cc731d7a038a790",
+    "content-hash": "597ab8c540a7389fa187ca6bcc27ae35",
     "packages": [
         {
             "name": "cakephp/core",


### PR DESCRIPTION
Fix Travis release after https://github.com/eventum/eventum/pull/1043.

We still use Travis to make snapshot and releases.