### PR TITLE
Fix Multiple Stored XSS in Administration allowing execution of arbitrary JavaScript code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix bug stored xss - Data when render on FE allows execution of arbitrary javascript code
+
 [3.10.9]: https://github.com/eventum/eventum/compare/v3.10.8...master
 
 ## [3.10.8] - 2021-11-10

--- a/templates/adv_search.tpl.html
+++ b/templates/adv_search.tpl.html
@@ -372,7 +372,7 @@
             {if $core.current_role < $core.roles.manager and $custom[i].cst_is_global}
             {$custom[i].cst_title}
             {else}
-            <a href="adv_search.php?custom_id={$custom[i].cst_id}" title="{t}edit this custom search{/t}">{$custom[i].cst_title}</a>
+            <a href="adv_search.php?custom_id={$custom[i].cst_id}" title="{t}edit this custom search{/t}">{$custom[i].cst_title|escape:"html"}</a>
             {/if}
             </span>
             {if $custom[i].cst_is_global}<span><i>({t}global filter{/t})</i></span>{/if}

--- a/templates/custom_fields.tpl.html
+++ b/templates/custom_fields.tpl.html
@@ -11,7 +11,7 @@
           {section name="i" loop=$custom_fields}
           <tr class="{cycle values='odd,even'}" {if $custom_fields[i].hide_when_no_options|default:0 == 1 && $custom_fields[i].value == ''}style="display: none"{/if}>
             <th class="{if $custom_fields[i].fld_min_role > $core.roles.customer}internal{/if}">
-                {$custom_fields[i].fld_title}
+                {$custom_fields[i].fld_title|escape:"html"}
             </th>
             <td>
               {if $custom_fields[i].fld_type == 'textarea'}

--- a/templates/edit_custom_fields.tpl.html
+++ b/templates/edit_custom_fields.tpl.html
@@ -18,11 +18,11 @@
 <tr class="custom_field"
     data-custom-id="{$custom_fields[i].fld_id}"
     data-custom-type="{$custom_fields[i].fld_type}"
-    data-custom-title="{$custom_fields[i].fld_title}"
+    data-custom-title="{$custom_fields[i].fld_title|escape:'html'}"
     data-custom-required="{$cf_required}"
     data-custom-validation-js="{$custom_fields[i].validation_js|default:''}">
   <th class="{if $custom_fields[i].fld_min_role > $core.roles.customer}internal{/if}">
-    {$custom_fields[i].fld_title}{if $cf_required} *{/if}
+    {$custom_fields[i].fld_title|escape:"html"}{if $cf_required} *{/if}
   </th>
   <td>
     {if $custom_fields[i].fld_type == 'text'}

--- a/templates/faq.tpl.html
+++ b/templates/faq.tpl.html
@@ -34,7 +34,7 @@
     </tr>
     {section name="i" loop=$faqs}
     <tr class="{cycle values='odd,even'}">
-        <td><b><a href="faq.php?id={$faqs[i].faq_id}" title="{t}read faq entry{/t}">{$faqs[i].faq_title}</a></b></td>
+        <td><b><a href="faq.php?id={$faqs[i].faq_id}" title="{t}read faq entry{/t}">{$faqs[i].faq_title|escape:"html"}</a></b></td>
         <td>{$faqs[i].faq_updated_date|timeago}</td>
     </tr>
     {/section}

--- a/templates/include/new_form.tpl.html
+++ b/templates/include/new_form.tpl.html
@@ -47,7 +47,7 @@
     <tr class="title">
       <th colspan="2">
         {t}Create New Issue{/t}
-        <span class="menu">({t}Current Project{/t}: {$core.project_name})</span>
+        <span class="menu">({t}Current Project{/t}: {$core.project_name|escape:'html'})</span>
       </th>
     </tr>
     {if $cats|@count > 0 && $core.current_role >= $field_display_settings.category.min_role}

--- a/templates/latest_news.tpl.html
+++ b/templates/latest_news.tpl.html
@@ -9,7 +9,7 @@
               <tr>
                 <td>
                   {section name="i" loop=$news}
-                  <b>{$news[i].nws_created_date|timeago} - <a href="news.php?id={$news[i].nws_id}" title="{t}full news entry{/t}">{$news[i].nws_title}</a></b>
+                  <b>{$news[i].nws_created_date|timeago} - <a href="news.php?id={$news[i].nws_id}" title="{t}full news entry{/t}">{$news[i].nws_title|escape:"html"}</a></b>
                   <br /><br />
                   {$news[i].nws_message|activateLinks:"links"}
                   <br /><br />

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -111,7 +111,7 @@
             {elseif $field_name == 'time_spent'}
               {$list[i].time_spent}
             {elseif $field_name == 'prc_title'}
-              {$list[i].prc_title}
+              {$list[i].prc_title|escape:"html"}
             {elseif $field_name == 'pre_title'}
               {$list[i].pre_title|escape:"html"}
             {elseif $field_name == 'iss_customer_id'}

--- a/templates/list.tpl.html
+++ b/templates/list.tpl.html
@@ -105,9 +105,9 @@
             {elseif $field_name == 'sev_rank'}
               {$list[i].sev_title|escape:"html"}
             {elseif $field_name == 'grp_name'}
-              {$list[i].grp_name}
+              {$list[i].grp_name|escape:"html"}
             {elseif $field_name == 'assigned'}
-              {$list[i].assigned_users}
+              {$list[i].assigned_users|escape:"html"}
             {elseif $field_name == 'time_spent'}
               {$list[i].time_spent}
             {elseif $field_name == 'prc_title'}

--- a/templates/manage/anonymous.tpl.html
+++ b/templates/manage/anonymous.tpl.html
@@ -61,7 +61,7 @@
         <tr class="title">
             <th colspan="2">
                 {t}Anonymous Reporting of New Issues{/t}
-                <div class="right">({t}Current Project{/t}: {$project.prj_title})</div>
+                <div class="right">({t}Current Project{/t}: {$project.prj_title|escape:"html"})</div>
             </th>
         </tr>
         <tr>

--- a/templates/manage/categories.tpl.html
+++ b/templates/manage/categories.tpl.html
@@ -47,7 +47,7 @@
             <th colspan="2">
                 {t}Manage Categories{/t}
                 <div class="right">
-                    ({t}Current Project{/t}: {$project.prj_title})
+                    ({t}Current Project{/t}: {$project.prj_title|escape:"html"})
                 </div>
             </th>
         </tr>
@@ -56,7 +56,7 @@
                 {t}Title{/t}: *
             </th>
             <td>
-                <input type="text" name="title" size="40" value="{$info.prc_title|default:''}">
+                <input type="text" name="title" size="40" value="{$info.prc_title|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>
@@ -90,7 +90,7 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].prc_id}"></td>
             <td width="100%">
-                &nbsp;<a href="{$core.rel_url}manage/categories.php?cat=edit&id={$list[i].prc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].prc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/categories.php?cat=edit&id={$list[i].prc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].prc_title|escape:"html"}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/column_display.tpl.html
+++ b/templates/manage/column_display.tpl.html
@@ -15,7 +15,7 @@
         <tr class="title">
             <th colspan="3">
                 {t}Manage Columns to Display{/t} {include file="help_link.tpl.html" topic="column_display"}
-                <div class="right">({t}Current Project{/t}: {$project_name})</div>
+                <div class="right">({t}Current Project{/t}: {$project_name|escape:"html"})</div>
             </th>
         </tr>
         <tr>

--- a/templates/manage/custom_fields.tpl.html
+++ b/templates/manage/custom_fields.tpl.html
@@ -220,7 +220,7 @@
                   {t}Title{/t}
                 </th>
                 <td>
-                  <input type="text" name="title" maxlength="255" size="40" value="{$info.fld_title|default:''}">
+                  <input type="text" name="title" maxlength="255" size="40" value="{$info.fld_title|default:''|escape:'html'}">
                   {include file="error_icon.tpl.html" field="title"}
                 </td>
               </tr>
@@ -229,7 +229,7 @@
                   {t}Short Description{/t}
                 </th>
                 <td>
-                  <input type="text" name="description" maxlength="255" size="40" value="{$info.fld_description|default:''}">
+                  <input type="text" name="description" maxlength="255" size="40" value="{$info.fld_description|default:''|escape:'html'}">
                   <span>({t}it will show up by the side of the field{/t})</span>
                 </td>
               </tr>
@@ -419,16 +419,16 @@
                 {rank_icon href="{$core.rel_url}manage/custom_fields.php?cat=change_rank&id={$list[i].fld_id}&direction=-1" direction="up"}
               </td>
               <td width="15%">
-                &nbsp;<a href="{$core.rel_url}manage/custom_fields.php?cat=edit&id={$list[i].fld_id}" title="{t}update this entry{/t}">{$list[i].fld_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/custom_fields.php?cat=edit&id={$list[i].fld_id}" title="{t}update this entry{/t}">{$list[i].fld_title|escape:"html"}</a>
               </td>
               <td width="20%">
-                &nbsp;{$list[i].projects}
+                &nbsp;{$list[i].projects|escape:"html"}
               </td>
               <td width="10%">
-                &nbsp;{$list[i].min_role_name}
+                &nbsp;{$list[i].min_role_name|escape:"html"}
               </td>
               <td width="10%">
-                &nbsp;{$list[i].min_role_edit_name}
+                &nbsp;{$list[i].min_role_edit_name|escape:"html"}
               </td>
               <td width="5%">
                 <nobr>&nbsp;{if $list[i].fld_type == 'combo'}{t}Combo Box{/t}{elseif $list[i].fld_type == 'multiple'}{t}Multiple Combo Box{/t}{elseif $list[i].fld_type == 'textarea'}{t}Textarea{/t}{elseif $list[i].fld_type == 'date'}{t}Date{/t}{elseif $list[i].fld_type == 'integer'}{t}Integer{/t}{elseif $list[i].fld_type == 'checkbox'}Checkbox{else}{t}Text Input{/t}{/if}</nobr>

--- a/templates/manage/email_accounts.tpl.html
+++ b/templates/manage/email_accounts.tpl.html
@@ -244,7 +244,7 @@
     {section name="i" loop=$list}
     <tr class="{cycle values='odd,even'}">
       <td width="4" align="center" nowrap><input type="checkbox" name="items[]" value="{$list[i].ema_id}"></td>
-      <td>&nbsp;{$list[i].prj_title}</td>
+      <td>&nbsp;{$list[i].prj_title|escape:"html"}</td>
       <td width="30%">
         &nbsp;<a href="{$core.rel_url}manage/email_accounts.php?cat=edit&id={$list[i].ema_id}" title="{t}update this entry{/t}">{$list[i].ema_hostname|escape:"html"}</a></td>
       <td>&nbsp;{$list[i].ema_type}</td>

--- a/templates/manage/email_responses.tpl.html
+++ b/templates/manage/email_responses.tpl.html
@@ -115,7 +115,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].ere_id}"></td>
               <td width="60%">
-                &nbsp;<a href="{$core.rel_url}manage/email_responses.php?cat=edit&id={$list[i].ere_id}" title="{t}update this entry{/t}">{$list[i].ere_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/email_responses.php?cat=edit&id={$list[i].ere_id}" title="{t}update this entry{/t}">{$list[i].ere_title|escape:"html"}</a>
               </td>
               <td width="40%">
                 &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/groups.tpl.html
+++ b/templates/manage/groups.tpl.html
@@ -73,7 +73,7 @@ function checkDelete()
             {t}Name{/t} *
         </th>
         <td>
-            <input type="text" name="group_name" size="40" value="{$info.grp_name|default:''}">
+            <input type="text" name="group_name" size="40" value="{$info.grp_name|default:''|escape:'html'}">
             {include file="error_icon.tpl.html" field="group_name"}
         </td>
     </tr>
@@ -82,7 +82,7 @@ function checkDelete()
             {t}Description{/t}
         </th>
         <td>
-            <input type="text" name="description" size="100" value="{$info.grp_description|default:''}">
+            <input type="text" name="description" size="100" value="{$info.grp_description|default:''|escape:'html'}">
             {include file="error_icon.tpl.html" field="description"}
         </td>
     </tr>
@@ -155,16 +155,16 @@ function checkDelete()
             <input type="checkbox" name="items[]" value="{$list[i].grp_id}" {if $smarty.section.i.total == 0}disabled{/if}>
         </td>
         <td width="20%">
-            &nbsp;<a href="{$core.rel_url}manage/groups.php?cat=edit&id={$list[i].grp_id}" title="{t}update this entry{/t}">{$list[i].grp_name}</a>
+            &nbsp;<a href="{$core.rel_url}manage/groups.php?cat=edit&id={$list[i].grp_id}" title="{t}update this entry{/t}">{$list[i].grp_name|escape:"html"}</a>
         </td>
         <td width="20%">
-            &nbsp;{$list[i].grp_description}
+            &nbsp;{$list[i].grp_description|escape:"html"}
         </td>
         <td width="40%">
-            &nbsp;{$list[i].manager}
+            &nbsp;{$list[i].manager|escape:"html"}
         </td>
         <td width="20%">
-            &nbsp;{", "|join:$list[i].projects}
+            &nbsp;{", "|join:$list[i].projects|escape:"html"}
         </td>
     </tr>
     {sectionelse}

--- a/templates/manage/issue_auto_creation.tpl.html
+++ b/templates/manage/issue_auto_creation.tpl.html
@@ -50,7 +50,7 @@
         <tr class="title">
             <th colspan="2">
                 {t}Auto-Creation of Issues{/t}
-                <div class="right">({t}Associated Project{/t}: {$prj_title})</div>
+                <div class="right">({t}Associated Project{/t}: {$prj_title|escape:"html"})</div>
             </th>
         </tr>
         <tr>

--- a/templates/manage/link_filters.tpl.html
+++ b/templates/manage/link_filters.tpl.html
@@ -150,13 +150,13 @@ function checkDelete()
                     &nbsp;{$list[i].lfi_replacement|escape:"html"}
                 </td>
                 <td width="20%">
-                    &nbsp;{$list[i].lfi_description}
+                    &nbsp;{$list[i].lfi_description|escape:"html"}
                 </td>
                 <td width="20%">
-                    &nbsp;{$list[i].min_usr_role_name}
+                    &nbsp;{$list[i].min_usr_role_name|escape:"html"}
                 </td>
                 <td width="20%">
-                    &nbsp;{", "|join:$list[i].project_names}
+                    &nbsp;{", "|join:$list[i].project_names|escape:"html"}
                 </td>
             </tr>
             {sectionelse}

--- a/templates/manage/news.tpl.html
+++ b/templates/manage/news.tpl.html
@@ -133,7 +133,7 @@ function checkDelete()
     <tr class="{cycle values='odd,even'}">
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].nws_id}"></td>
       <td width="40%">
-        &nbsp;<a href="{$core.rel_url}manage/news.php?cat=edit&id={$list[i].nws_id}" title="{t}update this entry{/t}">{$list[i].nws_title}</a>
+        &nbsp;<a href="{$core.rel_url}manage/news.php?cat=edit&id={$list[i].nws_id}" title="{t}update this entry{/t}">{$list[i].nws_title|escape:"html"}</a>
       </td>
       <td width="40%">
         &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/phone_categories.tpl.html
+++ b/templates/manage/phone_categories.tpl.html
@@ -46,7 +46,7 @@
         <tr class="title">
             <th colspan="2">
                 {t}Manage Phone Support Categories{/t}
-                <div class="right">({t}Current Project{/t}: {$project.prj_title})</div>
+                <div class="right">({t}Current Project{/t}: {$project.prj_title|escape:"html"})</div>
             </th>
         </tr>
         <tr>
@@ -54,7 +54,7 @@
                 {t}Title{/t}: *
             </th>
             <td>
-                <input type="text" name="title" size="40" value="{$info.phc_title|default:''}">
+                <input type="text" name="title" size="40" value="{$info.phc_title|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>
@@ -88,7 +88,7 @@
         <tr class="{cycle values='odd,even'}">
             <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].phc_id}"></td>
             <td width="100%">
-                &nbsp;<a href="{$core.rel_url}manage/phone_categories.php?cat=edit&id={$list[i].phc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].phc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/phone_categories.php?cat=edit&id={$list[i].phc_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].phc_title|escape:"html"}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/priorities.tpl.html
+++ b/templates/manage/priorities.tpl.html
@@ -79,7 +79,7 @@
             <th colspan="2">
                 {t}Manage Priorities{/t}
                 <div class="right">
-                    ({t}Current Project{/t}: {$project.prj_title})
+                    ({t}Current Project{/t}: {$project.prj_title|escape:"html"})
                 </div>
             </th>
         </tr>
@@ -88,7 +88,7 @@
                 {t}Title{/t}: *
             </th>
             <td>
-                <input type="text" name="title" size="40" value="{$info.pri_title|default:''}">
+                <input type="text" name="title" size="40" value="{$info.pri_title|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>
@@ -154,7 +154,7 @@
                 {if $list[i].pri_icon > 0}<span class="priority_icon priority-icon-{$list[i].pri_icon}" title="{$list[i].pri_icon}"></span>{/if}
             </td>
             <td width="100%">
-                &nbsp;<a href="{$core.rel_url}manage/priorities.php?cat=edit&id={$list[i].pri_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pri_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/priorities.php?cat=edit&id={$list[i].pri_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pri_title|escape:"html"}</a>
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/products.tpl.html
+++ b/templates/manage/products.tpl.html
@@ -57,7 +57,7 @@
                 {t}Title{/t} *
             </th>
             <td>
-                <input type="text" name="title" size="40" value="{$info.pro_title|default:''}">
+                <input type="text" name="title" size="40" value="{$info.pro_title|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>

--- a/templates/manage/projects.tpl.html
+++ b/templates/manage/projects.tpl.html
@@ -271,7 +271,7 @@ $().ready(function() {
         {section name="i" loop=$list}
         <tr class="{cycle values='odd,even'}">
           <td width="30%" >
-            &nbsp;<a href="{$core.rel_url}manage/projects.php?cat=edit&id={$list[i].prj_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
+            &nbsp;<a href="{$core.rel_url}manage/projects.php?cat=edit&id={$list[i].prj_id}" title="{t}update this entry{/t}">{$list[i].prj_title|escape:"html"}</a>
           </td>
           <td width="20%" >&nbsp;{$list[i].usr_full_name|escape:html}</td>
           <td >&nbsp;{$list[i].prj_status|capitalize}</td>

--- a/templates/manage/releases.tpl.html
+++ b/templates/manage/releases.tpl.html
@@ -47,7 +47,7 @@
             <th colspan="2">
               {t}Manage Releases{/t}
                 <div class="right">
-                    ({t}Current Project{/t}: {$project.prj_title})
+                    ({t}Current Project{/t}: {$project.prj_title|escape:"html"})
                 </div>
             </th>
           </tr>
@@ -56,7 +56,7 @@
               {t}Title{/t}:
             </th>
             <td>
-              <input type="text" name="title" size="40" value="{$info.pre_title|default:''}">
+              <input type="text" name="title" size="40" value="{$info.pre_title|default:''|escape:'html'}">
               {include file="error_icon.tpl.html" field="title"}
             </td>
           </tr>
@@ -111,7 +111,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].pre_id}"></td>
               <td width="40%">
-                &nbsp;<a href="{$core.rel_url}manage/releases.php?cat=edit&id={$list[i].pre_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pre_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/releases.php?cat=edit&id={$list[i].pre_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].pre_title|escape:"html"}</a>
               </td>
               <td>&nbsp;{$list[i].pre_scheduled_date}</td>
               <td>&nbsp;{$list[i].pre_status}</td>

--- a/templates/manage/resolution.tpl.html
+++ b/templates/manage/resolution.tpl.html
@@ -57,7 +57,7 @@
           {t}Title{/t}:
         </th>
         <td>
-          <input type="text" name="title" size="40" value="{$info.res_title|default:''}">
+          <input type="text" name="title" size="40" value="{$info.res_title|default:''|escape:'html'}">
           {include file="error_icon.tpl.html" field="title"}
         </td>
       </tr>
@@ -101,7 +101,7 @@
           <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].res_id}"></td>
           <td align="center">{$list[i].res_rank}</td>
           <td width="100%">
-            &nbsp;<a href="{$core.rel_url}manage/resolution.php?cat=edit&id={$list[i].res_id}" title="{t}update this entry{/t}">{$list[i].res_title}</a>
+            &nbsp;<a href="{$core.rel_url}manage/resolution.php?cat=edit&id={$list[i].res_id}" title="{t}update this entry{/t}">{$list[i].res_title|escape:"html"}</a>
           </td>
         </tr>
         {sectionelse}

--- a/templates/manage/round_robin.tpl.html
+++ b/templates/manage/round_robin.tpl.html
@@ -131,7 +131,7 @@ function checkDelete()
     <tr class="{cycle values="odd,even"}">
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].prr_id}"></td>
       <td width="30%">
-        &nbsp;<a href="{$core.rel_url}manage/round_robin.php?cat=edit&id={$list[i].prr_id}" title="{t}update this entry{/t}">{$list[i].prj_title}</a>
+        &nbsp;<a href="{$core.rel_url}manage/round_robin.php?cat=edit&id={$list[i].prr_id}" title="{t}update this entry{/t}">{$list[i].prj_title|escape:"html"}</a>
       </td>
       <td width="70%">
         &nbsp;{$list[i].users|escape:"html"}

--- a/templates/manage/severities.tpl.html
+++ b/templates/manage/severities.tpl.html
@@ -56,7 +56,7 @@
             <th colspan="2">
                 {t}Manage Severities{/t}
                 <div class="right">
-                    ({t}Current Project{/t}: {$project.prj_title})
+                    ({t}Current Project{/t}: {$project.prj_title|escape:"html"})
                 </div>
             </th>
         </tr>
@@ -65,7 +65,7 @@
                 {t}Title{/t} *
             </th>
             <td>
-                <input type="text" name="title" size="40" value="{$info.sev_title|default:''}">
+                <input type="text" name="title" size="40" value="{$info.sev_title|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>
@@ -74,7 +74,7 @@
                 {t}Description{/t} *
             </th>
             <td>
-                <input type="text" name="description" size="100" value="{$info.sev_description|default:''}">
+                <input type="text" name="description" size="100" value="{$info.sev_description|default:''|escape:'html'}">
                 {include file="error_icon.tpl.html" field="title"}
             </td>
         </tr>
@@ -124,10 +124,10 @@
               {rank_icon href="{$core.rel_url}manage/severities.php?cat=change_rank&id={$list[i].sev_id}&prj_id={$project.prj_id}&rank=asc" direction="up"}
             </td>
             <td width="200" nowrap>
-                &nbsp;<a class="link" href="{$core.rel_url}manage/severities.php?cat=edit&id={$list[i].sev_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].sev_title}</a>
+                &nbsp;<a class="link" href="{$core.rel_url}manage/severities.php?cat=edit&id={$list[i].sev_id}&prj_id={$project.prj_id}" title="{t}update this entry{/t}">{$list[i].sev_title|escape:"html"}</a>
             </td>
             <td width="100%">
-                &nbsp;{$list[i].sev_description}
+                &nbsp;{$list[i].sev_description|escape:"html"}
             </td>
         </tr>
         {sectionelse}

--- a/templates/manage/status_action_date.tpl.html
+++ b/templates/manage/status_action_date.tpl.html
@@ -131,7 +131,7 @@
     {section name="i" loop=$list}
     <tr class="{cycle values='odd,even'}">
       <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].psd_id}"></td>
-      <td width="20%">{$list[i].prj_title}</td>
+      <td width="20%">{$list[i].prj_title|escape:"html"}</td>
       <td width="20%">
         &nbsp;<a href="{$core.rel_url}manage/status_action_date.php?cat=edit&id={$list[i].psd_id}" title="{t}update this entry{/t}">{$list[i].sta_title|escape:"html"}</a>
       </td>

--- a/templates/manage/statuses.tpl.html
+++ b/templates/manage/statuses.tpl.html
@@ -166,7 +166,7 @@
               <td align="center">{$list[i].sta_rank}</td>
               <td align="center">{$list[i].sta_abbreviation}</td>
               <td width="40%">
-                &nbsp;<a href="{$core.rel_url}manage/statuses.php?cat=edit&id={$list[i].sta_id}" title="{t}update this entry{/t}">{$list[i].sta_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/statuses.php?cat=edit&id={$list[i].sta_id}" title="{t}update this entry{/t}">{$list[i].sta_title|escape:"html"}</a>
               </td>
               <td width="30%">
                 &nbsp;{$list[i].projects|escape:"html"}

--- a/templates/manage/time_tracking.tpl.html
+++ b/templates/manage/time_tracking.tpl.html
@@ -57,7 +57,7 @@
               {t}Title{/t}
             </th>
             <td>
-              <input type="text" name="title" size="40" value="{$info.ttc_title|default:''}">
+              <input type="text" name="title" size="40" value="{$info.ttc_title|default:''|escape:'html'}">
               {include file="error_icon.tpl.html" field="title"}
             </td>
           </tr>
@@ -91,7 +91,7 @@
             <tr class="{cycle values='odd,even'}">
               <td width="4" nowrap align="center"><input type="checkbox" name="items[]" value="{$list[i].ttc_id}"></td>
               <td width="100%">
-                &nbsp;<a href="{$core.rel_url}manage/time_tracking.php?prj_id={$project.prj_id}&cat=edit&id={$list[i].ttc_id}" title="{t}update this entry{/t}">{$list[i].ttc_title}</a>
+                &nbsp;<a href="{$core.rel_url}manage/time_tracking.php?prj_id={$project.prj_id}&cat=edit&id={$list[i].ttc_id}" title="{t}update this entry{/t}">{$list[i].ttc_title|escape:"html"}</a>
               </td>
             </tr>
             {sectionelse}

--- a/templates/manage/users_form.tpl.html
+++ b/templates/manage/users_form.tpl.html
@@ -149,7 +149,7 @@
         <table border="0">
           {foreach from=$project_list key=prj_id item=prj_name}
             <tr>
-              <td>{$prj_name}:</td>
+              <td>{$prj_name|escape:"html"}:</td>
               <td>
                 {if $info.roles.$prj_id.pru_role|default:'' == $core.roles.customer}
                   <span>{t}Customer{/t}</span>

--- a/templates/manage/users_list.tpl.html
+++ b/templates/manage/users_list.tpl.html
@@ -133,11 +133,11 @@
         </td>
         <td width="20%">
           <a href="{$core.rel_url}manage/users.php?cat=edit&id={$list[i].usr_id}"
-                   title="{t}update this entry{/t}">{$list[i].usr_full_name|default:$list[i].usr_email}</a>
+                   title="{t}update this entry{/t}">{$list[i].usr_full_name|default:$list[i].usr_email|escape:"html"}</a>
         </td>
         <td width="20%" nowrap>
           {foreach from=$list[i].roles item=role_data}
-            {$role_data.prj_title}: {$role_data.role}
+            {$role_data.prj_title|escape:"html"}: {$role_data.role}
             <br/>
           {/foreach}
         </td>

--- a/templates/phone_support.tpl.html
+++ b/templates/phone_support.tpl.html
@@ -59,8 +59,8 @@ function addPhoneCall()
             <td>{$phone_entries[i].phs_call_from_lname}, {$phone_entries[i].phs_call_from_fname}</td>
             <td>{$phone_entries[i].phs_call_to_lname}, {$phone_entries[i].phs_call_to_fname}</td>
             <td>{$phone_entries[i].phs_type|capitalize}</td>
-            <td nowrap>{$phone_entries[i].phc_title}</td>
-            <td nowrap>{$phone_entries[i].phs_phone_number} ({$phone_entries[i].phs_phone_type})</td>
+            <td nowrap>{$phone_entries[i].phc_title|escape:"html"}</td>
+            <td nowrap>{$phone_entries[i].phs_phone_number|escape:"html"} ({$phone_entries[i].phs_phone_type})</td>
           </tr>
           {include file="expandable_cell/body.tpl.html" ec_id="phone" list_id=$phone_entries[i].phs_id colspan="9" class=$row_class}
           {sectionelse}

--- a/templates/reports/category_statuses.tpl.html
+++ b/templates/reports/category_statuses.tpl.html
@@ -7,12 +7,12 @@
     <tr>
         <th>{t}Category{/t}</th>
         {foreach from=$statuses item=status}
-        <th>{$status}</th>
+        <th>{$status|escape:"html"}</th>
         {/foreach}
     </tr>
     {foreach from=$data item=row}
     <tr class="{cycle values='odd,even'}">
-        <td>{$row.title}</td>
+        <td>{$row.title|escape:"html"}</td>
         {foreach from=$row.statuses item=col}
         <td align="right">{$col.count}</td>
         {/foreach}

--- a/templates/reports/custom_fields.tpl.html
+++ b/templates/reports/custom_fields.tpl.html
@@ -196,7 +196,7 @@ setOptions('{$custom_field}', false);
       {else}
       <th>{t}Issue ID{/t}</th>
       <th>{t}Summary{/t}</th>
-      <th>{$field_info.fld_title}</th>
+      <th>{$field_info.fld_title|escape:"html"}</th>
       {/if}
     </tr>
     {foreach from=$data item=row}

--- a/templates/reports/custom_fields_weekly.tpl.html
+++ b/templates/reports/custom_fields_weekly.tpl.html
@@ -176,7 +176,7 @@
         <th>{t}Issue ID{/t}</th>
         <th>{t}Summary{/t}</th>
         <th>{t}Time Spent{/t}</th>
-        <th>{$field_info.fld_title}</th>
+        <th>{$field_info.fld_title|escape:"html"}</th>
         {if $per_user}
         <th>{t}User{/t}</th>
         {/if}

--- a/templates/reports/estimated_dev_time.tpl.html
+++ b/templates/reports/estimated_dev_time.tpl.html
@@ -3,7 +3,7 @@
 
 {block "report_content"}
 <h3 align="center">{t}Estimated Development Time by Category{/t}</h3>
-<p align="center" width="80%">{t escape=no 1=$core.project_name}Based on all open issue in Eventum for <b>%1</b>.{/t}</p>
+<p align="center" width="80%">{t escape=no 1=$core.project_name|escape:"html"}Based on all open issue in Eventum for <b>%1</b>.{/t}</p>
 <br />
 <table class="bordered grid">
     <tr>

--- a/templates/reports/estimated_dev_time.tpl.html
+++ b/templates/reports/estimated_dev_time.tpl.html
@@ -16,7 +16,7 @@
     </tr>
     {section name="issues" loop=$data}
     <tr class="{cycle values='odd,even'}">
-        <td align="center">{$data[issues].prc_title}</td>
+        <td align="center">{$data[issues].prc_title|escape:"html"}</td>
         <td align="center">{$data[issues].dev_time}</td>
     </tr>
     {/section}

--- a/templates/select_project.tpl.html
+++ b/templates/select_project.tpl.html
@@ -40,7 +40,7 @@
                     {if $project@first}checked="checked"{/if}>
                 </td>
                 <td>
-                    <label class="project_label" for="project_{$prj_id}">{$project}</label>
+                    <label class="project_label" for="project_{$prj_id}">{$project|escape:"html"}</label>
                 </td>
             </tr>
             {/foreach}

--- a/templates/time_tracking.tpl.html
+++ b/templates/time_tracking.tpl.html
@@ -26,7 +26,7 @@
               {if $core.user.usr_id == $time_entries[i].ttr_usr_id}[ <a class="delete_time_entry" data-ttr-id="{$time_entries[i].ttr_id}" href="popup.php?cat=delete_time&id={$time_entries[i].ttr_id}">{t}delete{/t}</a> ]{/if}
             </td>
             <td>{$time_entries[i].formatted_time}</td>
-            <td nowrap>{$time_entries[i].ttc_title}</td>
+            <td nowrap>{$time_entries[i].ttc_title|escape:"html"}</td>
             <td>
                 {if $time_entries[i].ttr_usr_id == $core.current_user_id or $core.current_role >= $core.roles.manager}
                     {assign var="edit_entry" value=true}

--- a/templates/view_form.tpl.html
+++ b/templates/view_form.tpl.html
@@ -114,7 +114,7 @@
                     {elseif $row.field|default:'' == 'associated_issues'}
                     {section name="i" loop=$issue.associated_issues_details}
                     {strip}
-                    <a href="view.php?id={$issue.associated_issues_details[i].associated_issue}" title="{t}issue{/t} #{$issue.associated_issues_details[i].associated_issue} ({$issue.associated_issues_details[i].current_status}) - {$issue.associated_issues_details[i].associated_title|escape:"html"}" class="{if $issue.associated_issues_details[i].is_closed}closed{/if}">#{$issue.associated_issues_details[i].associated_issue}</a>
+                    <a href="view.php?id={$issue.associated_issues_details[i].associated_issue}" title="{t}issue{/t} #{$issue.associated_issues_details[i].associated_issue} ({$issue.associated_issues_details[i].current_status|escape:'html'}) - {$issue.associated_issues_details[i].associated_title|escape:"html"}" class="{if $issue.associated_issues_details[i].is_closed}closed{/if}">#{$issue.associated_issues_details[i].associated_issue}</a>
                     {if not $smarty.section.i.last},{/if}
                     {/strip}
                     {sectionelse}

--- a/templates/view_form.tpl.html
+++ b/templates/view_form.tpl.html
@@ -76,7 +76,7 @@
                             {/if}
                         {elseif $row.field|default:'' == 'product'}
                             {if $issue.products|@count > 0}
-                                {$issue.products[0].product}
+                                {$issue.products[0].product|escape:"html"}
                                 {$issue.products[0].version}
                             {/if}
                         {elseif $row.field == 'customer_0'}


### PR DESCRIPTION
The data generated from Administration when rendering in FE lacks `escape:html` from which it can execute arbitrary javascript code.

Fix bug stored xss -  Data when render on FE allows execution of arbitrary javascript code

Disclosure: https://huntr.dev/bounties/cc5c6cdd-8030-4eb1-af75-947780ee12e0