### PR TITLE
Remove hard coded extension path from Example extension

### DIFF
--- a/docs/examples/extension/ExampleExtension.php
+++ b/docs/examples/extension/ExampleExtension.php
@@ -62,7 +62,7 @@ class ExampleExtension implements
             'Pimple\\' => $phpDir,
         ];
         $psr4 = [
-            'Example\\' => [$baseDir . '/docs/examples/extension'],
+            'Example\\' => [self::EXTENSION_DIR],
         ];
 
         $files = [


### PR DESCRIPTION
Current Example extension path is almost hard coded in the autoloader function. 
Moving ExampleExtension outside docs/ causes hard to understand errors.