### PR TITLE
Perform file content verification when both source flysystem File and target flysystem File exist instead of letting Flysystem throw an Exception

### DIFF
--- a/src/Attachment/StorageManager.php
+++ b/src/Attachment/StorageManager.php
@@ -169,4 +169,28 @@ class StorageManager
     {
         return $this->mount_manager->move($old_path, $new_path);
     }
+
+   /**
+    * Check if File exists
+    * @param string $path
+    * @return bool
+    */
+    public function fileExists($path): bool
+    {
+         return $this->mount_manager->has($path);
+    }
+
+   /**
+    * Get Contents of file if it exists
+    * @param string $path
+    * @return string
+    */
+    public function getFileContents($path): string
+    {
+        if($this->mount_manager->has($path)){
+            return $this->mount_manager->read($path);
+        }else{
+            threw new League\Flysystem\FileNotFoundException($path);
+        }
+    }
 }


### PR DESCRIPTION
Add code needed to check if file exists in target flysystem and verify if already exists

Adds helper functions to StorageManager to call underlying FlySystem functions in src/Attachment/StorageManager.php
Add data getter code + hashing + verifying code in src/Console/Command/AttachmentMigrateCommand.php