### PR TITLE
Fix `sort_by` not being filtered in search form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix `sort_by` not being filtered in search form, #1252
+
 [3.10.8]: https://github.com/eventum/eventum/compare/v3.10.7...master
 
 ## [3.10.7] - 2021-10-19

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -371,6 +371,15 @@ class Search
             $sort_by = Misc::escapeString($options['sort_by']);
         }
 
+        // default sort by option
+        $default_sort_by_option = ['last_action_date', 'pri_rank', 'iss_id', 'sta_rank', 'iss_summary'];
+        // check $sort_by
+        if (in_array($sort_by, $default_sort_by_options, true)) {
+            $sort_by = $sort_by;
+        } else {
+            $sort_by = '';
+        }
+
         $stmt .= '
                  GROUP BY
                     iss_id


### PR DESCRIPTION
Check sort_by value before query

Check the sort_by value in the request with the default table before entering the query.
Fix bug Time-Based Blind SQL Injection

- Disclosure: https://huntr.dev/bounties/668789af-8781-461c-99bb-d159e5a1d877/