### PR TITLE
Fix rendering of pie charts with PHP 8

### DIFF
--- a/src/Controller/Helper/PlotHelper.php
+++ b/src/Controller/Helper/PlotHelper.php
@@ -46,6 +46,10 @@ class PlotHelper
     private function create($width, $height)
     {
         $plot = new PHPlot($width, $height);
+        if (PHP_MAJOR_VERSION >= 8) {
+            // Hack to make PHPlot 6.1 work with PHP 8: manually call the old-style constructor
+            $plot->PHPlot($width, $height);
+        }
         $plot->SetTTFPath($this->fonts_path);
         $plot->SetUseTTF(true);
 


### PR DESCRIPTION
Eventum uses an ancient version of PHPlot which uses the old-style constructor syntax that is no longer supported by PHP 8. As a result the pie charts on the project home page fail to render.

To work around the issue, call the constructor manually.