### PR TITLE
Add loose email validation in LdapSyncCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Upgrading] for details on how to upgrade.
 
 - Hide the search input on single selects if there are 10 or fewer options, #1200
 - Make LDAP "Inactive DN" parameter optional, #1208
+- Add loose email validation in LdapSyncCommand, #1209
 
 ## [3.10.6] - 2021-08-03
 

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -147,8 +147,9 @@ class LdapSyncCommand extends BaseCommand
     {
         $users = $this->ldap->getUserListing($dn);
         foreach ($users as $user) {
+            $emails = $user->getEmails();
             // skip entries with no email
-            if (!$user->getEmails()) {
+            if (!$this->findValidEmail($emails)) {
                 $uid = $user->getUid();
                 $this->writeln("skip (no email): $uid", OutputInterface::VERBOSITY_VERBOSE);
                 continue;
@@ -156,6 +157,23 @@ class LdapSyncCommand extends BaseCommand
 
             yield $user;
         }
+    }
+
+    /**
+     * Find a valid email
+     *
+     * @param string[] $emails
+     * @return string|null
+     */
+    private function findValidEmail(array $emails): ?string
+    {
+        foreach ($emails as $email) {
+            if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
+                return $email;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -149,7 +149,7 @@ class LdapSyncCommand extends BaseCommand
         foreach ($users as $user) {
             $emails = $user->getEmails();
             // skip entries with no email
-            if (!$this->findValidEmail($emails)) {
+            if (!$this->hasValidEmail($emails)) {
                 $uid = $user->getUid();
                 $this->writeln("skip (no email): $uid", OutputInterface::VERBOSITY_VERBOSE);
                 continue;
@@ -160,20 +160,20 @@ class LdapSyncCommand extends BaseCommand
     }
 
     /**
-     * Find a valid email
+     * Return true if at least one valid email found
      *
      * @param string[] $emails
-     * @return string|null
+     * @return bool
      */
-    private function findValidEmail(array $emails): ?string
+    private function hasValidEmail(array $emails): bool
     {
         foreach ($emails as $email) {
             if (filter_var($email, FILTER_VALIDATE_EMAIL)) {
-                return $email;
+                return true;
             }
         }
 
-        return null;
+        return false;
     }
 
     /**


### PR DESCRIPTION
Skip LDAP user entries with no single valid email. This patch adds a loose check there is at least one valid email.