### PR TITLE
Use correct namespace and path for the extension example

### DIFF
--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
  * To enable this extension, write to config/setup.php:
  *
  * 'extensions' => [
- *   'Example\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
+ *   'Example\\ExampleExtension' => '/path/to/eventum/docs/examples/extension/ExampleExtension.php',
  * ],
  */
 class ExampleExtension implements

--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -26,7 +26,7 @@ use Symfony\Component\DependencyInjection\Loader\Configurator\ContainerConfigura
  * To enable this extension, write to config/setup.php:
  *
  * 'extensions' => [
- *   'Eventum\\Extension\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
+ *   'Example\\ExampleExtension' => '/path/to/this/file/ExampleExtension.php',
  * ],
  */
 class ExampleExtension implements


### PR DESCRIPTION
`ExampleExtension` class is defined in `Example` namespace so fix the namespaced reference and the file path hardcoded in the 
extension loader function.