### PR TITLE
Fix false error when disabling users in filtered list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ See [Upgrading] for details on how to upgrade.
 
 - Update PHPlot to v8.0.0.3 to fix rendering with PHP 8, #1537
 - Fix display of icons in priority dropdown list, #1535
+- Fix false error when disabling users in filtered list, #1544
 
 [3.10.15]: https://github.com/eventum/eventum/compare/v3.10.14...master
 

--- a/templates/manage/users_list.tpl.html
+++ b/templates/manage/users_list.tpl.html
@@ -11,7 +11,7 @@
   function checkDelete()
   {
     var total_selected = Eventum.getField('items[]').filter(':checked').length;
-    var total = Eventum.getField('items[]').length;
+    var total = {$list|@count};
     if (Eventum.getField('status').val() == 'inactive') {
       if (active_users_count < 2) {
         alert('{t escape=js}You cannot change the status of the only active user left in the system.{/t}');


### PR DESCRIPTION
When filtering the users list to a single entry, Eventum will
incorrectly refuse to deactivate that account because the number of
selected entries equals the number of visible entries.

Adapt the check to compare with the size of the unfiltered list.