### PR TITLE
Feature: Add $connection to MAIL_PROCESS_BEFORE event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 See [Upgrading] for details on how to upgrade.
 
 - Fix checkboxes in custom field administration, #1357
+- Feature: Add `$connection` to `MAIL_PROCESS_BEFORE` event, #1414
 
 [3.10.11]: https://github.com/eventum/eventum/compare/v3.10.10...master
 

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -20,6 +20,7 @@ use Eventum\Event\SystemEvents;
 use Eventum\Extension\ExtensionLoader;
 use Eventum\LinkFilter\LinkFilter;
 use Eventum\Mail\Helper\AddressHeader;
+use Eventum\Mail\Imap\ImapConnection;
 use Eventum\Mail\ImapMessage;
 use Eventum\Mail\MailMessage;
 use Eventum\ServiceContainer;
@@ -631,10 +632,12 @@ class Workflow
      * @return  mixed null by default, -1 if the rest of the email script should not be processed
      * @since 3.8.11 emits ISSUE_UPDATED_BEFORE event
      * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
+     * @since 3.10.11 Passes connection as 'connection' key to event
      */
-    public static function preEmailDownload(int $prj_id, ImapMessage $mail): bool
+    public static function preEmailDownload(int $prj_id, ImapMessage $mail, ImapConnection $connection): bool
     {
         $event = new EventContext($prj_id, null, null, [], $mail);
+        $event['connection'] = $connection;
         ServiceContainer::dispatch(SystemEvents::MAIL_PROCESS_BEFORE, $event);
         if ($event->isPropagationStopped()) {
             return false;

--- a/lib/eventum/class.workflow.php
+++ b/lib/eventum/class.workflow.php
@@ -630,7 +630,7 @@ class Workflow
      * @param   int $prj_id The project ID
      * @param   ImapMessage $mail The Imap Mail Message object
      * @return  mixed null by default, -1 if the rest of the email script should not be processed
-     * @since 3.8.11 emits ISSUE_UPDATED_BEFORE event
+     * @since 3.8.11 emits MAIL_PROCESS_BEFORE event
      * @since 3.8.13 workflow integration is done by WorkflowLegacyExtension
      * @since 3.10.11 Passes connection as 'connection' key to event
      */

--- a/src/Mail/ProcessMailMessage.php
+++ b/src/Mail/ProcessMailMessage.php
@@ -102,7 +102,7 @@ class ProcessMailMessage
         }
 
         // pass in $mail object so it can be modified
-        if (!Workflow::preEmailDownload($this->prj_id, $mail)) {
+        if (!Workflow::preEmailDownload($this->prj_id, $mail, $this->connection)) {
             $this->debug("Skip $resource: Skipped by workflow");
 
             return;


### PR DESCRIPTION
This allows to have workflow event to delete email:

```php
    /**
     * Ignore emails from being processed
     */
    public function blockIncomingMail(GenericEvent $event): void
    {
        /** @var ImapMessage $mail */
        $mail = $event->getSubject();

        if (!in_array($mail->getSender(), self::BLOCK_SENDERS, true)) {
            return;
        }

        $event->stopPropagation();
        $this->debug('Stopped mail from {}', ['sender' => $mail->getSender()]);
        $dumper = new MailDumper(self::DUMP_PATH);
        $dumper->dump($mail);

        /** @var ImapConnection $connection */
        $connection = $event['connection'];
        $connection->deleteMessage($mail);
    }

```