### PR TITLE
Make user notification on account creation optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ See [Upgrading] for details on how to upgrade.
 
 - Hide the search input on single selects if there are 10 or fewer options, #1200
 - Make LDAP "Inactive DN" parameter optional, #1208
+- Make user notification on account creation optional, #1210
 
 ## [3.10.6] - 2021-08-03
 

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -1079,9 +1079,10 @@ class User
      * Method used to add a new user to the system.
      *
      * @param   array $user The array of user information
+     * @param   bool $notify
      * @return  int usr_id being created
      */
-    public static function insert(array $user)
+    public static function insert(array $user, $notify = true)
     {
         $params = [
             $user['customer_id'] ?? null,
@@ -1130,8 +1131,8 @@ class User
             }
         }
 
-        // send email to user only if password is set
-        if (isset($user['password']) && $user['password'] !== '') {
+        // send email to user
+        if ($notify == true) {
             Notification::notifyNewUser($usr_id, $user['password']);
         }
 

--- a/lib/eventum/class.user.php
+++ b/lib/eventum/class.user.php
@@ -1130,8 +1130,10 @@ class User
             }
         }
 
-        // send email to user
-        Notification::notifyNewUser($usr_id, $user['password']);
+        // send email to user only if password is set
+        if (isset($user['password']) && $user['password'] !== '') {
+            Notification::notifyNewUser($usr_id, $user['password']);
+        }
 
         // add user id and do not expose password to event
         $user['id'] = (int)$usr_id;


### PR DESCRIPTION
Do not send email notice if user password is not set. 
If user accounts are created outside Eventum e.g. in LDAP and then ldapsync'ed then there is no reason to send email notice with
empty password.