### PR TITLE
LdapSyncCommand: disable users missing in LDAP Active DN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Upgrading] for details on how to upgrade.
 - Make user notification on account creation optional, #1210
 - Add loose email validation in LdapSyncCommand, #1209
 - Add an option to tune notifications on account inserts in LdapSyncCommand, #1211
-- LdapSyncCommand: Disable users which are not found in LDAP Active DN, #1221
+- LdapSyncCommand: Disable users missing from LDAP Active DN, #1221
 
 [3.10.7]: https://github.com/eventum/eventum/compare/v3.10.6...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ See [Upgrading] for details on how to upgrade.
 - Make user notification on account creation optional, #1210
 - Add loose email validation in LdapSyncCommand, #1209
 - Add an option to tune notifications on account inserts in LdapSyncCommand, #1211
-- LdapSyncCommand: Add an option to disable missed LDAP users, #1221
+- LdapSyncCommand: Disable users which are not found in LDAP Active DN, #1221
 
 [3.10.7]: https://github.com/eventum/eventum/compare/v3.10.6...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ See [Upgrading] for details on how to upgrade.
 - Make user notification on account creation optional, #1210
 - Add loose email validation in LdapSyncCommand, #1209
 - Add an option to tune notifications on account inserts in LdapSyncCommand, #1211
+- LdapSyncCommand: Add an option to disable missed LDAP users, #1221
 
 [3.10.7]: https://github.com/eventum/eventum/compare/v3.10.6...master
 

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -40,6 +40,7 @@ class LdapSyncCommand extends BaseCommand
         $this
             ->addOption('dry-run', null, InputOption::VALUE_NONE)
             ->addOption('create-users', null, InputOption::VALUE_NONE)
+            ->addOption('disable-missed', null, InputOption::VALUE_NONE)
             ->addOption('no-update', null, InputOption::VALUE_NONE)
             ->addOption('no-disable', null, InputOption::VALUE_NONE)
             ->addOption('no-notify', null, InputOption::VALUE_NONE);
@@ -52,6 +53,7 @@ class LdapSyncCommand extends BaseCommand
         $noUpdate = $input->getOption('no-update');
         $noDisable = $input->getOption('no-disable');
         $noNotify = $input->getOption('no-notify');
+        $disableMissed = $input->getOption('disable-missed');
 
         $this->dryrun = $dryrun;
 
@@ -64,6 +66,7 @@ class LdapSyncCommand extends BaseCommand
 
         $this->updateUsers(!$noUpdate);
         $this->disableUsers(!$noDisable);
+        $this->disableMissedUsers($disableMissed);
 
         return 0;
     }
@@ -94,6 +97,38 @@ class LdapSyncCommand extends BaseCommand
                 $this->updateLocalUserFromBackend($uid);
             } catch (AuthException $e) {
                 $this->writeln("<error>ERROR</error>: <info>$uid</info>: {$e->getMessage()}");
+            }
+        }
+    }
+
+    /**
+     * Process active users missed from ldap
+     *
+     * @param bool $enabled
+     */
+    private function disableMissedUsers($enabled): void
+    {
+        if (!$enabled || !$this->ldap->active_dn) {
+            $this->writeln('Skip missed users');
+
+            return;
+        }
+
+        $users = User::getActiveAssocList();
+        foreach ($users as $usr_id => $name) {
+            $uid = User::getExternalID($usr_id);
+
+            if ($uid) {
+                // try to find user
+                $remote = $this->ldap->getLdapUser($uid);
+
+                // handle missed users
+                if ($remote === null) {
+                   $this->disableAccount("", $uid);
+                }
+            } else {
+                $email = User::getEmail($usr_id);
+                $this->writeln("<info>LDAP uid not found</info> for $usr_id, $email", self::VERY_VERBOSE);
             }
         }
     }

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -109,7 +109,7 @@ class LdapSyncCommand extends BaseCommand
     private function disableMissedUsers($enabled): void
     {
         if (!$enabled || !$this->ldap->active_dn) {
-            $this->writeln('Skip missed users');
+            $this->writeln('Skip Disable missed LDAP users', self::VERBOSE);
 
             return;
         }
@@ -141,7 +141,7 @@ class LdapSyncCommand extends BaseCommand
     private function disableUsers($enabled): void
     {
         if (!$enabled || !$this->ldap->inactive_dn) {
-            $this->writeln('Skipping disable users');
+            $this->writeln('Skipping disable inactive LDAP users');
 
             return;
         }

--- a/src/Console/Command/LdapSyncCommand.php
+++ b/src/Console/Command/LdapSyncCommand.php
@@ -40,7 +40,7 @@ class LdapSyncCommand extends BaseCommand
         $this
             ->addOption('dry-run', null, InputOption::VALUE_NONE)
             ->addOption('create-users', null, InputOption::VALUE_NONE)
-            ->addOption('disable-missed', null, InputOption::VALUE_NONE)
+            ->addOption('disable-missing', null, InputOption::VALUE_NONE)
             ->addOption('no-update', null, InputOption::VALUE_NONE)
             ->addOption('no-disable', null, InputOption::VALUE_NONE)
             ->addOption('no-notify', null, InputOption::VALUE_NONE);
@@ -53,7 +53,7 @@ class LdapSyncCommand extends BaseCommand
         $noUpdate = $input->getOption('no-update');
         $noDisable = $input->getOption('no-disable');
         $noNotify = $input->getOption('no-notify');
-        $disableMissed = $input->getOption('disable-missed');
+        $disableMissing = $input->getOption('disable-missing');
 
         $this->dryrun = $dryrun;
 
@@ -66,7 +66,7 @@ class LdapSyncCommand extends BaseCommand
 
         $this->updateUsers(!$noUpdate);
         $this->disableUsers(!$noDisable);
-        $this->disableMissedUsers($disableMissed);
+        $this->disableMissingUsers($disableMissing);
 
         return 0;
     }
@@ -102,14 +102,14 @@ class LdapSyncCommand extends BaseCommand
     }
 
     /**
-     * Process active users missed from ldap
+     * Process active users missing from ldap
      *
      * @param bool $enabled
      */
-    private function disableMissedUsers($enabled): void
+    private function disableMissingUsers($enabled): void
     {
         if (!$enabled || !$this->ldap->active_dn) {
-            $this->writeln('Skip Disable missed LDAP users', self::VERBOSE);
+            $this->writeln('Skip Disable missing LDAP users', self::VERBOSE);
 
             return;
         }
@@ -122,7 +122,7 @@ class LdapSyncCommand extends BaseCommand
                 // try to find user
                 $remote = $this->ldap->getLdapUser($uid);
 
-                // handle missed users
+                // handle missing users
                 if ($remote === null) {
                    $this->disableAccount("", $uid);
                 }


### PR DESCRIPTION
LdapSyncCommand lacks an option to search and disable Eventum users which are not found in LDAP Active DN. Current code expects to find inactive users in Inactive DN.

This patch proposes --disable-missed option to check active Eventum users against LDAP. Users which are not found in Active DN to be set inactive.