### PR TITLE
Fix: Drop "replace" keys from composer.json

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Build release tarball
         env:
-          BUILD_IMAGE: ghcr.io/eventum/eventum:release-image
+          BUILD_IMAGE: ghcr.io/eventum/eventum:release-image-v2
         run: |
           docker run -v $(pwd):/app $BUILD_IMAGE bin/releng/dist.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       name: GitHub Release
       script:
         - docker --version
-        - BUILD_IMAGE=ghcr.io/eventum/eventum:release-image
+        - BUILD_IMAGE=ghcr.io/eventum/eventum:release-image-v2
         - unset LANG LANGUAGE LC_ALL
         - export -p > env.sh
         - docker run -v $(pwd):/app -e DOCKER_ENV_LOAD=./env.sh $BUILD_IMAGE bin/releng/dist.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ See [Upgrading] for details on how to upgrade.
 - Feature: Add getExtensionConfig helper for external extensions, #1286
 - Fix: Use MarkdownConverter instead of deprecated CommonMarkConverter, #1289
 - Feature: Use ServiceContainer first when finding classes for extensions, #1290
+- Fix: Drop "replace" keys from composer.json, #1291
 
 [3.10.10]: https://github.com/eventum/eventum/compare/v3.10.9...master
 

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -18,6 +18,7 @@ RUN set -x \
     gettext \
     git \
     gnupg \
+    jq \
     make \
     php-curl \
     php-dom \

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -51,10 +51,14 @@ clean_whitespace() {
 install_dependencies() {
 	echo >&2 "Setup composer deps"
 
+	# remove packages defined in "extra.replace"
+	$topdir/bin/releng/composer-replace.sh
+
 	composer install --prefer-dist --no-dev --no-suggest
 
 	# clean distribution and dump autoloader again
 	clean_vendor
+
 	# call "composer install" to workaround for flex not placing the version check
 	composer install --prefer-dist --no-dev --no-suggest
 	composer dump-autoload

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -50,32 +50,16 @@ update_timestamps() {
 
 vcs_checkout() {
 	set -x
-	local submodule dir=$dir absdir
+	local dir=$dir absdir
 
 	rm -rf $dir
 	install -d $dir
 	absdir=$(readlink -f $dir)
 
-	# setup submodules
-	git submodule init
-	git submodule update
-
 	git archive HEAD | tar -x -C $dir
 
 	$quick && return
-
-	# include submodules
-	# see http://stackoverflow.com/a/16843717
-	dir=$absdir git submodule foreach 'cd $toplevel/$path && git archive HEAD | tar -x -C $dir/$path/'
-
 	update_timestamps
-
-	local submodule
-	for submodule in $(git submodule -q foreach 'echo $path'); do
-		cd $submodule
-		dir=$absdir/$submodule update_timestamps
-		cd $topdir
-	done
 }
 
 po_checkout() {

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -34,20 +34,6 @@ find_prog() {
 	echo ${prog:-false}
 }
 
-# update timestamps from last commit
-# see http://stackoverflow.com/a/5531813
-update_timestamps() {
-	set +x
-	echo >&2 "Updating timestamps from last commit of each file in ${dir#$topdir/}, please wait..."
-	git ls-files | while read file; do
-		# skip files which were not exported
-		test -f "$dir/$file" || continue
-		rev=$(git rev-list -n 1 HEAD "$file")
-		file_time=$(git show --pretty=format:%ai --abbrev-commit $rev | head -n 1)
-		touch -d "$file_time" "$dir/$file"
-	done
-}
-
 vcs_checkout() {
 	set -x
 	local dir=$dir absdir
@@ -59,7 +45,7 @@ vcs_checkout() {
 	git archive HEAD | tar -x -C $dir
 
 	$quick && return
-	update_timestamps
+	$topdir/bin/releng/update_timestamps.sh $topdir $dir
 }
 
 po_checkout() {

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -8,32 +8,6 @@ topdir=$(pwd)
 
 quick=${QUICK-false}
 
-find_prog() {
-	set +x
-	local c version prog=$1
-
-	case "$prog" in
-	phing)
-		version="-version"
-		;;
-	*)
-		version="--version"
-		;;
-	esac
-
-	names="./$prog.phar $prog.phar $prog"
-	prog=
-	for c in $names; do
-		prog=$(which $c) || continue
-		prog=$(readlink -f "$prog")
-		break
-	done
-
-	${prog:-false} $version >&2
-
-	echo ${prog:-false}
-}
-
 vcs_checkout() {
 	set -x
 	local dir=$dir absdir
@@ -77,13 +51,13 @@ clean_whitespace() {
 install_dependencies() {
 	echo >&2 "Setup composer deps"
 
-	$composer install --prefer-dist --no-dev --no-suggest
+	composer install --prefer-dist --no-dev --no-suggest
 
 	# clean distribution and dump autoloader again
 	clean_vendor
 	# call "composer install" to workaround for flex not placing the version check
-	$composer install --prefer-dist --no-dev --no-suggest
-	$composer dump-autoload
+	composer install --prefer-dist --no-dev --no-suggest
+	composer dump-autoload
 }
 
 install_assets() {
@@ -97,7 +71,7 @@ dependencies_report() {
 	echo >&2 "Create dependencies report"
 
 	# save dependencies information
-	$composer licenses --no-dev --no-ansi > deps
+	composer licenses --no-dev --no-ansi > deps
 	# avoid composer warning in resulting doc file
 	grep Warning: deps && exit 1
 	clean_whitespace deps
@@ -109,7 +83,7 @@ phpcompatinfo_report() {
 	echo >&2 "Create phpcompatinfo report"
 
 	cp $topdir/phpcompatinfo.json .
-	$phpcompatinfo analyser:run --alias current --output docs/PhpCompatInfo.txt
+	phpcompatinfo analyser:run --alias current --output docs/PhpCompatInfo.txt
 	rm phpcompatinfo.json
 
 	# avoid empty result
@@ -135,7 +109,7 @@ clean_scripts() {
 
 clean_vendor() {
 	echo >&2 "Cleanup vendor of unwanted files"
-	$phing -f $topdir/build.xml clean-vendor
+	phing -f $topdir/build.xml clean-vendor
 
 	# Clean empty dirs
 	find vendor -type d -print0 | sort -zr | xargs -0 rmdir --ignore-fail-on-non-empty
@@ -147,7 +121,7 @@ clean_vendor() {
 
 clean_dist() {
 	echo >&2 "Cleanup distribution of unwanted files"
-	$phing -f $topdir/build.xml clean-dist
+	phing -f $topdir/build.xml clean-dist
 }
 
 cleanup_postdist() {
@@ -169,7 +143,7 @@ phplint() {
 	$quick && return
 
 	echo "Running php lint on source files using $(php --version | head -n1)"
-	$phing -f $topdir/build.xml phplint
+	phing -f $topdir/build.xml phplint
 	rm .phplint.cache
 }
 
@@ -234,10 +208,6 @@ prepare_source() {
 
 	phplint
 }
-
-composer=$(find_prog composer)
-phpcompatinfo=$(find_prog phpcompatinfo)
-phing=$(find_prog phing)
 
 # checkout
 vcs_checkout

--- a/bin/releng/composer-replace.sh
+++ b/bin/releng/composer-replace.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -eu
+
+# setup "replace" section in composer.json
+replace=$(jq .extra.replace composer.json)
+composer=$(mktemp composerXXXXXX)
+jq --arg replace "$replace" '.replace = ($replace|fromjson)' composer.json > $composer
+mv -f $composer composer.json
+
+# now remove the packages
+packages=$(jq -r '.extra.replace|keys[]' composer.json)
+set -x
+composer remove $packages --update-no-dev --ansi

--- a/bin/releng/composer-replace.sh
+++ b/bin/releng/composer-replace.sh
@@ -10,4 +10,4 @@ mv -f $composer composer.json
 # now remove the packages
 packages=$(jq -r '.extra.replace|keys[]' composer.json)
 set -x
-composer remove $packages --update-no-dev --ansi
+composer remove $packages --update-no-dev --no-scripts --no-update-with-dependencies --ansi

--- a/bin/releng/tools.sh
+++ b/bin/releng/tools.sh
@@ -12,6 +12,7 @@ get() {
 
 	make $tool
 	cp -p $tool $destdir
+	ln -s $tool $destdir/${tool%.phar}
 }
 
 get phpcompatinfo.phar

--- a/bin/releng/update_timestamps.sh
+++ b/bin/releng/update_timestamps.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+set -eu
+
+# update timestamps from last commit
+# see http://stackoverflow.com/a/5531813
+update_timestamps() {
+	echo >&2 "Updating timestamps from last commit of each file in ${dir#$topdir/}, please wait..."
+
+	git ls-files | while read file; do
+		# skip files which were not exported
+		test -f "$dir/$file" || continue
+		rev=$(git rev-list -n 1 HEAD "$file")
+		file_time=$(git show --pretty=format:%ai --abbrev-commit $rev | head -n 1)
+		touch -d "$file_time" "$dir/$file"
+	done
+}
+
+topdir="$1"
+dir="$2"
+update_timestamps "$@"

--- a/composer.json
+++ b/composer.json
@@ -180,6 +180,16 @@
         "public-dir": "htdocs",
         "symfony": {
             "require": "4.4.*"
+        },
+        "replace": {
+            "laminas/laminas-loader": "2.99",
+            "laminas/laminas-zendframework-bridge": "1.99",
+            "paragonie/random_compat": "9.99.99",
+            "symfony/polyfill-ctype": "1.99",
+            "symfony/polyfill-intl-idn": "1.99",
+            "symfony/polyfill-intl-normalizer": "1.99",
+            "symfony/polyfill-mbstring": "1.99",
+            "symfony/polyfill-php72": "1.99"
         }
     },
     "support": {

--- a/composer.json
+++ b/composer.json
@@ -90,16 +90,6 @@
         "willdurand/email-reply-parser": "^2.7.0",
         "xemlock/htmlpurifier-html5": "^0.1.10"
     },
-    "replace": {
-        "laminas/laminas-zendframework-bridge": "1.99",
-        "laminas/laminas-loader": "2.99",
-        "paragonie/random_compat": "9.99.99",
-        "symfony/polyfill-ctype": "1.99",
-        "symfony/polyfill-intl-idn": "1.99",
-        "symfony/polyfill-intl-normalizer": "1.99",
-        "symfony/polyfill-mbstring": "1.99",
-        "symfony/polyfill-php72": "1.99"
-    },
     "require-dev": {
         "balbuf/composer-git-merge-driver": "^1.1",
         "eventum/rpc": "^4.3.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "a5a09f8416efcfb169de15168c7bf422",
+    "content-hash": "12c51ae21b26aded40efe7b839df0864",
     "packages": [
         {
             "name": "cakephp/core",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53c0fc92fe4ffc2ec450ff0651be4a78",
+    "content-hash": "a5a09f8416efcfb169de15168c7bf422",
     "packages": [
         {
             "name": "cakephp/core",
@@ -2040,6 +2040,54 @@
             "time": "2021-10-01T16:07:46+00:00"
         },
         {
+            "name": "laminas/laminas-loader",
+            "version": "2.8.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-loader.git",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-loader/zipball/d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "reference": "d0589ec9dd48365fd95ad10d1c906efd7711c16b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "conflict": {
+                "zendframework/zend-loader": "*"
+            },
+            "require-dev": {
+                "laminas/laminas-coding-standard": "~2.2.1",
+                "phpunit/phpunit": "^9.3"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Laminas\\Loader\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Autoloading and plugin loading strategies",
+            "homepage": "https://laminas.dev",
+            "keywords": [
+                "laminas",
+                "loader"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-02T18:30:53+00:00"
+        },
+        {
             "name": "laminas/laminas-mail",
             "version": "2.15.1",
             "source": {
@@ -2377,6 +2425,62 @@
                 }
             ],
             "time": "2021-09-08T23:16:56+00:00"
+        },
+        {
+            "name": "laminas/laminas-zendframework-bridge",
+            "version": "1.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.3",
+                "psalm/plugin-phpunit": "^0.15.1",
+                "squizlabs/php_codesniffer": "^3.5",
+                "vimeo/psalm": "^4.6"
+            },
+            "type": "library",
+            "extra": {
+                "laminas": {
+                    "module": "Laminas\\ZendFrameworkBridge"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/autoload.php"
+                ],
+                "psr-4": {
+                    "Laminas\\ZendFrameworkBridge\\": "src//"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-3-Clause"
+            ],
+            "description": "Alias legacy ZF class names to Laminas Project equivalents.",
+            "keywords": [
+                "ZendFramework",
+                "autoloading",
+                "laminas",
+                "zf"
+            ],
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-09-03T17:53:30+00:00"
         },
         {
             "name": "league/commonmark",
@@ -2831,6 +2935,51 @@
                 "utility"
             ],
             "time": "2016-01-21T16:19:39+00:00"
+        },
+        {
+            "name": "paragonie/random_compat",
+            "version": "v9.99.100",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paragonie/random_compat.git",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paragonie/random_compat/zipball/996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "reference": "996434e5492cb4c3edcb9168db6fbb1359ef965a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">= 7"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "4.*|5.*",
+                "vimeo/psalm": "^1"
+            },
+            "suggest": {
+                "ext-libsodium": "Provides a modern crypto API that can be used to generate random bytes."
+            },
+            "type": "library",
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Paragon Initiative Enterprises",
+                    "email": "security@paragonie.com",
+                    "homepage": "https://paragonie.com"
+                }
+            ],
+            "description": "PHP 5.x polyfill for random_bytes() and random_int() from PHP 7",
+            "keywords": [
+                "csprng",
+                "polyfill",
+                "pseudorandom",
+                "random"
+            ],
+            "time": "2020-10-15T08:29:30+00:00"
         },
         {
             "name": "perftools/php-profiler",
@@ -3675,12 +3824,12 @@
             ],
             "authors": [
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
-                },
-                {
                     "name": "Kore Nordmann",
                     "email": "mail@kore-nordmann.de"
+                },
+                {
+                    "name": "Sebastian Bergmann",
+                    "email": "sebastian@phpunit.de"
                 }
             ],
             "description": "Diff implementation",
@@ -5940,6 +6089,397 @@
                 }
             ],
             "time": "2021-08-04T20:31:23+00:00"
+        },
+        {
+            "name": "symfony/polyfill-ctype",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-ctype.git",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-ctype": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Ctype\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Gert de Pagter",
+                    "email": "BackEndTea@gmail.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for ctype functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "ctype",
+                "polyfill",
+                "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-idn",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-idn.git",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "reference": "65bd267525e82759e7d8c4e8ceea44f398838e65",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1",
+                "symfony/polyfill-intl-normalizer": "^1.10",
+                "symfony/polyfill-php72": "^1.10"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Idn\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Laurent Bassin",
+                    "email": "laurent@bassin.info"
+                },
+                {
+                    "name": "Trevor Rowbotham",
+                    "email": "trevor.rowbotham@pm.me"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's idn_to_ascii and idn_to_utf8 functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "idn",
+                "intl",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:27:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-intl-normalizer",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "reference": "8590a5f561694770bdcd3f9b5c69dde6945028e8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-intl": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Intl\\Normalizer\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ],
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for intl's Normalizer class and related functions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "intl",
+                "normalizer",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-02-19T12:13:01+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.23.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "reference": "9174a3d80210dca8daa7f31fec659150bbeabfc6",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T12:26:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php72",
+            "version": "v1.23.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php72.git",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php72/zipball/9a142215a36a3888e30d0a9eeea9766764e96976",
+                "reference": "9a142215a36a3888e30d0a9eeea9766764e96976",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.23-dev"
+                },
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php72\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.2+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-05-27T09:17:38+00:00"
         },
         {
             "name": "symfony/polyfill-php73",

--- a/symfony.lock
+++ b/symfony.lock
@@ -122,6 +122,9 @@
     "laminas/laminas-config": {
         "version": "3.3.0"
     },
+    "laminas/laminas-loader": {
+        "version": "2.8.0"
+    },
     "laminas/laminas-mail": {
         "version": "2.11.0"
     },
@@ -160,6 +163,9 @@
     },
     "ocramius/package-versions": {
         "version": "1.4.2"
+    },
+    "paragonie/random_compat": {
+        "version": "v9.99.100"
     },
     "perftools/php-profiler": {
         "version": "0.7.2"
@@ -376,6 +382,21 @@
             "phpunit.xml.dist",
             "tests/bootstrap.php"
         ]
+    },
+    "symfony/polyfill-ctype": {
+        "version": "v1.23.0"
+    },
+    "symfony/polyfill-intl-idn": {
+        "version": "v1.23.0"
+    },
+    "symfony/polyfill-intl-normalizer": {
+        "version": "v1.23.0"
+    },
+    "symfony/polyfill-mbstring": {
+        "version": "v1.23.1"
+    },
+    "symfony/polyfill-php72": {
+        "version": "v1.23.0"
     },
     "symfony/polyfill-php73": {
         "version": "v1.17.0"


### PR DESCRIPTION
Using replace is nice way to minimize vendor size,
but it also makes it very difficult to install dependencies
when eventun/eventum is being used as "packages-dev"

The major obstacle is that "replace" may be provided by only one package
the way composer thinks.

The "replace" works fine when used as project, but we also want to use
eventum as library, for example extension development