### PR TITLE
Add example command for extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,6 +47,7 @@ See [Upgrading] for details on how to upgrade.
 - Fix `DynamicCustomFieldController` accessing repository too soon, #1041, #1061
 - Refactor: Add LazyProperties to AbstractMigration, #1042
 - Remove leftovers from mnapoli/silly from commands, #1040
+- Add example command for extension, #1216
 
 [3.10.3]: https://github.com/eventum/eventum/compare/v3.10.2...v3.10.3
 

--- a/docs/examples/extension/Console/Command/ExampleHelloCommand.php
+++ b/docs/examples/extension/Console/Command/ExampleHelloCommand.php
@@ -11,8 +11,9 @@
  * that were distributed with this source code.
  */
 
-namespace Eventum\Console\Command;
+namespace Example\Console\Command;
 
+use Eventum\Console\Command\BaseCommand;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 

--- a/docs/examples/extension/config/services.yml
+++ b/docs/examples/extension/config/services.yml
@@ -1,1 +1,12 @@
+services:
+  # default configuration for services in *this* file
+  _defaults:
+    autowire: true      # Automatically injects dependencies in your services.
+    autoconfigure: true # Automatically registers your services as commands, event subscribers, etc.
+
+  # makes classes in Console/Command/ available to be used as services
+  # this creates a service per class whose id is the fully-qualified class name
+  Example\Console\Command\:
+    resource: '../Console/Command/*'
+
 # vim:ts=4:sw=4:et

--- a/src/Console/Command/ExampleHelloCommand.php
+++ b/src/Console/Command/ExampleHelloCommand.php
@@ -1,0 +1,40 @@
+<?php
+
+/*
+ * This file is part of the Eventum (Issue Tracking System) package.
+ *
+ * @copyright (c) Eventum Team
+ * @license GNU General Public License, version 2 or later (GPL-2+)
+ *
+ * For the full copyright and license information,
+ * please see the COPYING and AUTHORS files
+ * that were distributed with this source code.
+ */
+
+namespace Eventum\Console\Command;
+
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+class ExampleHelloCommand extends BaseCommand
+{
+    public const DEFAULT_COMMAND = 'example:hello';
+
+    protected static $defaultName = 'eventum:' . self::DEFAULT_COMMAND;
+
+    protected function configure(): void
+    {
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $this->sayHello();
+
+        return 0;
+    }
+
+    private function sayHello(): void
+    {
+        $this->writeln('<info>Hello world!</info>');
+    }
+}


### PR DESCRIPTION
Here is an example command I trying to add to a release of Eventum, but I get 
the error:

```
[eventumtest Command]$ /eventum/bin/console.php eventum:example:hello
  There are no commands defined in the "eventum:example" namespace.
..
```
Not sure I understand how to add custom console commands.