### PR TITLE
Add optional Secure attribute for Eventum cookies

### DIFF
--- a/lib/eventum/class.auth.php
+++ b/lib/eventum/class.auth.php
@@ -453,10 +453,11 @@ class Auth
         $config = ServiceContainer::getConfig();
         $cookieDomain = $config['cookie_domain'];
         $cookiePath = $config['cookie_path'];
+        $cookieSecure = $config['cookie_secure'];
         if ($cookieDomain) {
-            setcookie($name, $value, $expiration, $cookiePath, $cookieDomain);
+            setcookie($name, $value, $expiration, $cookiePath, $cookieDomain, $cookieSecure);
         } else {
-            setcookie($name, $value, $expiration, $cookiePath);
+            setcookie($name, $value, $expiration, $cookiePath, "", $cookieSecure);
         }
     }
 

--- a/lib/eventum/class.setup.php
+++ b/lib/eventum/class.setup.php
@@ -353,6 +353,7 @@ class Setup
             'short_name' => 'Eventum',
             'tool_caption' => 'Eventum',
             'cookie' => 'eventum',
+            'cookie_secure' => false,
             'relative_url' => '/',
             'monitor' => [
                 'diskcheck' => [


### PR DESCRIPTION
Add optional Secure attribute for Eventum cookies. 

Justification: having secure cookies attribute might be useful given coming changes in browsers behaviour -
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite#browser_compatibility

SameSite is a different problem and might need a different/better patch.