### PR TITLE
Fix exception in ManageBaseController

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 See [Upgrading] for details on how to upgrade.
 
-- Fix exception in ManageBaseController, #1435, #1482
+- Fix exception in ManageBaseController, LDAP login, #1435, #1482, #1174
 
 [3.10.13]: https://github.com/eventum/eventum/compare/v3.10.12...master
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 See [Upgrading] for details on how to upgrade.
 
+- Fix exception in ManageBaseController, #1435, #1482
+
 [3.10.13]: https://github.com/eventum/eventum/compare/v3.10.12...master
 
 ## [3.10.12] - 2023-01-03

--- a/src/ServiceContainer.php
+++ b/src/ServiceContainer.php
@@ -107,7 +107,7 @@ class ServiceContainer
     public static function getLogger($name = null): LoggerInterface
     {
         if ($name !== null) {
-            $container = static::getKernel()->getContainer();
+            $container = static::getKernel()->ensureBooted()->getContainer();
             /** @var LoggerInterface $logger */
             $logger = $container->get("monolog.logger.$name");
 


### PR DESCRIPTION
Fixes #1435, #1174

Ensure the kernel is booted before getting a named logger instance.