### PR TITLE
Fix 500 error on /ajax/dynamic_custom_field.js.php?form_type=report_form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 See [Upgrading] for details on how to upgrade.
 
-- Fix `DynamicCustomFieldController` accessing repository too soon, #1041
+- Fix `DynamicCustomFieldController` accessing repository too soon, #1041, #1061
 - Refactor: Add LazyProperties to AbstractMigration, #1042
 - Remove leftovers from mnapoli/silly from commands, #1040
 

--- a/src/Controller/Ajax/DynamicCustomFieldController.php
+++ b/src/Controller/Ajax/DynamicCustomFieldController.php
@@ -68,10 +68,12 @@ class DynamicCustomFieldController extends AjaxBaseController
 
     private function getData(): array
     {
+        $repo = $this->repository->getCustomFieldRepository();
+
         if ($this->issue_id) {
-            $customFields = $this->customFieldRepository->getListByIssue($this->prj_id, $this->issue_id, $this->role_id, null, true);
+            $customFields = $repo->getListByIssue($this->prj_id, $this->issue_id, $this->role_id, null, true);
         } else {
-            $customFields = $this->customFieldRepository->getListByProject($this->prj_id, $this->role_id, $this->form_type, null, true);
+            $customFields = $repo->getListByProject($this->prj_id, $this->role_id, $this->form_type, null, true);
         }
 
         $data = [];

--- a/src/Controller/Ajax/DynamicCustomFieldController.php
+++ b/src/Controller/Ajax/DynamicCustomFieldController.php
@@ -15,14 +15,9 @@ namespace Eventum\Controller\Ajax;
 
 use Auth;
 use Eventum\CustomField\Fields\DynamicCustomFieldInterface;
-use Eventum\Db\Doctrine;
-use Eventum\Model\Repository\CustomFieldRepository;
-use LazyProperty\LazyPropertiesTrait;
 
 class DynamicCustomFieldController extends AjaxBaseController
 {
-    use LazyPropertiesTrait;
-
     /** @var string */
     protected $tpl_name = 'js/dynamic_custom_field.tpl.js';
     /** @var int */
@@ -31,18 +26,12 @@ class DynamicCustomFieldController extends AjaxBaseController
     private $issue_id;
     /** @var string */
     private $form_type;
-    /** @var CustomFieldRepository */
-    private $customFieldRepository;
 
     /**
      * {@inheritdoc}
      */
     protected function configure(): void
     {
-        $this->initLazyProperties([
-            /** @see getCustomFieldRepository */
-            'customFieldRepository',
-        ]);
         $request = $this->getRequest();
 
         $this->issue_id = $request->request->getInt('iss_id') ?: $request->query->getInt('iss_id');
@@ -102,10 +91,5 @@ class DynamicCustomFieldController extends AjaxBaseController
     protected function prepareTemplate(): void
     {
         $this->tpl->assign('fields', $this->getData());
-    }
-
-    private function getCustomFieldRepository(): CustomFieldRepository
-    {
-        return Doctrine::getCustomFieldRepository();
     }
 }

--- a/src/Controller/Helper/RepositoryHelper.php
+++ b/src/Controller/Helper/RepositoryHelper.php
@@ -15,6 +15,7 @@ namespace Eventum\Controller\Helper;
 
 use Eventum\Db\Doctrine;
 use Eventum\Model\Entity\UserPreference;
+use Eventum\Model\Repository\CustomFieldRepository;
 
 class RepositoryHelper
 {
@@ -24,5 +25,10 @@ class RepositoryHelper
     public function getUserPreferences(): UserPreference
     {
         return Doctrine::getUserPreferenceRepository()->findOrCreate($this->usr_id);
+    }
+
+    public function getCustomFieldRepository(): CustomFieldRepository
+    {
+        return Doctrine::getCustomFieldRepository();
     }
 }


### PR DESCRIPTION
Apparently can't have two __get() handlers:
- lazy properties
- controller helpers

So, use existing 'repository' helper to get access to CustomFieldRepository.

This is another fix to #1041