### PR TITLE
Fix JavaScript error on Add time tracking page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix JavaScript error on Add time tracking page, #1064
+
 [3.10.4]: https://github.com/eventum/eventum/compare/v3.10.3...master
 
 ## [3.10.3] - 2021-04-19

--- a/templates/time_tracking_entry.tpl.html
+++ b/templates/time_tracking_entry.tpl.html
@@ -66,12 +66,12 @@ function validateTimeForm()
     }
 
     var now = new Date();
-    var d1 = makeDate(f, 'date');
+    var d1 = Eventum.makeDate('date');
     if (d1 > now) {
         alert('{t}Start time in the future.{/t}');
         return false;
     }
-    var d2 = makeDate(f, 'date2');
+    var d2 = Eventum.makeDate('date2');
     if (d2 > now) {
         alert('{t}End time in the future.{/t}');
         return false;


### PR DESCRIPTION
Error was caught by Sentry integration ;)

```
ReferenceError: makeDate is not defined
  at HTMLFormElement.validateTimeForm (/time_tracking.php:197:14)
  at HTMLFormElement.dispatch (/js/components.js:1:28262)
  at HTMLFormElement._.handle (/js/components.js:1:24974)
  at HTMLFormElement.r (/js/raven.js:1:4665)
```

Testing:
1. add time entry, set start time in future
2. add time entry, set end time in the future