### PR TITLE
Fix attachments corruption when attached to emails from web

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Upgrading] for details on how to upgrade.
 - Add HelperTrait to register all lazy properties, #1062, #1069, #1070
 - Add `ISSUE_CREATE_PARAMS` event when creating new issue, #1063, #1072
 - Validate from/to/cc headers before submiting email from web, #1075
+- Fix attachments corruption when attached to emails from web, #1068, #1076
 
 [3.10.4]: https://github.com/eventum/eventum/compare/v3.10.3...master
 

--- a/src/Mail/Helper/MimePart.php
+++ b/src/Mail/Helper/MimePart.php
@@ -47,6 +47,7 @@ class MimePart extends Mime\Part
     {
         return self::create($content, $type)
             ->setDisposition(Mime\Mime::DISPOSITION_ATTACHMENT)
+            ->setEncoding(Mime\Mime::ENCODING_BASE64)
             ->setFileName($filename);
     }
 }


### PR DESCRIPTION
Fixes https://github.com/eventum/eventum/issues/1068

Testing:
1. open issue in eventum web
2. click send email button on bottom of the page
3. in the popup window choose attach a file (attachment area)
4. send the email
5. in refreshed issue view page click on the email that was just sent
6. from there download the attachment
7. compare the attachment md5 with the file that was uploaded