### PR TITLE
Update fastify/github-action-merge-dependabot to v3.0.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,8 +183,13 @@ jobs:
   automerge:
     needs: release
     runs-on: ubuntu-20.04
+
+    permissions:
+      pull-requests: write
+      contents: write
+
     steps:
-      - uses: fastify/github-action-merge-dependabot@v2.1.1
+      - uses: fastify/github-action-merge-dependabot@v3.0.0
         if: ${{ github.actor == 'dependabot[bot]' && github.event_name == 'pull_request' }}
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
- https://github.com/fastify/github-action-merge-dependabot/tree/5983205c569917cd35ba9dfec8858236c74cd86a#how-to-upgrade-from-2x-to-new-3x
- https://github.com/fastify/github-action-merge-dependabot/pull/107