### PR TITLE
Create .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,5 @@
 # Commits to ignore from git blame
 # $ git blame --ignore-revs-file .git-blame-ignore-revs
 #
+# Composer: reformat with spaces
+04bd38c664a4cc1a5f4e775e69e95b7581c3d7d4

--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# Commits to ignore from git blame
+# $ git blame --ignore-revs-file .git-blame-ignore-revs
+#


### PR DESCRIPTION
GitHub seems to support this natively:
- https://github.com/rabbitmq/rabbitmq-website/commit/e1164f4c9e82ce42711a4fe717c84fe0193c5c73#commitcomment-153857920

Docs/Blogs:
- https://graphite.dev/guides/git-blame-ignore-revs#step-2-creating-a-git-blame-ignore-revs-file
- https://github.com/orgs/community/discussions/5033
- https://medium.com/@ramunarasinga/git-blame-ignore-revs-to-ignore-bulk-formatting-changes-f20ac23e6155

Works now:
- https://github.com/eventum/eventum/blame/2843a7ae892fb52273c5f8d3e4ceffd48126afc1/composer.json