### PR TITLE
Docs: How to keep forked Eventum even with the upstream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,6 @@ How to update forked repository to be up to date with the `master`:
 - Switch to master `git checkout master`
 - Fetch latest changes `git fetch upstream`
 - Rebase for clean pull requests `git rebase -i upstream/master`
-- Update your forked repo `git push`
 - Do not make commits on your `master` branch
 
 ## Development

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,7 +37,7 @@ Commits follow good practices for message and content
 [good commit messages]: http://chris.beams.io/posts/git-commit/
 [atomic commits]: http://www.freshconsulting.com/atomic-commits/
 
-Keep your forked repository even with the master one
+How to update forked repository to be up to date with the `master`:
 - Check remotes `git remote -v`
 - Add Eventum as upstream `git remote add upstream https://github.com/eventum/eventum.git`
 - Switch to master `git checkout master`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ How to update forked repository to be up to date with the `master`:
 - Fetch latest changes `git fetch upstream`
 - Rebase for clean pull requests `git rebase upstream/master`
 - Update your forked repo `git push`
-- Do not work on `master` branch
+- Do not make commits on your `master` branch
 
 ## Development
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,15 @@ Commits follow good practices for message and content
 [good commit messages]: http://chris.beams.io/posts/git-commit/
 [atomic commits]: http://www.freshconsulting.com/atomic-commits/
 
+Keep your forked repository even with the master one
+- Check remotes `git remote -v`
+- Add Eventum as upstream `git remote add upstream https://github.com/eventum/eventum.git`
+- Switch to master `git checkout master`
+- Fetch latest changes `git fetch upstream`
+- Rebase for clean pull requests `git rebase upstream/master`
+- Update your forked repo `git push`
+- Do not work on `master` branch
+
 ## Development
 
 For asset compilation [laravel-mix] is used.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,7 @@ How to update forked repository to be up to date with the `master`:
 - Add Eventum as upstream `git remote add upstream https://github.com/eventum/eventum.git`
 - Switch to master `git checkout master`
 - Fetch latest changes `git fetch upstream`
-- Rebase for clean pull requests `git rebase upstream/master`
+- Rebase for clean pull requests `git rebase -i upstream/master`
 - Update your forked repo `git push`
 - Do not make commits on your `master` branch
 


### PR DESCRIPTION
How to keep forked Eventum even with the upstream