### PR TITLE
Make "Inactive DN" parameter optional as the Help page says

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details on how to upgrade.
 [3.10.7]: https://github.com/eventum/eventum/compare/v3.10.6...master
 
 - Hide the search input on single selects if there are 10 or fewer options, #1200
+- Make LDAP "Inactive DN" parameter optional, #1208
 
 ## [3.10.6] - 2021-08-03
 

--- a/src/Auth/Adapter/LdapAdapter.php
+++ b/src/Auth/Adapter/LdapAdapter.php
@@ -72,7 +72,7 @@ class LdapAdapter implements AdapterInterface
         $this->default_role = $config['default_role'];
         $this->create_users = (bool)$config['create_users'];
 
-        if (!$this->active_dn || !$this->inactive_dn) {
+        if (!$this->active_dn) {
             throw new AuthException('LDAP Adapter not configured');
         }
     }


### PR DESCRIPTION
Make "Inactive DN" parameter optional as the [Help](https://github.com/eventum/eventum/blob/a149ed43f345c17570ce3aadeb4d819b81333d10/docs/help/ldap.md) page says. 

Eventum hides "Customize LDAP Config" page if the parameter is not set. `bin/console.php eventum:ldap:sync` fails as well.