### PR TITLE
Fix invalid input for advanced search sort_by

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 See [Upgrading] for details on how to upgrade.
 
-- Fix `sort_by` not being filtered in search form, #1252
+- Fix `sort_by` not being filtered in search form, #1252, #1255
 - Fix bug allowing to execute arbitrary JavaScript in SVG files, #1251
 
 [3.10.8]: https://github.com/eventum/eventum/compare/v3.10.7...master

--- a/lib/eventum/class.db_helper.php
+++ b/lib/eventum/class.db_helper.php
@@ -92,6 +92,7 @@ class DB_Helper
      * @param   string $str The string that needs to be escaped
      * @param   bool $add_quotes Whether to add quotes around result as well
      * @return  string The escaped string
+     * @deprecated Using this is bad design, must use placeholders in query
      */
     public static function escapeString($str, $add_quotes = false): string
     {

--- a/lib/eventum/class.misc.php
+++ b/lib/eventum/class.misc.php
@@ -289,7 +289,7 @@ class Misc
      *
      * @param   string|array $input The original string
      * @return  string|array The escaped (or not) string
-     * @deprecated Using this is bad design, must use placeholders in query
+     * @deprecated Using this is bad design, must use placeholders in query. and $add_quote=false is unsafe if used improperly
      */
     public static function escapeString($input, $add_quotes = false)
     {

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -371,15 +371,6 @@ class Search
             $sort_by = Misc::escapeString($options['sort_by']);
         }
 
-        // default sort by option
-        $default_sort_by_options = ['last_action_date', 'pri_rank', 'iss_id', 'sta_rank', 'iss_summary'];
-        // check $sort_by
-        if (in_array($sort_by, $default_sort_by_options, true)) {
-            $sort_by = $sort_by;
-        } else {
-            $sort_by = '';
-        }
-
         $stmt .= '
                  GROUP BY
                     iss_id

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -20,6 +20,8 @@ use Eventum\Session;
  */
 class Search
 {
+    private const SORT_BY_FIELDS = ['last_action_date', 'pri_rank', 'iss_id', 'sta_rank', 'iss_summary'];
+
     /**
      * Method used to get a specific parameter in the issue listing cookie.
      *
@@ -368,7 +370,12 @@ class Search
             $fld_details = Custom_Field::getDetails($fld_id);
             $sort_by = 'cf_sort.' . Custom_Field::getDBValueFieldNameByType($fld_details['fld_type']);
         } else {
-            $sort_by = DB_Helper::getInstance()->quoteIdentifier($options['sort_by']);
+            if (in_array($options['sort_by'], self::SORT_BY_FIELDS, true)) {
+                $sort_by = $options['sort_by'];
+            } else {
+                $sort_by = 'pri_rank';
+            }
+            $sort_by = DB_Helper::getInstance()->quoteIdentifier($sort_by);
         }
 
         $stmt .= '

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -20,7 +20,7 @@ use Eventum\Session;
  */
 class Search
 {
-    private const SORT_BY_FIELDS = ['last_action_date', 'pri_rank', 'iss_id', 'sta_rank', 'iss_summary'];
+    private const SORT_BY_FIELDS = ['last_action_date', 'pri_rank', 'iss_id', 'sta_rank', 'iss_summary', 'custom_field'];
 
     /**
      * Method used to get a specific parameter in the issue listing cookie.
@@ -89,7 +89,8 @@ class Search
     {
         $request_only = !$save_db; // if we should only look at get / post not the DB or cookies
 
-        $sort_by = self::getParam('sort_by', $request_only);
+        $sort_by = self::getParam('sort_by', $request_only, self::SORT_BY_FIELDS);
+        $sort_by = $sort_by ?: 'pri_rank';
         $sort_order = self::getParam('sort_order', $request_only, ['asc', 'desc']);
         $rows = self::getParam('rows', $request_only);
         $hide_closed = self::getParam('hide_closed', $request_only);
@@ -370,12 +371,7 @@ class Search
             $fld_details = Custom_Field::getDetails($fld_id);
             $sort_by = 'cf_sort.' . Custom_Field::getDBValueFieldNameByType($fld_details['fld_type']);
         } else {
-            if (in_array($options['sort_by'], self::SORT_BY_FIELDS, true)) {
-                $sort_by = $options['sort_by'];
-            } else {
-                $sort_by = 'pri_rank';
-            }
-            $sort_by = DB_Helper::getInstance()->quoteIdentifier($sort_by);
+            $sort_by = DB_Helper::getInstance()->quoteIdentifier($options['sort_by']);
         }
 
         $stmt .= '

--- a/lib/eventum/class.search.php
+++ b/lib/eventum/class.search.php
@@ -368,7 +368,7 @@ class Search
             $fld_details = Custom_Field::getDetails($fld_id);
             $sort_by = 'cf_sort.' . Custom_Field::getDBValueFieldNameByType($fld_details['fld_type']);
         } else {
-            $sort_by = Misc::escapeString($options['sort_by']);
+            $sort_by = DB_Helper::getInstance()->quoteIdentifier($options['sort_by']);
         }
 
         $stmt .= '

--- a/src/Controller/ListController.php
+++ b/src/Controller/ListController.php
@@ -252,7 +252,7 @@ class ListController extends BaseController
         $current_sort_order = $options['sort_order'];
         foreach ($sortfields as $field => $sortfield) {
             $sort_order = $fields[$field];
-            if ($current_sort_by == $sortfield) {
+            if ($current_sort_by === $sortfield) {
                 if (strtolower($current_sort_order) === 'asc') {
                     $sort_order = 'desc';
                 } else {


### PR DESCRIPTION
Followup to https://github.com/eventum/eventum/pull/1252:

The fix didn't account for custom fields and resulted sql error in case of invalid input, which resulted a 500 page.

The new fix, field is validated against the list from the adv_search template only when not using custom fields:
- https://github.com/eventum/eventum/blob/81fbd075b12ba32b01c4720c1408672e034d54f9/templates/adv_search.tpl.html#L155-L162

Also, the `$sort_by` is now escaped with `quoteIdentifier` (method for columns) rather `escape` (method for values)