### PR TITLE
Feature: Add support for building release tarball with Dockerfile stages

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+# Paths not necessary for building release
+/node_modules
+/releases/
+/tests/

--- a/.gitattributes
+++ b/.gitattributes
@@ -14,6 +14,7 @@
 /.travis.yml export-ignore
 /phpcompatinfo.json export-ignore
 /build.xml export-ignore
+/phive.xml export-ignore
 /bin/releng/ export-ignore
 
 /config/phpxref.cfg export-ignore

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
 
   # https://github.com/fastify/github-action-merge-dependabot
   automerge:
-    needs: test
+    needs: release
     runs-on: ubuntu-20.04
     steps:
       - uses: fastify/github-action-merge-dependabot@v2.1.1

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -40,12 +40,14 @@ RUN set -x \
 
 FROM deps AS releng
 WORKDIR /app
-COPY bin/releng/locales.sh ./bin/releng/locales.sh
-RUN bin/releng/locales.sh
+RUN \
+    --mount=type=bind,source=./bin/releng/locales.sh,target=./bin/releng/locales.sh \
+    bin/releng/locales.sh
 
-COPY Makefile .
-COPY bin/releng/tools.sh ./bin/releng/tools.sh
-RUN bin/releng/tools.sh /usr/bin
+RUN \
+    --mount=type=bind,source=./Makefile,target=./Makefile \
+    --mount=type=bind,source=./bin/releng/tools.sh,target=./bin/releng/tools.sh \
+    bin/releng/tools.sh /usr/bin
 
 # docker build . -f bin/releng/Dockerfile -t app --target=stage-release
 FROM releng AS stage-release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -160,14 +160,23 @@ RUN \
     --mount=type=bind,from=build-src,source=/app/localization/LINGUAS.php,target=./localization/LINGUAS.php \
     --mount=type=bind,from=build-src,source=/app/localization/Makefile,target=./localization/Makefile \
     --mount=type=bind,from=build-src,source=/app/localization/eventum.pot,target=./localization/eventum.pot \
-    --mount=type=bind,from=build-assets,source=/app/htdocs/css,target=./htdocs/css \
-    --mount=type=bind,from=build-assets,source=/app/htdocs/js,target=./htdocs/js \
-    --mount=type=bind,from=build-assets,source=/app/htdocs/fonts,target=./htdocs/fonts \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/css,target=./htdocs/css,rw \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/js,target=./htdocs/js,rw \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/fonts,target=./htdocs/fonts,rw \
     --mount=type=bind,from=build-assets,source=/app/htdocs/images,target=./htdocs/images,rw \
     --mount=type=bind,from=build-assets,source=/app/htdocs/mix-manifest.json,target=./htdocs/mix-manifest.json,rw \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/eventum.gif,target=./htdocs/images/eventum.gif \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/no_data.gif,target=./htdocs/images/no_data.gif \
-    --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor \
+    --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor,rw \
+<<eot bash -xe
+    # install dirs and fix permissions
+    install -d var/{log,cache,lock}
+    install -d config/{workflow,custom_field,templates,crm,partner,include}
+    touch var/log/{eventum.log,auth.log,cli.log,errors.log,login_attempts.log}
+    touch config/{private_key.php,secret_key.php,setup.php}
+    chmod -R a+rX,g-w .
+    chmod -R a+rwX config var
+
     tar -cf /out/eventum-$APP_VERSION.tar \
         --exclude=*.phar \
         --exclude=.dockerignore \
@@ -184,6 +193,7 @@ RUN \
         --exclude=webpack.mix.js \
         --exclude=yarn.lock \
         -C / eventum-$APP_VERSION/
+eot
 
 # APP_VERSION=$(git describe --tags --match=v*)
 # docker build . -f bin/releng/Dockerfile --build-arg=APP_VERSION=${APP_VERSION#v} --target=out -o out

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -168,7 +168,22 @@ RUN \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/eventum.gif,target=./htdocs/images/eventum.gif \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/no_data.gif,target=./htdocs/images/no_data.gif \
     --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor \
-    tar -cf /out/eventum-$APP_VERSION.tar -C / eventum-$APP_VERSION/
+    tar -cf /out/eventum-$APP_VERSION.tar \
+        --exclude=*.phar \
+        --exclude=.dockerignore \
+        --exclude=bin/releng \
+        --exclude=composer.json \
+        --exclude=composer.lock \
+        --exclude=contrib/git \
+        --exclude=contrib/shell-semver \
+        --exclude=htdocs/debugbar \
+        --exclude=package.json \
+        --exclude=res/packages/test \
+        --exclude=src/Mail/MailStorage.php \
+        --exclude=symfony.lock \
+        --exclude=webpack.mix.js \
+        --exclude=yarn.lock \
+        -C / eventum-$APP_VERSION/
 
 # APP_VERSION=$(git describe --tags --match=v*)
 # docker build . -f bin/releng/Dockerfile --build-arg=APP_VERSION=${APP_VERSION#v} --target=out -o out

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -151,8 +151,9 @@ RUN \
 
 # docker build . -f bin/releng/Dockerfile -t app --target=build-tar
 FROM $BUILD_IMAGE AS build-tar
-WORKDIR /app
+WORKDIR /out
 ARG APP_VERSION=unknown
+WORKDIR /eventum-$APP_VERSION
 RUN \
     --mount=type=bind,from=build-src,source=/app,target=.,rw \
     --mount=type=bind,from=build-po,source=/app/localization,target=./localization,rw \
@@ -167,6 +168,6 @@ RUN \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/eventum.gif,target=./htdocs/images/eventum.gif \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/no_data.gif,target=./htdocs/images/no_data.gif \
     --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor \
-    tar -cf /eventum-$APP_VERSION.tar --exclude=*.phar .
+    tar -cf /out/eventum-$APP_VERSION.tar -C / eventum-$APP_VERSION/
 
 FROM releng AS release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -120,6 +120,21 @@ RUN \
 # Clean empty dirs
 RUN find vendor -type d -print0 | sort -zr | xargs -0 rmdir --ignore-fail-on-non-empty
 
+# Dump autoloader, including package versions
+ARG APP_VERSION=0.0.0
+RUN \
+    --mount=type=cache,id=composer,target=/root/.cache/composer \
+    --mount=type=bind,source=./composer.json,target=./composer.json \
+    --mount=type=bind,source=./composer.lock,target=./composer.lock \
+    --mount=type=cache,target=./lib/eventum,ro \
+<<eot
+    if [ "${APP_VERSION%-*-*}" != "$APP_VERSION" ]; then
+        APP_VERSION=$(IFS=-; set -- $APP_VERSION; echo dev-${1#v}-$2@$3)
+    fi
+    COMPOSER_ROOT_VERSION=$APP_VERSION \
+    composer dump-autoload --no-dev --ansi
+eot
+
 # docker build . -f bin/releng/Dockerfile -t app --target=build-assets
 FROM $BUILD_IMAGE AS build-assets
 WORKDIR /app

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -68,4 +68,15 @@ RUN \
     git archive HEAD | tar -x -C /app && \
     bin/releng/update_timestamps.sh / /app
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-po
+FROM $BUILD_IMAGE AS build-po
+RUN bzr branch lp:~glen666/eventum/po /po
+WORKDIR /app/localization
+RUN \
+    --mount=type=bind,source=./localization,target=/src/localization,rw \
+<<eot bash
+    cp -af /po/localization/*.po .
+    make -r -f /src/localization/Makefile touch-po
+eot
+
 FROM releng AS release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -126,7 +126,7 @@ RUN \
     --mount=type=cache,id=composer,target=/root/.cache/composer \
     --mount=type=bind,source=./composer.json,target=./composer.json \
     --mount=type=bind,source=./composer.lock,target=./composer.lock \
-    --mount=type=cache,target=./lib/eventum,ro \
+    --mount=type=bind,from=build-src,source=/app/lib/eventum,target=./lib/eventum,ro \
 <<eot
     if [ "${APP_VERSION%-*-*}" != "$APP_VERSION" ]; then
         APP_VERSION=$(IFS=-; set -- $APP_VERSION; echo dev-${1#v}-$2@$3)

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -78,6 +78,9 @@ RUN \
     cp -af /po/localization/*.po .
     make -r -f /src/localization/Makefile touch-po
 eot
+RUN \
+    --mount=type=bind,source=./localization/Makefile,target=./Makefile \
+    make install clean
 
 # docker build . -f bin/releng/Dockerfile -t app --target=build-vendor
 FROM $BUILD_IMAGE AS build-vendor

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -1,7 +1,10 @@
+# syntax = docker/dockerfile:1.3-labs
 #
 # Dockerfile for Building Eventum Release
 # https://github.com/eventum/eventum
 #
+
+ARG BUILD_IMAGE=ghcr.io/eventum/eventum:release-image-v2
 
 # Image for building release
 FROM ubuntu:focal AS base

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -79,4 +79,18 @@ RUN \
     make -r -f /src/localization/Makefile touch-po
 eot
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-assets
+FROM $BUILD_IMAGE AS build-assets
+WORKDIR /app
+RUN \
+    --mount=type=cache,id=yarn,target=/usr/local/share/.cache/yarn \
+    --mount=type=bind,source=./package.json,target=./package.json \
+    --mount=type=bind,source=./yarn.lock,target=./yarn.lock \
+    yarn
+RUN \
+    --mount=type=bind,source=./package.json,target=./package.json \
+    --mount=type=bind,source=./webpack.mix.js,target=./webpack.mix.js \
+    --mount=type=bind,source=./res/assets,target=./res/assets \
+    yarn assets:production
+
 FROM releng AS release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -170,4 +170,9 @@ RUN \
     --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor \
     tar -cf /out/eventum-$APP_VERSION.tar -C / eventum-$APP_VERSION/
 
+# APP_VERSION=$(git describe --tags --match=v*)
+# docker build . -f bin/releng/Dockerfile --build-arg=APP_VERSION=${APP_VERSION#v} --target=out -o out
+FROM scratch AS out
+COPY --from=build-tar /out/* /
+
 FROM releng AS release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -79,6 +79,44 @@ RUN \
     make -r -f /src/localization/Makefile touch-po
 eot
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-vendor
+FROM $BUILD_IMAGE AS build-vendor
+WORKDIR /app
+
+# Install hirak/prestissimo for parallel downloads
+ENV COMPOSER_CACHE_DIR=/root/.cache/composer
+RUN \
+    --mount=type=cache,id=composer,target=/root/.cache/composer \
+    --mount=type=cache,id=composer-bin,target=/root/.composer \
+   composer global require hirak/prestissimo --ansi
+
+# Install runtime dependencies
+RUN \
+    --mount=type=cache,id=composer,target=/root/.cache/composer \
+    --mount=type=cache,id=composer-bin,target=/root/.composer \
+    --mount=type=bind,source=./composer.json,target=./composer.json \
+    --mount=type=bind,source=./composer.lock,target=./composer.lock \
+    --mount=type=cache,target=./lib/eventum,ro \
+    composer install --prefer-dist --no-dev --no-suggest --no-scripts --no-autoloader --ansi
+
+# Remove packages defined in "extra.replace"
+RUN \
+    --mount=type=cache,id=composer,target=/root/.cache/composer \
+    --mount=type=cache,id=composer-bin,target=/root/.composer \
+    --mount=type=bind,source=./composer.json,target=/src/composer.json \
+    --mount=type=bind,source=./composer.lock,target=/src/composer.lock \
+    --mount=type=bind,source=./bin/releng/composer-replace.sh,target=./bin/releng/composer-replace.sh \
+    cp /src/* . && \
+    bin/releng/composer-replace.sh
+
+# Cleanup vendor of unwanted files
+RUN \
+    --mount=type=bind,source=./build.xml,target=/src/build.xml \
+    phing -f /src/build.xml clean-vendor
+
+# Clean empty dirs
+RUN find vendor -type d -print0 | sort -zr | xargs -0 rmdir --ignore-fail-on-non-empty
+
 # docker build . -f bin/releng/Dockerfile -t app --target=build-assets
 FROM $BUILD_IMAGE AS build-assets
 WORKDIR /app

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -149,6 +149,24 @@ RUN \
     --mount=type=bind,source=./res/assets,target=./res/assets \
     yarn assets:production
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-phpcompatinfo
+FROM $BUILD_IMAGE AS build-phpcompatinfo
+RUN \
+    --mount=type=bind,source=./phpcompatinfo.json,target=./phpcompatinfo.json \
+    --mount=type=bind,source=./bin,target=./bin \
+    --mount=type=bind,source=./db,target=./db \
+    --mount=type=bind,source=./htdocs,target=./htdocs \
+    --mount=type=bind,source=./lib,target=./lib \
+    --mount=type=bind,source=./res,target=./res \
+    --mount=type=bind,source=./src,target=./src \
+    --mount=type=bind,source=./autoload.php,target=./autoload.php \
+    --mount=type=bind,source=./init.php,target=./init.php \
+    --mount=type=bind,source=./phinx.php,target=./phinx.php \
+	phpcompatinfo analyser:run --alias current --output PhpCompatInfo.txt
+
+# Avoid empty result
+RUN if grep -qF 'None data source matching' PhpCompatInfo.txt; then exit 2; fi
+
 # docker build . -f bin/releng/Dockerfile -t app --target=build-tar
 FROM $BUILD_IMAGE AS build-tar
 WORKDIR /out
@@ -167,6 +185,7 @@ RUN \
     --mount=type=bind,from=build-assets,source=/app/htdocs/mix-manifest.json,target=./htdocs/mix-manifest.json,rw \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/eventum.gif,target=./htdocs/images/eventum.gif \
     --mount=type=bind,from=build-src,source=/app/htdocs/images/no_data.gif,target=./htdocs/images/no_data.gif \
+    --mount=type=bind,from=build-phpcompatinfo,source=/app/PhpCompatInfo.txt,target=./docs/PhpCompatInfo.txt,rw \
     --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor,rw \
 <<eot bash -xe
     # install dirs and fix permissions

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -134,4 +134,24 @@ RUN \
     --mount=type=bind,source=./res/assets,target=./res/assets \
     yarn assets:production
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-tar
+FROM $BUILD_IMAGE AS build-tar
+WORKDIR /app
+ARG APP_VERSION=unknown
+RUN \
+    --mount=type=bind,from=build-src,source=/app,target=.,rw \
+    --mount=type=bind,from=build-po,source=/app/localization,target=./localization,rw \
+    --mount=type=bind,from=build-src,source=/app/localization/LINGUAS.php,target=./localization/LINGUAS.php \
+    --mount=type=bind,from=build-src,source=/app/localization/Makefile,target=./localization/Makefile \
+    --mount=type=bind,from=build-src,source=/app/localization/eventum.pot,target=./localization/eventum.pot \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/css,target=./htdocs/css \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/js,target=./htdocs/js \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/fonts,target=./htdocs/fonts \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/images,target=./htdocs/images,rw \
+    --mount=type=bind,from=build-assets,source=/app/htdocs/mix-manifest.json,target=./htdocs/mix-manifest.json,rw \
+    --mount=type=bind,from=build-src,source=/app/htdocs/images/eventum.gif,target=./htdocs/images/eventum.gif \
+    --mount=type=bind,from=build-src,source=/app/htdocs/images/no_data.gif,target=./htdocs/images/no_data.gif \
+    --mount=type=bind,from=build-vendor,source=/app/vendor,target=./vendor \
+    tar -cf /eventum-$APP_VERSION.tar --exclude=*.phar .
+
 FROM releng AS release

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -60,4 +60,12 @@ COPY . .
 FROM stage-release AS build-release
 RUN bin/releng/build-release.sh
 
+# docker build . -f bin/releng/Dockerfile -t app --target=build-src
+FROM $BUILD_IMAGE AS build-src
+WORKDIR /src
+RUN \
+    --mount=type=bind,target=/src \
+    git archive HEAD | tar -x -C /app && \
+    bin/releng/update_timestamps.sh / /app
+
 FROM releng AS release

--- a/bin/releng/build-release.sh
+++ b/bin/releng/build-release.sh
@@ -213,6 +213,14 @@ prepare_source() {
 	phplint
 }
 
+action="${1:-}"
+
+# perform standalone operation
+if [ -n "$action" ]; then
+	"$1"
+	exit $?
+fi
+
 # checkout
 vcs_checkout
 po_checkout

--- a/src/Version.php
+++ b/src/Version.php
@@ -16,6 +16,7 @@ namespace Eventum;
 final class Version
 {
     private const UNPARSED_VERSION = 'No version set (parsed as 1.0.0)';
+    private const UNKNOWN_VERSION = '0.0.0@';
 
     /** @var string */
     public $reference;
@@ -36,6 +37,10 @@ final class Version
      */
     public function __construct(string $versionString)
     {
+        if ($versionString === self::UNKNOWN_VERSION) {
+            return;
+        }
+
         [$reference, $hash] = explode('@', $versionString, 2);
         if ($reference === self::UNPARSED_VERSION) {
             return;


### PR DESCRIPTION
This utilizes stages for build, thus allowing parallel execution and cache on rebuilds

```bash
APP_VERSION=$(git describe --tags --match=v*)
docker build . -f bin/releng/Dockerfile --build-arg=APP_VERSION=${APP_VERSION#v} --target=out -o out --progress=plain
```

```
$ ls -lh out/*
-rw-r--r-- 1 root root 49M Dec 13 04:09 out/eventum-3.10.9-74-ge4a6118f8.tar
```