### PR TITLE
Lock jquery-ui to 1.12.x

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ See [Upgrading] for details on how to upgrade.
 
 - Fix `sort_by` not being filtered in search form, #1252
 - Fix bug allowing to execute arbitrary JavaScript in SVG files, #1251
-- Bump jquery-ui from 1.12.1 to 1.13.0, drops jQuery 1.7 support, #1240
 
 [3.10.8]: https://github.com/eventum/eventum/compare/v3.10.7...master
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "font-awesome": "^4.7.0",
     "jquery": "1.9.x",
     "jquery-form": "^4.3.0",
-    "jquery-ui": "^1.13.0",
+    "jquery-ui": "1.12.x",
     "js-cookie": "^2.2.1",
     "laravel-mix": "^5.0.9",
     "mermaid": "^8.9.1",

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -49,6 +49,7 @@ mix.scripts([
     'node_modules/jquery-ui/ui/tabbable.js',
 
     'node_modules/jquery-ui/ui/data.js',
+    'node_modules/jquery-ui/ui/jquery-1-7.js',
     'node_modules/jquery-ui/ui/ie.js',
 
     'node_modules/jquery-ui/ui/disable-selection.js',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4365,22 +4365,15 @@ jquery-form@^4.3.0:
   dependencies:
     jquery ">=1.7.2"
 
-jquery-ui@^1.13.0:
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.13.0.tgz#ab5ac65f37ca093c51b3478c4097f55bbc008f36"
-  integrity sha512-Osf7ECXNTYHtKBkn9xzbIf9kifNrBhfywFEKxOeB/OVctVmLlouV9mfc2qXCp6uyO4Pn72PXKOnj09qXetopCw==
-  dependencies:
-    jquery ">=1.8.0 <4.0.0"
+jquery-ui@1.12.x:
+  version "1.12.1"
+  resolved "https://registry.yarnpkg.com/jquery-ui/-/jquery-ui-1.12.1.tgz#bcb4045c8dd0539c134bc1488cdd3e768a7a9e51"
+  integrity sha1-vLQEXI3QU5wTS8FIjN0+dop6nlE=
 
 jquery@1.9.x, "jquery@>=1.5.0 <4.0", jquery@>=1.7, jquery@>=1.7.2, jquery@>=1.7.x, jquery@>=1.8:
   version "1.9.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-1.9.1.tgz#e4cd4835faaefbade535857613c0fc3ff2adaf34"
   integrity sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=
-
-"jquery@>=1.8.0 <4.0.0":
-  version "3.6.0"
-  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.6.0.tgz#c72a09f15c1bdce142f49dbf1170bdf8adac2470"
-  integrity sha512-JVzAR/AjBvVt2BmYhxRCSYysDsPcssdmTFnzyLEts9qNwmjmu4JTAMYubEfwVOSwpQ1I1sKKFcxhZCI2buerfw==
 
 js-cookie@^2.2.1:
   version "2.2.1"


### PR DESCRIPTION
Revert "Bump jquery-ui from 1.12.1 to 1.13.0 (#1240)"

It's not compatible, for example view issue page has such errors on console:

```
jquery-ui.js?id=44a2af31b10434ff00c4:3226 Uncaught TypeError: $.uniqueSort is not a function
    at processClassString (jquery-ui.js?id=44a2af31b10434ff00c4:3226)
    at $.<computed>.<computed>._classes (jquery-ui.js?id=44a2af31b10434ff00c4:3239)
    at $.<computed>.<computed>._toggleClass (jquery-ui.js?id=44a2af31b10434ff00c4:3276)
    at $.<computed>.<computed>._addClass (jquery-ui.js?id=44a2af31b10434ff00c4:3264)
    at $.<computed>.<computed>._create (jquery-ui.js?id=44a2af31b10434ff00c4:15110)
    at $.<computed>.<computed>._create (jquery-ui.js?id=44a2af31b10434ff00c4:2834)
    at $.<computed>.<computed>._createWidget (jquery-ui.js?id=44a2af31b10434ff00c4:3032)
    at new $.<computed>.<computed> (jquery-ui.js?id=44a2af31b10434ff00c4:2789)
    at HTMLDivElement.<anonymous> (jquery-ui.js?id=44a2af31b10434ff00c4:2972)
    at Function.each (components.js?id=81f149179a79cc2f11e5:648)
    at jQuery.fn.init.each (components.js?id=81f149179a79cc2f11e5:270)
    at jQuery.fn.init.$.fn.<computed> [as progressbar] (jquery-ui.js?id=44a2af31b10434ff00c4:2964)
    at HTMLDivElement.<anonymous> (app.js?id=d0fd6bc6e7450e4c773c:26517)
    at Function.each (components.js?id=81f149179a79cc2f11e5:648)
    at jQuery.fn.init.each (components.js?id=81f149179a79cc2f11e5:270)
    at HTMLDocument.<anonymous> (app.js?id=d0fd6bc6e7450e4c773c:26515)
    at fire (components.js?id=81f149179a79cc2f11e5:1037)
    at Object.fireWith [as resolveWith] (components.js?id=81f149179a79cc2f11e5:1148)
    at Function.ready (components.js?id=81f149179a79cc2f11e5:433)
    at HTMLDocument.completed (components.js?id=81f149179a79cc2f11e5:103)
```

So such update should be postponed to future version.