### PR TITLE
Use node 16 for release image

### DIFF
--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -218,7 +218,7 @@ RUN \
         -C / eventum-$APP_VERSION/
 eot
 
-# APP_VERSION=$(git describe --tags --match=v*)
+# APP_VERSION=$(git describe --tags --match="v*")
 # docker build . -f bin/releng/Dockerfile --build-arg=APP_VERSION=${APP_VERSION#v} --target=out -o out
 FROM scratch AS out
 COPY --from=build-tar /out/* /

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -4,10 +4,11 @@
 # https://github.com/eventum/eventum
 #
 
-ARG BUILD_IMAGE=ghcr.io/eventum/eventum:release-image-v2
+# docker build . -f bin/releng/Dockerfile -t ghcr.io/eventum/eventum:release-image-v3
+ARG BUILD_IMAGE=ghcr.io/eventum/eventum:release-image-v3
 
 # Image for building release
-FROM ubuntu:focal AS base
+FROM ubuntu:20.04 AS base
 
 FROM base AS deps
 RUN set -x \

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -38,6 +38,8 @@ RUN set -x \
     xz-utils \
     && curl -sS https://dl.yarnpkg.com/debian/pubkey.gpg | sudo apt-key add - \
     && echo "deb https://dl.yarnpkg.com/debian/ stable main" | sudo tee /etc/apt/sources.list.d/yarn.list \
+    && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null \
+    && echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main' > /etc/apt/sources.list.d/nodesource.list \
     && apt update && apt install -y --no-install-recommends nodejs yarn \
 	&& exit 0
 

--- a/bin/releng/Dockerfile
+++ b/bin/releng/Dockerfile
@@ -42,7 +42,8 @@ RUN set -x \
     && curl -sS https://deb.nodesource.com/gpgkey/nodesource.gpg.key | gpg --dearmor | tee /usr/share/keyrings/nodesource.gpg >/dev/null \
     && echo 'deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x focal main' > /etc/apt/sources.list.d/nodesource.list \
     && apt update && apt install -y --no-install-recommends nodejs yarn \
-	&& exit 0
+    && rm -rf /var/lib/apt/lists/* \
+    && exit 0
 
 FROM deps AS releng
 WORKDIR /app

--- a/bin/releng/locales.sh
+++ b/bin/releng/locales.sh
@@ -9,3 +9,4 @@ sudo apt-get --reinstall install -qq \
 # display some info from system
 dpkg --list | grep language-pack
 locale -a
+rm -rf /var/lib/apt/lists/*

--- a/bin/releng/tools.sh
+++ b/bin/releng/tools.sh
@@ -11,7 +11,7 @@ get() {
 	local tool="$1"
 
 	make $tool
-	cp -p $tool $destdir
+	ln $tool $destdir || cp -p $tool $destdir
 	ln -s $tool $destdir/${tool%.phar}
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "webpack:production": "cross-env NODE_ENV=production webpack --config=node_modules/laravel-mix/setup/webpack.config.js"
   },
   "engines": {
-    "node": "^8.10.0||^10"
+    "node": "^16"
   },
   "dependencies": {},
   "devDependencies": {


### PR DESCRIPTION
Keep it modern.

This is to also fix an dependency error:
```
#14 3.742 warning file-loader@2.0.0: Invalid bin field for "file-loader".
#14 21.11 info fsevents@1.2.13: The platform "linux" is incompatible with this module.
#14 21.11 info "fsevents@1.2.13" is an optional dependency and failed compatibility check. Excluding it from installation.
#14 21.12 info fsevents@2.3.2: The platform "linux" is incompatible with this module.
#14 21.12 info "fsevents@2.3.2" is an optional dependency and failed compatibility check. Excluding it from installation.
#14 21.13 error d3@7.6.1: The engine "node" is incompatible with this module. Expected version ">=12". Got "10.19.0"
#14 21.14 error Found incompatible module.
```
- https://github.com/eventum/eventum/pull/1307