### PR TITLE
Feature: Use ServiceContainer first when finding classes for extensions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@
 
 See [Upgrading] for details on how to upgrade.
 
-- Add getExtensionConfig helper for external extensions, #1286
+- Feature: Add getExtensionConfig helper for external extensions, #1286
 - Fix: Use MarkdownConverter instead of deprecated CommonMarkConverter, #1289
+- Feature: Use ServiceContainer first when finding classes for extensions, #1290
 
 [3.10.10]: https://github.com/eventum/eventum/compare/v3.10.9...master
 

--- a/src/Extension/ExtensionManager.php
+++ b/src/Extension/ExtensionManager.php
@@ -222,12 +222,20 @@ final class ExtensionManager implements
 
     /**
      * Create new instance of named class,
+     * Lookup it fom service container, if not found
      * use factory from extensions that provide factory method.
      *
      * @return object
+     * @since 3.10.10 will try to lookup from service container first
      */
     protected function createInstance(Provider\ExtensionProvider $preferredExtension, string $className)
     {
+        // First try from service container
+        $container = ServiceContainer::getInstance();
+        if (isset($container[$className])) {
+            return $container[$className];
+        }
+
         $getSortedExtensions = static function (array $extensions) use ($preferredExtension): Generator {
             // prefer provided extension
             if ($preferredExtension instanceof Provider\FactoryProvider) {


### PR DESCRIPTION
This allows clean up extensions needing to provide factory method that just do lookup from container:

```php
    public function factory($className)
    {
        $services = self::getServiceContainer();

        if (isset($services[$className])) {
            return $services[$className];
        }

        return null;
    }
```