### PR TITLE
Fix "chosen" select box rendering in Firefox

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Upgrading] for details on how to upgrade.
 
 - Fix exception in ManageBaseController, LDAP login, #1435, #1482, #1174
 - Various fixes for PHP 8 compatibility, #1483
+- Fix "chosen" select box rendering in Firefox, #1486
 
 [3.10.13]: https://github.com/eventum/eventum/compare/v3.10.12...master
 

--- a/res/assets/sass/main.scss
+++ b/res/assets/sass/main.scss
@@ -393,19 +393,12 @@ td.light {
 }
 
 /* for jquery-chosen */
-.chosen-container .chosen-drop {
-    position: relative;
-}
-
 .chosen-select {
     width: 290px;
 }
 
 .chosen-container {
-    height: 27px;
-
     .chosen-drop {
-        top: 0;
         box-shadow: 4px 4px 5px rgba(0, 0, 0, 0.3);
     }
 }


### PR DESCRIPTION
Select boxes enriched with jquery-chosen are not properly rendered in Firefox: The dropdown is permanently visible (albeit initially empty), even if the select box is closed.

The issue seems to be caused by custom CSS rules which date back to a time when the plugin worked differently.