### PR TITLE
Update fastify/github-action-merge-dependabot v1 -> v2.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     needs: test
     runs-on: ubuntu-20.04
     steps:
-      - uses: fastify/github-action-merge-dependabot@v1
+      - uses: fastify/github-action-merge-dependabot@v2.0.0
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This avoids error like:
- https://github.com/fastify/github-action-merge-dependabot/issues/27