### PR TITLE
Add HelperTrait to register all lazy properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 See [Upgrading] for details on how to upgrade.
 
 - Fix JavaScript error on Add time tracking page, #1064
+- Add HelperTrait to register all lazy properties, #1062
 
 [3.10.4]: https://github.com/eventum/eventum/compare/v3.10.3...master
 

--- a/src/Controller/Helper/HelperTrait.php
+++ b/src/Controller/Helper/HelperTrait.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Controller\Helper;
+
+use LazyProperty\LazyPropertiesTrait;
+
+trait HelperTrait
+{
+    use LazyPropertiesTrait;
+
+    private function initHelpers(): void
+    {
+        $this->initLazyProperties([
+            /** @see getAssign */
+            'assign',
+            /** @see getAttach */
+            'attach',
+            /** @see getCsrf */
+            'csrf',
+            /** @see getDb */
+            'db',
+            /** @see getHtml */
+            'html',
+            /** @see getLogger */
+            'logger',
+            /** @see getMessages */
+            'messages',
+            /** @see getPlot */
+            'plot',
+            /** @see getRepository */
+            'repository',
+        ]);
+    }
+
+    protected function getAssign(): AssignHelper
+    {
+        return new AssignHelper();
+    }
+
+    protected function getAttach(): AttachHelper
+    {
+        return new AttachHelper();
+    }
+
+    protected function getCsrf(): CsrfHelper
+    {
+        return new CsrfHelper();
+    }
+
+    protected function getDb(): DbHelper
+    {
+        return new DbHelper();
+    }
+
+    protected function getHtml(): HtmlHelper
+    {
+        return new HtmlHelper();
+    }
+
+    protected function getLogger(): LoggerHelper
+    {
+        return new LoggerHelper();
+    }
+
+    protected function getMessages(): MessagesHelper
+    {
+        return new MessagesHelper();
+    }
+
+    protected function getPlot(): PlotHelper
+    {
+        return new PlotHelper();
+    }
+
+    protected function getRepository(): RepositoryHelper
+    {
+        return new RepositoryHelper();
+    }
+}

--- a/src/Controller/Helper/HelperTrait.php
+++ b/src/Controller/Helper/HelperTrait.php
@@ -21,7 +21,8 @@ trait HelperTrait
 
     private function initHelpers(): void
     {
-        $this->initLazyProperties([
+        $lazyProperties = property_exists($this, 'lazyProperties') ? $this->lazyProperties : [];
+        $lazyProperties += [
             /** @see getAssign */
             'assign',
             /** @see getAttach */
@@ -40,7 +41,8 @@ trait HelperTrait
             'plot',
             /** @see getRepository */
             'repository',
-        ]);
+        ];
+        $this->initLazyProperties($lazyProperties);
     }
 
     protected function getAssign(): AssignHelper


### PR DESCRIPTION
This replaces one magic with another magic, which is maybe less magical, but still magical.

This allows controllers to define lazy properties without conflicting with base lazy properties:

```php
private $lazyProperties = ['fieldname', 'fieldname2'];
```