### PR TITLE
Update fastify/github-action-merge-dependabot 2.0.2 -> v2.1.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -140,7 +140,7 @@ jobs:
     needs: test
     runs-on: ubuntu-20.04
     steps:
-      - uses: fastify/github-action-merge-dependabot@v2.0.0
+      - uses: fastify/github-action-merge-dependabot@v2.1.1
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
refs:
- https://github.com/fastify/github-action-merge-dependabot/commit/8ddd309b3f1e89233ff236e2c7fa9fd4f212e5ef


> ⚠️UPGRADE NEEDED
>  
> **Version v2.0.0 will stop working on 1st August 2021**. If you are using version v2.0.0, you must upgrade to the latest version. 